### PR TITLE
Important: form default settings  missing on form create

### DIFF
--- a/app/Modules/Form/Predefined.php
+++ b/app/Modules/Form/Predefined.php
@@ -895,11 +895,19 @@ class Predefined extends Form
         }
 
         if (isset($predefinedForm['formSettings'])) {
-            $this->defaultSettings = $predefinedForm['formSettings'];
+            $this->defaultSettings = apply_filters('fluentform_create_default_settings', $predefinedForm['formSettings']);
+            $predefinedForm['metas'][] = [
+                'meta_key' => 'formSettings',
+                'value' => json_encode($this->defaultSettings)
+            ];
         }
 
         if (isset($predefinedForm['notifications'])) {
             $this->defaultNotifications = $predefinedForm['notifications'];
+            $predefinedForm['metas'][] = [
+                'meta_key' => 'notifications',
+                'value' => json_encode($this->defaultNotifications)
+            ];
         }
 
         if($predefinedName) {


### PR DESCRIPTION
On creation of form, notification data and settings were not saving, added these two settings Please check again