### PR TITLE
Fix: hold next/previous  button - long field with condition

### DIFF
--- a/resources/assets/public/Pro/form-conditionals.js
+++ b/resources/assets/public/Pro/form-conditionals.js
@@ -94,6 +94,7 @@ const formConditional = function ($, $theForm, form) {
         }, form.debounce_time || 300);
 
         const hideShowElements = function (items) {
+            let timeoutId;
             $.each(items, (itemName, status) => {
                 const el = getElement(itemName);
                 let $parent = el.closest('.has-conditions');
@@ -106,7 +107,10 @@ const formConditional = function ($, $theForm, form) {
                         .slideDown(200, function() {
                             // Check if this container has range sliders that need reinitialization
                             if ($parent.find('input[type="range"]').length > 0) {
-                                setTimeout(function() {
+                                if (timeoutId) {
+                                    clearTimeout(timeoutId);
+                                }
+                                timeoutId = setTimeout(function() {
                                     $theForm.trigger('reInitRangeSliders');
                                 }, 50);
                             }


### PR DESCRIPTION
https://lounge.authlab.io/projects#/boards/16/tasks/19311-Long-form-built-with-numerous-

This happens because the form has a lot of RangeSlider fields 30+, while the condition re-initializes each RangeSlider with a setTimeout holds the next/previous button logic.