### PR TITLE
Scroll to success message if not in viewport

### DIFF
--- a/resources/assets/public/form-submission.js
+++ b/resources/assets/public/form-submission.js
@@ -237,6 +237,13 @@ jQuery(document).ready(function () {
                                     })
                                         .html(res.data.result.message)
                                         .insertAfter($theForm);
+                                    // Scroll to success msg if not in viewport
+                                    var successMsg = $('#'+formId + '_success');
+                                    if (successMsg.length && !isElementInViewport(successMsg[0])) {
+                                        $('html, body').delay(animDuration).animate({
+                                            scrollTop: successMsg.offset().top - (!!$('#wpadminbar') ? 32 : 0) - 20
+                                        }, animDuration);
+                                    }
 
                                     $theForm.find('.ff-el-is-error').removeClass('ff-el-is-error');
 


### PR DESCRIPTION
For longer form, success message is out of viewport when the submission action is to hide the form