### PR TITLE
Fixed no scroll option in form selection

### DIFF
--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -59,7 +59,7 @@
                   <span class="el-dropdown-link">
                     {{ current_form_title }}
                   </span>
-                    <el-dropdown-menu slot="dropdown">
+                    <el-dropdown-menu slot="dropdown" style="max-height:300px; overflow-y:scroll;">
                         <el-dropdown-item
                                 v-for="form in forms"
                                 :key="'form_switch_'+form.id"
@@ -82,7 +82,7 @@
                   <span class="el-dropdown-link">
                         {{$t('Columns')}}
                   </span>
-                    <el-dropdown-menu slot="dropdown" >
+                    <el-dropdown-menu slot="dropdown" style="max-height:300px; overflow-y:scroll;" >
 
                         <el-dropdown-item
                                 v-for="(column, column_name) in columns"


### PR DESCRIPTION
If there are a large number of forms then in the entires page the form selection dropdown is displayed in full height without any scroll. Same for the column selection dropdown.

Before - https://prnt.sc/1xn1m7q
After - https://prnt.sc/1xn1zr8