### PR TITLE
MailChimp Dynamic Tag Issue Fixed

### DIFF
--- a/app/Services/Integrations/MailChimp/MailChimpSubscriber.php
+++ b/app/Services/Integrations/MailChimp/MailChimpSubscriber.php
@@ -112,9 +112,18 @@ trait MailChimpSubscriber
 
         $tags = array_map('trim', $tags);
         $tags = array_filter($tags);
+        //explode inner commas values to array
+        $tagsFormatted = [];
+        foreach ($tags as $tag) {
+            if (strpos($tag, ',') !== false) {
+                $tagsFormatted = explode(',', $tag);
+            } else {
+                $tagsFormatted[] = $tag;
+            }
+        }
 
         if ($tags) {
-            $arguments['tags'] = $tags;
+            $arguments['tags'] = $tagsFormatted;
         }
 
         $note = '';


### PR DESCRIPTION
When using dynamic tags, it was not respecting the comma and adding all tags as one tag https://prnt.sc/1icsx3g