### PR TITLE
Fix: set default text color for preview forms

### DIFF
--- a/resources/assets/preview/preview.scss
+++ b/resources/assets/preview/preview.scss
@@ -9,6 +9,7 @@
 }
 body{
   background-color: #F2F2F2;
+  color: #000;
 }
 ul,
 ol{


### PR DESCRIPTION
https://lounge.authlab.io/projects#/boards/16/tasks/9764-Design-Preview-color

https://support.wpmanageninja.com/#/tickets/111791/view