### PR TITLE
Fix: Email notification label Send to Email from Send to Emailx

### DIFF
--- a/resources/assets/admin/components/settings/Notifications.vue
+++ b/resources/assets/admin/components/settings/Notifications.vue
@@ -162,7 +162,7 @@
                         <!--additional field based on the send to selection-->
                         <template v-if="selected.value.sendTo.type === 'email'">
                             <el-form-item
-                                :label="$t('Send to Emailx')"
+                                :label="$t('Send to Email')"
                                 class="conditional-items ff-form-item"
                                 :class="errors.has('sendTo.email') ? 'is-error' : ''"
 


### PR DESCRIPTION
In the email notification, the label was set to Send to Emailx. This commit will update the value to: Send to Email