### PR TITLE
Fix: empty user meta key

### DIFF
--- a/app/Services/FormBuilder/EditorShortcodeParser.php
+++ b/app/Services/FormBuilder/EditorShortcodeParser.php
@@ -217,7 +217,10 @@ class EditorShortcodeParser
 
             if (false !== strpos($prop, 'meta.')) {
                 $metaKey = substr($prop, strlen('meta.'));
-                $metaKey = sanitize_key($metaKey);
+                $metaKey = sanitize_text_field($metaKey);
+                if (empty($metaKey)) {
+                    return '';
+                }
                 $userId = $user->ID;
                 $data = get_user_meta($userId, $metaKey, true);
                 $data = Helper::safeUnserialize($data);


### PR DESCRIPTION
Different languages rather than alpha numeric character returns empty string for sanitize_key

https://lounge.authlab.io/projects#/boards/16/tasks/18207-Issue-with-usermetam