### PR TITLE
Fix: in EntryDetails table "0" or 0 value not storing

### DIFF
--- a/app/Services/Submission/SubmissionService.php
+++ b/app/Services/Submission/SubmissionService.php
@@ -618,7 +618,7 @@ class SubmissionService
         
         $entryItems = [];
         foreach ($formData as $dataKey => $dataValue) {
-            if (empty($dataValue)) {
+            if ($dataValue === '' || $dataValue === null) {
                 continue;
             }
             


### PR DESCRIPTION
The EntryDetails table is not saving the 0 value. So, the visual report is not showing the proper data. The checker should check an empty string or a null value.

https://lounge.authlab.io/projects#/boards/16/tasks/3769-Issue-with-Net-Promo