### PR TITLE
Fix: non-string inputs to support input.replace

### DIFF
--- a/resources/assets/public/fluentform-advanced.js
+++ b/resources/assets/public/fluentform-advanced.js
@@ -19,6 +19,16 @@ import calculation from './Pro/calculations';
         const formSelector = '.' + form.form_instance;
 
         function sanitizeDynamicValue(input) {
+            // Convert input to string if it's not already a string
+            if (input === null || input === undefined) {
+                return '';
+            }
+
+            // Convert to string if it's not already
+            if (typeof input !== 'string') {
+                input = String(input);
+            }
+            
             // Remove dangerous tags and event handlers
             input = input.replace(/<script.*?>.*?<\/script>/gis, '')
                 .replace(/<iframe.*?>.*?<\/iframe>/gis, '')


### PR DESCRIPTION
Updated the sanitizeDynamicValue method to safely handle null, undefined, and non-string inputs by converting them to strings or returning an empty string.

https://lounge.authlab.io/projects#/boards/16/tasks/13288-Conversational-Form-

https://support.wpmanageninja.com/#/tickets/134464/view