### PR TITLE
Payment clac shortcode issue fixed

### DIFF
--- a/resources/assets/admin/components/editor-field-settings/templates/inputCalculationSettings.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/inputCalculationSettings.vue
@@ -68,7 +68,7 @@
         },
         methods: {
             getItemCode(item) {
-                if (item.element == 'input_number' || item.element == 'rangeslider') {
+                if (item.element == 'input_number' || item.element == 'rangeslider' || (item.element == 'multi_payment_component' && item.attributes.type =='single')) {
                     return '{input.' + item.attributes.name + '}';
                 } else if(item.element == 'select') {
                     return '{select.' + item.attributes.name + '}';
@@ -78,7 +78,7 @@
                     return '{radio.' + item.attributes.name + '}';
                 } else if(item.element == 'repeater_field') {
                     return '{repeat.'+item.attributes.name+'}';
-                } else if(item.element == 'multi_payment_component') {
+                } else if(item.element == 'multi_payment_component' && item.attributes.type !=='single') {
                     return '{payment.'+item.attributes.name+'}';
                 }
             },


### PR DESCRIPTION
In case of single payment when someone want to calculate the value the shortcode add as {payment.payment_input} so it doesn’t work however it works as {input.payment_input}