### PR TITLE
Use upload dir for attachment base path

### DIFF
--- a/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
+++ b/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
@@ -108,13 +108,14 @@ class EmailNotificationActions
         $emailAttachments = [];
         if (! empty($emailData['attachments']) && is_array($emailData['attachments'])) {
             $attachments = [];
+            $uploadDir = wp_get_upload_dir();
             foreach ($emailData['attachments'] as $name) {
                 $fileUrls = ArrayHelper::get($formData, $name);
                 if ($fileUrls && is_array($fileUrls)) {
                     foreach ($fileUrls as $url) {
                         $filePath = str_replace(
-                            site_url(''),
-                            wp_normalize_path(untrailingslashit(ABSPATH)),
+                            $uploadDir['baseurl'],
+                            wp_normalize_path($uploadDir['basedir']),
                             $url
                         );
                         if (file_exists($filePath)) {

--- a/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
+++ b/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
@@ -87,10 +87,7 @@ class EmailNotificationActions
         );
 
         $emailData = $feed['processedValues'];
-        $emailAttachments = $this->getAttachments($emailData, $formData, $entry, $form);
-        if ($emailAttachments) {
-            $emailData['attachments'] = $emailAttachments;
-        }
+        $emailData['attachments'] = $this->getAttachments($emailData, $formData, $entry, $form);
 
         $notifier->notify($emailData, $formData, $form, $entry->id);
     }


### PR DESCRIPTION
`ABSPATH` is not necessarily the base path for the WordPress uploads directory. The uploads dir can exist separate from WP core dir by changing `WP_CONTENT_URL`.

Regardless of upload save destination, Fluentform should always save files under the uploads dir.

![image](https://github.com/user-attachments/assets/97922913-cc8d-4e70-adbf-928b2e464e09)

We can then use **upload url** and **upload dir** instead of **site url** and **abspath** to calculate the attachment path.

Additionally, `$emailData['attachments']` should always be set, even if the attachments is an empty array as that indicates no valid attachment paths could be found. Currently `wp_mail` will be called with form input names of the attachments, which not in line with [wp_mail's documentation](https://developer.wordpress.org/reference/functions/wp_mail/).

