### PR TITLE
MailChimp dynamic issue fix

### DIFF
--- a/app/Services/Integrations/MailChimp/MailChimpSubscriber.php
+++ b/app/Services/Integrations/MailChimp/MailChimpSubscriber.php
@@ -113,8 +113,20 @@ trait MailChimpSubscriber
         $tags = array_map('trim', $tags);
         $tags = array_filter($tags);
 
+        //explode dynamic commas values to array
+        $tagsFormatted = [];
+        foreach ($tags as $tag) {
+            if (strpos($tag, ',') !== false) {
+                $innerTags = explode(',', $tag);
+                foreach ($innerTags as $t) {
+                    $tagsFormatted[] = $t;
+                }
+            } else {
+                $tagsFormatted[] = $tag;
+            }
+        }
         if ($tags) {
-            $arguments['tags'] = $tags;
+            $arguments['tags'] = array_map('trim', $tagsFormatted);
         }
 
         $note = '';


### PR DESCRIPTION
When using dynamic tags, it was not respecting the comma and adding all tags as one tag