### PR TITLE
Email attachment missing due to abspath issue

### DIFF
--- a/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
+++ b/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
@@ -106,19 +106,22 @@ class EmailNotificationActions
     private function getAttachments($emailData, $formData, $entry, $form)
     {
         $emailAttachments = [];
-        if (! empty($emailData['attachments']) && is_array($emailData['attachments'])) {
+
+        $uploadDir = wp_upload_dir();
+
+        if (!empty($emailData['attachments']) && is_array($emailData['attachments'])) {
             $attachments = [];
             foreach ($emailData['attachments'] as $name) {
                 $fileUrls = ArrayHelper::get($formData, $name);
                 if ($fileUrls && is_array($fileUrls)) {
                     foreach ($fileUrls as $url) {
-                        $filePath = str_replace(
-                            site_url(''),
-                            wp_normalize_path(untrailingslashit(ABSPATH)),
-                            $url
-                        );
-                        if (file_exists($filePath)) {
-                            $attachments[] = $filePath;
+                        if (strpos($url, $uploadDir['baseurl']) === 0) {
+                            $relativePath = str_replace($uploadDir['baseurl'], '', $url);
+                            $filePath = wp_normalize_path($uploadDir['basedir'] . $relativePath);
+
+                            if (file_exists($filePath)) {
+                                $attachments[] = $filePath;
+                            }
                         }
                     }
                 }
@@ -126,16 +129,14 @@ class EmailNotificationActions
             $emailAttachments = $attachments;
         }
         $mediaAttachments = ArrayHelper::get($emailData, 'media_attachments');
-        if (! empty($mediaAttachments) && is_array($mediaAttachments)) {
+        if (!empty($mediaAttachments) && is_array($mediaAttachments)) {
             $attachments = [];
             foreach ($mediaAttachments as $file) {
                 $fileUrl = ArrayHelper::get($file, 'url');
-                if ($fileUrl) {
-                    $filePath = str_replace(
-                        site_url(''),
-                        wp_normalize_path(untrailingslashit(ABSPATH)),
-                        $fileUrl
-                    );
+                if ($fileUrl && strpos($fileUrl, $uploadDir['baseurl']) === 0) {
+                    $relativePath = str_replace($uploadDir['baseurl'], '', $fileUrl);
+                    $filePath = wp_normalize_path($uploadDir['basedir'] . $relativePath);
+
                     if (file_exists($filePath)) {
                         $attachments[] = $filePath;
                     }


### PR DESCRIPTION
https://lounge.authlab.io/projects#/boards/16/tasks/11548-Email-attachment-got-missing-i

https://support.wpmanageninja.com/#/tickets/127465/view

Issue: The issue is due to a subdirectory installation or redirection setup, which is common on managed hosts like Flywheel, which misleads the file attachments location.

Solution: Use wp_upload_dir() because it returns baseurl and basedir that are guaranteed to match, and it works even if the site is in a subdirectory, symlinked, or running on a custom structure