### PR TITLE
dynamic classes added to image form editor's placeholder component

### DIFF
--- a/resources/assets/admin/components/templates/imagePlaceholder.vue
+++ b/resources/assets/admin/components/templates/imagePlaceholder.vue
@@ -1,7 +1,8 @@
 <template>
     <withLabel :item="item">
-        <div style="max-height: 70px;">
-            <img :src="item.editor_options.imageUrl" style="max-height: inherit">
+        <div :class="item.editor_options.container_class" style="max-height: 70px;">
+            <img :class="item.editor_options.image_class" :src="item.editor_options.imageUrl"
+                 style="max-height: inherit">
         </div>
     </withLabel>
 </template>


### PR DESCRIPTION
Classes added to image form editor's placeholder component. It can be used as: 
                        'editor_options' => array(
				'title'           => __( 'My title', 'my-addon' ),
				'icon_class'      => 'ff-icon-donut-chart',
				'template'        => 'imagePlaceholder',
				'imageUrl'        => 'fluentwiz.png',
				'image_class'     => 'dynamic_image_class',
				'container_class' => 'dynamic_container_class'
			),