### PR TITLE
Fix: WPForm Migrator empty Form

### DIFF
--- a/app/Services/Migrator/Bootstrap.php
+++ b/app/Services/Migrator/Bootstrap.php
@@ -103,6 +103,9 @@ class Bootstrap
         \FluentForm\App\Modules\Acl\Acl::verify(['fluentform_settings_manager', 'fluentform_forms_manager']);
         
         $formIds = wpFluentForm('request')->get('form_ids');
+        if (!is_array($formIds)) {
+            $formIds = [];
+        }
         $formIds = array_map('sanitize_text_field', $formIds);
 
         $this->setImporterType();


### PR DESCRIPTION
https://lounge.authlab.io/projects#/boards/16/tasks/12366-PHP-version-incompat