### PR TITLE
Fix: editor when value prop changes

### DIFF
--- a/resources/assets/common/_ace_editor_js.vue
+++ b/resources/assets/common/_ace_editor_js.vue
@@ -25,6 +25,11 @@
                 if (status && !this.editor) {
                     this.initEditor();
                 }
+            },
+            value(newVal) {
+                if (this.editor && newVal !== this.editor.getValue()) {
+                    this.editor.setValue(newVal || '', -1);
+                }
             }
         },
         methods: {


### PR DESCRIPTION
Add a watcher for the component's value prop that updates the Ace editor content when the incoming value differs from the editor's current value. The change calls editor.setValue(newVal || '', -1) (if the editor exists) to sync content without disturbing cursor/selection, preventing the editor and prop from becoming out-of-sync.

https://lounge.authlab.io/projects#/boards/16/tasks/20168-Custom-JS-disappears-after-sav