### PR TITLE
Feature/per-form-email-summary

### DIFF
--- a/app/Hooks/actions.php
+++ b/app/Hooks/actions.php
@@ -968,6 +968,7 @@ add_filter('cron_schedules', function ($schedules) {
 
 add_action('fluentform_do_scheduled_tasks', 'fluentFormHandleScheduledTasks');
 add_action('fluentform_do_email_report_scheduled_tasks', 'fluentFormHandleScheduledEmailReport');
+add_action('fluentform_do_email_report_scheduled_tasks', 'fluentFormHandlePerFormEmailReport');
 
 add_action('fluentform/integration_action_result', function ($feed, $status, $note = '') {
     if (!isset($feed['scheduled_action_id']) || !$status) {

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -181,7 +181,14 @@ class Form extends Model
             ],
             'delete_entry_on_submission'         => 'no',
             'conv_form_per_step_save'            => false,
-            'conv_form_resume_from_last_step'    => false
+            'conv_form_resume_from_last_step'    => false,
+            'per_form_email_summary'             => [
+                'status'            => 'no',
+                'send_to_type'      => 'admin_email',
+                'custom_recipients'  => '',
+                'sending_day'       => 'Mon',
+                'subject'            => '',
+            ],
         ];
 
         if ($formId) {

--- a/app/Services/Scheduler/Scheduler.php
+++ b/app/Services/Scheduler/Scheduler.php
@@ -2,10 +2,14 @@
 
 namespace FluentForm\App\Services\Scheduler;
 
+use FluentForm\App\Helpers\Helper;
+use FluentForm\App\Models\Form;
 use FluentForm\App\Models\FormAnalytics;
+use FluentForm\App\Models\Scheduler as SchedulerModel;
 use FluentForm\App\Models\Submission;
 use FluentForm\App\Modules\Payments\PaymentHelper;
 use FluentForm\App\Services\Emogrifier\Emogrifier;
+use FluentForm\Framework\Support\Arr;
 
 class Scheduler
 {
@@ -95,7 +99,16 @@ class Scheduler
 
         foreach ($submissionCounts as $submissionCount) {
             $submissionCount->permalink = admin_url('admin.php?page=fluent_forms&route=entries&form_id='.$submissionCount->form_id);
+            $submissionCount->draft_total = 0;
         }
+
+        $draftCounts = self::getDraftSubmissionCounts($reportDateFrom, null);
+        foreach ($submissionCounts as $submissionCount) {
+            if (isset($draftCounts[ $submissionCount->form_id ])) {
+                $submissionCount->draft_total = (int) $draftCounts[ $submissionCount->form_id ];
+            }
+        }
+
         if(!$submissionCounts || $submissionCounts->isEmpty()) {
             return; // Nothing found
         }
@@ -203,6 +216,254 @@ class Scheduler
         ], $data, $emailResult);
 
         return $emailResult;
+    }
+
+    /**
+     * Process per-form email summary reports (runs separately from global report).
+     */
+    public static function processPerFormEmailReports()
+    {
+        global $wpdb;
+        $currentDay = date('D');
+        $days = 7;
+        $config = apply_filters('fluentform/per_form_email_summary_config', ['days' => $days]);
+        $days = isset($config['days']) ? intval($config['days']) : 7;
+        if ($days < 1) {
+            $days = 7;
+        }
+        $reportDateFrom = date('Y-m-d', time() - $days * 86400);
+
+        $forms = Form::all();
+        foreach ($forms as $form) {
+            $formId = $form->id;
+            $formSettings = Form::getFormMeta('formSettings', $formId);
+            if (!is_array($formSettings)) {
+                $formSettings = is_string($formSettings) ? json_decode($formSettings, true) : [];
+            }
+            $summary = isset($formSettings['per_form_email_summary']) ? $formSettings['per_form_email_summary'] : [];
+            if (empty($summary) || !is_array($summary)) {
+                continue;
+            }
+            $summary = wp_parse_args($summary, [
+                'status'            => 'no',
+                'send_to_type'      => 'admin_email',
+                'custom_recipients' => '',
+                'sending_day'       => 'Mon',
+                'subject'            => '',
+            ]);
+
+            if ($summary['status'] !== 'yes' || $summary['sending_day'] !== $currentDay) {
+                continue;
+            }
+
+            if ($summary['send_to_type'] === 'admin_email') {
+                $recipients = [get_option('admin_email')];
+            } else {
+                $custom_recipients = isset($summary['custom_recipients']) ? $summary['custom_recipients'] : '';
+                $custom_recipients = explode(',', $custom_recipients);
+                $recipients = [];
+                foreach ($custom_recipients as $recipient) {
+                    $recipient = trim($recipient);
+                    if (is_email($recipient)) {
+                        $recipients[] = $recipient;
+                    }
+                }
+            }
+            if (empty($recipients)) {
+                continue;
+            }
+
+            $submissionCounts = Submission::select([
+                    wpFluent()->raw("COUNT({$wpdb->prefix}fluentform_submissions.id) as total"),
+                    'fluentform_submissions.form_id',
+                    'fluentform_forms.title'
+                ])
+                ->groupBy('fluentform_submissions.form_id')
+                ->where('fluentform_submissions.form_id', $formId)
+                ->where('fluentform_submissions.created_at', '>', $reportDateFrom)
+                ->join('fluentform_forms', 'fluentform_forms.id', '=', 'fluentform_submissions.form_id')
+                ->get();
+
+            foreach ($submissionCounts as $submissionCount) {
+                $submissionCount->permalink = admin_url('admin.php?page=fluent_forms&route=entries&form_id=' . $submissionCount->form_id);
+                $submissionCount->draft_total = 0;
+            }
+            $draftCountsPerForm = self::getDraftSubmissionCounts($reportDateFrom, $formId);
+            $draftTotal = isset($draftCountsPerForm[ $formId ]) ? (int) $draftCountsPerForm[ $formId ] : 0;
+            foreach ($submissionCounts as $submissionCount) {
+                $submissionCount->draft_total = $draftTotal;
+            }
+
+            $paymentCounts = [];
+            if (PaymentHelper::hasPaymentSettings()) {
+                $paymentCounts = wpFluent()->table('fluentform_transactions')
+                    ->select([
+                        wpFluent()->raw("SUM({$wpdb->prefix}fluentform_transactions.payment_total) as total_amount"),
+                        'fluentform_transactions.form_id',
+                        'fluentform_transactions.currency',
+                        'fluentform_forms.title'
+                    ])
+                    ->groupBy('fluentform_transactions.form_id')
+                    ->where('fluentform_transactions.form_id', $formId)
+                    ->where('fluentform_transactions.created_at', '>', $reportDateFrom)
+                    ->where('fluentform_transactions.status', '=', 'paid')
+                    ->join('fluentform_forms', 'fluentform_forms.id', '=', 'fluentform_transactions.form_id')
+                    ->get();
+                foreach ($paymentCounts as $paymentCount) {
+                    $paymentCount->readable_amount = $paymentCount->currency . ' ' . number_format($paymentCount->total_amount / 100);
+                }
+            }
+
+            $reportDateTo = date('Y-m-d 23:59:59', time());
+            $integrationStats = self::getIntegrationStats($formId, [ $reportDateFrom . ' 00:00:00', $reportDateTo ]);
+
+            $data = [
+                'submissions'       => $submissionCounts,
+                'payments'          => $paymentCounts,
+                'days'              => $days,
+                'single_form'       => true,
+                'form_title'        => $form->title,
+                'form_id'           => $formId,
+                'draft_total'       => $draftTotal,
+                'integration_stats' => $integrationStats,
+            ];
+            $emailBody = wpFluentForm('view')->make('email.report.body', $data);
+            $emailBody = apply_filters('fluentform/email_summary_body', $emailBody, $data);
+
+            $originalEmailBody = $emailBody;
+            ob_start();
+            try {
+                $emogrifier = new Emogrifier($emailBody);
+                $emailBody = $emogrifier->emogrify();
+            } catch (\Exception $e) {
+                $emailBody = $originalEmailBody;
+            }
+            ob_get_clean();
+
+            $emailSubject = isset($summary['subject']) && $summary['subject'] !== ''
+                ? $summary['subject']
+                : sprintf(__('Weekly summary for %s', 'fluentform'), $form->title);
+            $replacements = [
+                '{form_title}' => $form->title,
+                '{form_id}'    => (string) $formId,
+                '{days}'       => (string) $days,
+                '{site_name}'  => get_bloginfo('name'),
+            ];
+            $emailSubject = str_replace(array_keys($replacements), array_values($replacements), $emailSubject);
+            $emailSubject = apply_filters('fluentform/per_form_email_summary_subject', $emailSubject, $formId, $data);
+
+            $headers = ['Content-Type: text/html; charset=utf-8'];
+            wp_mail($recipients, $emailSubject, $emailBody, $headers);
+        }
+    }
+
+    /**
+     * Get draft (incomplete) submission counts per form for the period.
+     *
+     * @param string     $reportDateFrom Date string (Y-m-d) for start of period.
+     * @param int|null   $formId         Optional. Limit to one form.
+     * @return array<int,int> Map of form_id => count.
+     */
+    private static function getDraftSubmissionCounts($reportDateFrom, $formId = null)
+    {
+        global $wpdb;
+        $table = $wpdb->prefix . 'fluentform_draft_submissions';
+        $exists = $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table;
+        if (!$exists) {
+            return apply_filters('fluentform/email_summary_draft_counts', [], $reportDateFrom, $formId);
+        }
+
+        try {
+            $query = wpFluent()->table('fluentform_draft_submissions')
+                ->select([
+                    'form_id',
+                    wpFluent()->raw('COUNT(id) AS draft_total'),
+                ])
+                ->groupBy('form_id');
+
+            if ($formId !== null) {
+                $query->where('form_id', '=', (int) $formId);
+            }
+
+            $dateCol = null;
+            // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Table name is from prefix, safe.
+            $cols = $wpdb->get_results('SHOW COLUMNS FROM `' . esc_sql($table) . '`');
+            foreach (is_array($cols) ? $cols : [] as $col) {
+                $field = isset($col->Field) ? $col->Field : '';
+                if ($field === 'updated_at' || $field === 'created_at') {
+                    $dateCol = $field;
+                    break;
+                }
+            }
+            if ($dateCol !== null) {
+                $query->where($dateCol, '>=', $reportDateFrom . ' 00:00:00');
+            }
+
+            $rows = $query->get();
+            $counts = [];
+            foreach ($rows as $row) {
+                $counts[ (int) $row->form_id ] = (int) $row->draft_total;
+            }
+            return apply_filters('fluentform/email_summary_draft_counts', $counts, $reportDateFrom, $formId);
+        } catch (\Exception $e) {
+            return apply_filters('fluentform/email_summary_draft_counts', [], $reportDateFrom, $formId);
+        }
+    }
+
+    /**
+     * Get successful, failed and processing integration (API) run counts per form.
+     * Only includes integration_notify_ actions (excludes email notifications etc).
+     *
+     * @param int   $formId    Form ID.
+     * @param array $dateRange Optional. [ startDate, endDate ] for filtering.
+     * @return array<string, array{success: int, failed: int, processing: int}> Map of integration display name => [ 'success' => n, 'failed' => n, 'processing' => n ].
+     */
+    public static function getIntegrationStats($formId, $dateRange = [])
+    {
+        $formId = (int) $formId;
+        if ($formId <= 0) {
+            return [];
+        }
+        $query = SchedulerModel::selectRaw('action, status, COUNT(*) as run_count')
+            ->where('form_id', $formId)
+            ->where(function ($q) {
+                $q->where('action', 'like', 'fluentform/integration_notify_%')
+                    ->orWhere('action', 'like', 'fluentform_integration_notify_%');
+            });
+
+        $startDate = Arr::get($dateRange, 0);
+        $endDate = Arr::get($dateRange, 1);
+        if ($startDate && $endDate) {
+            if ($startDate != date('Y-m-d H:i:s', strtotime($startDate))) {
+                $startDate .= ' 00:00:01';
+            }
+            if ($endDate != date('Y-m-d H:i:s', strtotime($endDate))) {
+                $endDate .= ' 23:59:59';
+            }
+            $query->where('updated_at', '>=', $startDate)
+                ->where('updated_at', '<=', $endDate);
+        }
+
+        $rows = $query->groupBy('action', 'status')->get();
+
+        $stats = [];
+        foreach ($rows as $row) {
+            $name = Helper::getLogInitiator($row->action, 'api');
+            if (! isset($stats[ $name ])) {
+                $stats[ $name ] = [ 'success' => 0, 'failed' => 0, 'processing' => 0 ];
+            }
+            $status = strtolower((string) $row->status);
+            $count = (int) $row->run_count;
+            if ($status === 'pending' || $status === 'processing') {
+                $stats[ $name ]['processing'] += $count;
+            } elseif ($status === 'success' || $status === 'completed') {
+                $stats[ $name ]['success'] += $count;
+            } else {
+                $stats[ $name ]['failed'] += $count;
+            }
+        }
+
+        return apply_filters('fluentform/get_integration_stats', $stats, $formId, $dateRange);
     }
 
     private static function cleanUpOldData()

--- a/app/Services/Settings/SettingsService.php
+++ b/app/Services/Settings/SettingsService.php
@@ -173,10 +173,26 @@ class SettingsService
             'url'                        => 'sanitize_url',
             'webhook'                    => 'sanitize_url',
             'textTitle'                  => 'sanitize_text_field',
-            'conv_form_per_step_save'    => 'rest_sanitize_boolean'
+            'conv_form_per_step_save'    => 'rest_sanitize_boolean',
+            'send_to_type'               => 'sanitize_text_field',
+            'custom_recipients'          => 'sanitize_text_field',
+            'sending_day'                => 'sanitize_text_field',
         ];
 
-        return fluentform_backend_sanitizer($settings, $sanitizerMap);
+        $settings = fluentform_backend_sanitizer($settings, $sanitizerMap);
+
+        if (isset($settings['per_form_email_summary']) && is_array($settings['per_form_email_summary'])) {
+            $perFormSummaryMap = [
+                'status'            => 'sanitize_text_field',
+                'send_to_type'      => 'sanitize_text_field',
+                'custom_recipients' => 'sanitize_text_field',
+                'sending_day'       => 'sanitize_text_field',
+                'subject'           => 'sanitize_text_field',
+            ];
+            $settings['per_form_email_summary'] = fluentform_backend_sanitizer($settings['per_form_email_summary'], $perFormSummaryMap);
+        }
+
+        return $settings;
     }
 
     public function store($attributes = [])

--- a/app/Views/admin/form/settings_wrapper.php
+++ b/app/Views/admin/form/settings_wrapper.php
@@ -50,6 +50,12 @@ use FluentForm\Framework\Helpers\ArrayHelper;
 						</li>
 						<li>
 							<a class="ff-page-scroll"
+								href="#per-form-email-summaries">
+								<?php echo esc_html(__('Email Summaries', 'fluentform')); ?>
+							</a>
+						</li>
+						<li>
+							<a class="ff-page-scroll"
 								href="#scheduling-and-restrictions">
 								<?php echo esc_html(__('Scheduling & Restrictions', 'fluentform')); ?>
 							</a>

--- a/app/Views/email/report/body.php
+++ b/app/Views/email/report/body.php
@@ -123,7 +123,14 @@
                         <td class="alert alert-warning"
                             style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; color: #fff; font-weight: 500; text-align: center; border-radius: 3px 3px 0 0; background-color: #673ab7; margin: 0; padding: 20px;"
                             align="center" bgcolor="#FF9F00" valign="top">
-                            <?php esc_html_e('Weekly Email Summary of Your Forms', 'fluentform'); ?>
+                            <?php
+                            if ( ! empty( $single_form ) && ! empty( $form_title ) ) {
+                                /* translators: %s: form title */
+                                echo esc_html( sprintf( __( 'Weekly Email Summary for %s', 'fluentform' ), $form_title ) );
+                            } else {
+                                esc_html_e( 'Weekly Email Summary of Your Forms', 'fluentform' );
+                            }
+                            ?>
                         </td>
                     </tr>
                     <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
@@ -137,20 +144,50 @@
                                         style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
                                         valign="top">
                                         <b><?php esc_html_e('Hello There,', 'fluentform'); ?></b><br/>
-                                        <?php printf(
-                                          /* translators: %d is the Number Email Summary Days */
-                                          esc_html__('Let\'s see how your forms performed in the last %d days.', 'fluentform'), intval($days));; ?>
+                                        <?php
+                                        if ( ! empty( $single_form ) ) {
+                                            printf(
+                                                /* translators: %d is the number of days */
+                                                esc_html__( 'Here is how this form performed in the last %d days.', 'fluentform' ),
+                                                intval( $days )
+                                            );
+                                        } else {
+                                            printf(
+                                                /* translators: %d is the Number Email Summary Days */
+                                                esc_html__( 'Let\'s see how your forms performed in the last %d days.', 'fluentform' ),
+                                                intval( $days )
+                                            );
+                                        }
+                                        ?>
                                     </td>
                                 </tr>
                                 <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                     <td class="content-block"
                                         style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
                                         valign="top">
+                                        <?php
+                                        $has_submissions = ! empty( $submissions ) && ( is_array( $submissions ) ? count( $submissions ) : ( method_exists( $submissions, 'count' ) ? $submissions->count() : 0 ) ) > 0;
+                                        $has_draft_column = false;
+                                        if ( $has_submissions ) {
+                                            foreach ( $submissions as $s ) {
+                                                $dt = isset( $s->draft_total ) ? (int) $s->draft_total : 0;
+                                                if ( $dt > 0 ) {
+                                                    $has_draft_column = true;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                        $draft_total_display = isset( $draft_total ) ? (int) $draft_total : 0;
+                                        if ( $has_submissions ) :
+                                        ?>
                                         <table class="summary_table">
                                             <thead>
                                             <tr>
                                                 <th><?php esc_html_e('Form', 'fluentform'); ?></th>
                                                 <th><?php esc_html_e('Entries', 'fluentform'); ?></th>
+                                                <?php if ( $has_draft_column ) : ?>
+                                                <th><?php esc_html_e('Incomplete', 'fluentform'); ?></th>
+                                                <?php endif; ?>
                                             </tr>
                                             </thead>
                                             <tbody>
@@ -158,12 +195,96 @@
                                                 <tr>
                                                     <td><?php echo esc_html($submission->title); ?></td>
                                                     <td><?php echo esc_attr($submission->total); ?></td>
+                                                    <?php if ( $has_draft_column ) : ?>
+                                                    <td><?php echo esc_attr( isset( $submission->draft_total ) ? (int) $submission->draft_total : 0 ); ?></td>
+                                                    <?php endif; ?>
+                                                </tr>
+                                            <?php endforeach; ?>
+                                            </tbody>
+                                        </table>
+                                        <?php elseif ( ! empty( $single_form ) && $draft_total_display > 0 ) : ?>
+                                        <p>
+                                            <?php
+                                            printf(
+                                                /* translators: %d is the number of days */
+                                                esc_html__( 'No completed entries were received for this form in the last %d days.', 'fluentform' ),
+                                                intval( $days )
+                                            );
+                                            ?>
+                                        </p>
+                                        <p>
+                                            <?php
+                                            printf(
+                                                /* translators: %s: number of incomplete/draft submissions */
+                                                esc_html__( 'Incomplete (draft) submissions: %s', 'fluentform' ),
+                                                '<strong>' . esc_html( (string) $draft_total_display ) . '</strong>'
+                                            );
+                                            ?>
+                                        </p>
+                                        <?php else : ?>
+                                        <p>
+                                            <?php
+                                            if ( ! empty( $single_form ) ) {
+                                                printf(
+                                                    /* translators: %d is the number of days */
+                                                    esc_html__( 'No entries were received for this form in the last %d days.', 'fluentform' ),
+                                                    intval( $days )
+                                                );
+                                            } else {
+                                                printf(
+                                                    /* translators: %d is the number of days */
+                                                    esc_html__( 'No entries were received in the last %d days.', 'fluentform' ),
+                                                    intval( $days )
+                                                );
+                                            }
+                                            ?>
+                                        </p>
+                                        <?php endif; ?>
+                                    </td>
+                                </tr>
+
+                                <?php if ( ! empty( $integration_stats ) && is_array( $integration_stats ) ) : ?>
+                                <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                                    <td class="content-block"
+                                        style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
+                                        valign="top">
+                                        <h3><?php esc_html_e('Integrations', 'fluentform'); ?></h3>
+                                        <?php
+                                        $has_processing = false;
+                                        foreach ( $integration_stats as $maybe_counts ) {
+                                            if ( is_array( $maybe_counts ) && ! empty( $maybe_counts['processing'] ) ) {
+                                                $has_processing = true;
+                                                break;
+                                            }
+                                        }
+                                        ?>
+                                        <table class="summary_table">
+                                            <thead>
+                                            <tr>
+                                                <th><?php esc_html_e('Integration', 'fluentform'); ?></th>
+                                                <th><?php esc_html_e('Successful', 'fluentform'); ?></th>
+                                                <th><?php esc_html_e('Failed', 'fluentform'); ?></th>
+                                                <?php if ( $has_processing ) : ?>
+                                                    <th><?php esc_html_e('Processing', 'fluentform'); ?></th>
+                                                <?php endif; ?>
+                                            </tr>
+                                            </thead>
+                                            <tbody>
+                                            <?php foreach ( $integration_stats as $name => $counts ) : ?>
+                                                <tr>
+                                                    <td><?php echo esc_html( $name ); ?></td>
+                                                    <td><?php echo esc_attr( (string) ( isset( $counts['success'] ) ? $counts['success'] : 0 ) ); ?></td>
+                                                    <td><?php echo esc_attr( (string) ( isset( $counts['failed'] ) ? $counts['failed'] : 0 ) ); ?></td>
+                                                    <?php if ( $has_processing ) : ?>
+                                                        <td><?php echo esc_attr( (string) ( isset( $counts['processing'] ) ? $counts['processing'] : 0 ) ); ?></td>
+                                                    <?php endif; ?>
                                                 </tr>
                                             <?php endforeach; ?>
                                             </tbody>
                                         </table>
                                     </td>
                                 </tr>
+                                <?php endif; ?>
 
                                 <?php if ($payments): ?>
                                     <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
@@ -191,6 +312,18 @@
                                     </tr>
                                 <?php endif; ?>
 
+                                <?php if ( ! empty( $single_form ) && ! empty( $form_id ) ) : ?>
+                                <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                                    <td class="content-block"
+                                        style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
+                                        valign="top">
+                                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=fluent_forms&route=entries&form_id=' . intval( $form_id ) ) ); ?>"><?php esc_html_e( 'View entries', 'fluentform' ); ?></a>
+                                        &nbsp;|&nbsp;
+                                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=fluent_forms_reports&form_id=' . intval( $form_id ) . '&range=week' ) ); ?>"><?php esc_html_e( 'View Reports', 'fluentform' ); ?></a>
+                                    </td>
+                                </tr>
+                                <?php endif; ?>
+
                                 <tr style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
                                     <td class="content-block"
                                         style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;"
@@ -215,7 +348,7 @@
                                         );
                                         $generateText = apply_filters('fluentform/email_summary_body_text', $generateText, $submissions);
                                         ?>
-                                        <?php echo wp_kses_post($generateText); ?> .
+                                        <?php echo wp_kses_post($generateText); ?>
                                     </td>
                                 </tr>
                             </table>
@@ -231,27 +364,43 @@
                                 style="font-family: 'Helvetica Neue',Helvetica,Arial,sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; color: #999; text-align: center; margin: 0; padding: 0 0 20px;"
                                 align="center" valign="top">
                                 <?php
-                                $footerText = sprintf(
-                                     /* translators: 1: opening anchor tag to site, 2: closing anchor tag, 3: opening anchor tag to settings, 4: closing anchor tag */
-                                    __('This email has been sent from %1$syour website%2$s via Fluent Forms. You can disable this email %3$syour website%4$s', 'fluentform'),
-                                    '<a href="' .  site_url() . '">',
-                                    '</a>',
-                                    '<a href="' .  admin_url('admin.php?page=fluent_forms_settings') . '">',
-                                    '</a>'
-                                );
+                                if ( ! empty( $single_form ) && ! empty( $form_id ) ) {
+                                    $site_url     = site_url();
+                                    $settings_url = admin_url(
+                                        'admin.php?page=fluent_forms&form_id=' . intval( $form_id ) . '&route=settings&sub_route=form_settings#/basic_settings'
+                                    );
+                                    $footerText   = sprintf(
+                                        /* translators: 1: opening anchor to site URL, 2: site URL text, 3: closing anchor, 4: opening anchor to per-form settings, 5: closing anchor */
+                                        __( 'This email has been sent from %1$s%2$s%3$s via Fluent Forms. You can disable this email from %4$shere%5$s', 'fluentform' ),
+                                        '<a href="' . esc_url( $site_url ) . '">',
+                                        esc_html( $site_url ),
+                                        '</a>',
+                                        '<a href="' . esc_url( $settings_url ) . '">',
+                                        '</a>'
+                                    );
+                                } else {
+                                    $footerText = sprintf(
+                                        /* translators: 1: opening anchor tag to site, 2: closing anchor tag, 3: opening anchor tag to settings, 4: closing anchor tag */
+                                        __( 'This email has been sent from %1$syour website%2$s via Fluent Forms. You can disable this email from %3$shere%4$s', 'fluentform' ),
+                                        '<a href="' . site_url() . '">',
+                                        '</a>',
+                                        '<a href="' . admin_url( 'admin.php?page=fluent_forms_settings' ) . '">',
+                                        '</a>'
+                                    );
+                                }
                                 $footerText = apply_filters_deprecated(
                                     'fluentform_email_summary_footer_text',
                                     [
-                                        $footerText
+                                        $footerText,
                                     ],
                                     FLUENTFORM_FRAMEWORK_UPGRADE,
                                     'fluentform/email_summary_footer_text',
                                     'Use fluentform/email_summary_footer_text instead of fluentform_email_summary_footer_text.'
                                 );
-                                $footerText = apply_filters('fluentform/email_summary_footer_text', $footerText);
+                                $footerText = apply_filters( 'fluentform/email_summary_footer_text', $footerText );
                                 ?>
                                 <p>
-                                    <?php echo wp_kses_post($footerText); ?>
+                                    <?php echo wp_kses_post( $footerText ); ?>
                                 </p>
                             </td>
                         </tr>

--- a/boot/globals.php
+++ b/boot/globals.php
@@ -254,6 +254,11 @@ function fluentFormHandleScheduledEmailReport()
     \FluentForm\App\Services\Scheduler\Scheduler::processEmailReport();
 }
 
+function fluentFormHandlePerFormEmailReport()
+{
+    \FluentForm\App\Services\Scheduler\Scheduler::processPerFormEmailReports();
+}
+
 function fluentform_upgrade_url()
 {
     return 'https://fluentforms.com/pricing/?utm_source=plugin&utm_medium=wp_install&utm_campaign=ff_upgrade&theme_style=' . fluentform_get_active_theme_slug();

--- a/resources/assets/admin/Reports/App.vue
+++ b/resources/assets/admin/Reports/App.vue
@@ -698,7 +698,7 @@ export default {
 
         fetchFormsList() {
             const url = FluentFormsGlobal.$rest.route("selectFormsForReport");
-            FluentFormsGlobal.$rest.get(url)
+            return FluentFormsGlobal.$rest.get(url)
                 .then(response => {
                     if (response.forms) {
                         this.formsList = response.forms;
@@ -707,6 +707,25 @@ export default {
                 .catch(error => {
                     console.error("Error fetching forms list:", error);
                 });
+        },
+
+        applyUrlParams() {
+            const params = new URLSearchParams(window.location.search);
+            const formId = params.get('form_id');
+            const range = params.get('range');
+            if (formId) {
+                const id = parseInt(formId, 10);
+                if (!isNaN(id)) {
+                    this.selectedGlobalFormId = id;
+                }
+            }
+            if (range) {
+                this.lastUsedSelector = 'range';
+                this.selectedRange = range;
+                this.updateGlobalDateParams();
+            } else {
+                this.fetchReports();
+            }
         },
 
         handleDateRangeChange(range) {
@@ -858,8 +877,9 @@ export default {
         }
     },
     mounted() {
-        this.fetchReports();
-        this.fetchFormsList();
+        this.fetchFormsList().then(() => {
+            this.applyUrlParams();
+        });
     }
 };
 </script>

--- a/resources/assets/admin/components/settings/FormSettings.vue
+++ b/resources/assets/admin/components/settings/FormSettings.vue
@@ -513,6 +513,97 @@
                     </card-body>
                 </card>
 
+                <!-- Per-form Email Summaries -->
+                <card id="per-form-email-summaries">
+                    <card-head>
+                        <h5 class="title">{{ $t('Email Summaries') }}</h5>
+                        <p class="text">
+                            {{ $t('Receive a weekly report for this form\'s submissions and performance.') }}
+                        </p>
+                    </card-head>
+                    <card-body>
+                        <el-form label-position="top">
+                            <el-form-item class="ff-form-item">
+                                <template slot="label">
+                                    {{ $t('Status') }}
+                                    <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
+                                        <div slot="content">
+                                            <p>{{ $t('Enable this feature to get weekly reports on how this form is performing.') }}</p>
+                                        </div>
+                                        <i class="ff-icon ff-icon-info-filled text-primary"></i>
+                                    </el-tooltip>
+                                </template>
+                                <el-checkbox true-label="yes" false-label="no" v-model="formSettings.per_form_email_summary.status">
+                                    {{ $t('Enable Email Summaries') }}
+                                </el-checkbox>
+                            </el-form-item>
+                            <template v-if="formSettings.per_form_email_summary.status == 'yes'">
+                                <el-form-item class="ff-form-item">
+                                    <template slot="label">
+                                        {{ $t('Send To') }}
+                                        <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
+                                            <div slot="content">
+                                                <p>{{ $t('Specify the recipient of the weekly report.') }}</p>
+                                            </div>
+                                            <i class="ff-icon ff-icon-info-filled text-primary"></i>
+                                        </el-tooltip>
+                                    </template>
+                                    <el-radio-group v-model="formSettings.per_form_email_summary.send_to_type">
+                                        <el-radio label="admin_email">{{ $t('Site Admin') }}</el-radio>
+                                        <el-radio label="custom_email">{{ $t('Custom Email') }}</el-radio>
+                                    </el-radio-group>
+                                </el-form-item>
+                                <el-row :gutter="24">
+                                    <el-col :span="24" v-if="formSettings.per_form_email_summary.send_to_type == 'custom_email'">
+                                        <el-form-item class="ff-form-item">
+                                            <label class="mb-3" style="display: block;">{{ $t('Enter Recipient Email Address') }}</label>
+                                            <el-input class="w-100" :placeholder="$t('Recipient Email Address')"
+                                                v-model="formSettings.per_form_email_summary.custom_recipients"></el-input>
+                                            <p class="fs-14 mt-1">{{ $t('For multiple email addresses, use comma to separate them.') }}</p>
+                                        </el-form-item>
+                                    </el-col>
+                                    <el-col :sm="24" :md="12">
+                                        <el-form-item class="ff-form-item">
+                                            <template slot="label">
+                                                {{ $t('Get Reports On') }}
+                                                <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
+                                                    <div slot="content">
+                                                        <p>{{ $t('Select the day to receive weekly report.') }}</p>
+                                                    </div>
+                                                    <i class="ff-icon ff-icon-info-filled text-primary"></i>
+                                                </el-tooltip>
+                                            </template>
+                                            <el-select class="w-100 ff-input-s1" :placeholder="$t('Select Day')" v-model="formSettings.per_form_email_summary.sending_day">
+                                                <el-option v-for="(sendDay, dayKey) in sending_days" :key="dayKey" :value="dayKey"
+                                                    :label="$t(sendDay)"></el-option>
+                                            </el-select>
+                                        </el-form-item>
+                                    </el-col>
+                                    <el-col :sm="24" :md="12">
+                                        <el-form-item class="ff-form-item">
+                                            <template slot="label">
+                                                {{ $t('Subject Line') }}
+                                                <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
+                                                    <div slot="content">
+                                                        <p>{{ $t('Enter the subject line of the email summaries') }}</p>
+                                                    </div>
+                                                    <i class="ff-icon ff-icon-info-filled text-primary"></i>
+                                                </el-tooltip>
+                                            </template>
+                                            <el-input
+                                                class="w-100"
+                                                :placeholder="$t('Email Subject')"
+                                                v-model="formSettings.per_form_email_summary.subject"
+                                            />
+                                            <p class="fs-14 mt-1">{{ $t('You can use smart codes in the subject line: {form_title}, {form_id}', { form_title: '{form_title}', form_id: '{form_id}' }) }}</p>
+                                        </el-form-item>
+                                    </el-col>
+                                </el-row>
+                            </template>
+                        </el-form>
+                    </card-body>
+                </card>
+
                 <!-- Form Restrictions -->
                 <card id="scheduling-and-restrictions">
                     <card-head>
@@ -843,6 +934,15 @@
                     'asterisk-left': 'Left to Label',
                     'asterisk-right': 'Right to Label'
                 },
+                sending_days: {
+                    Mon: 'Monday',
+                    Tue: 'Tuesday',
+                    Wed: 'Wednesday',
+                    Thu: 'Thursday',
+                    Fri: 'Friday',
+                    Sat: 'Saturday',
+                    Sun: 'Sunday'
+                },
                 advancedValidationSettings: {
                     status: false,
                     type: 'all',
@@ -940,6 +1040,13 @@
                         helpMessagePlacement: 'with_label',
                         errorMessagePlacement: 'inline',
                         cssClassName: ''
+                    },
+                    per_form_email_summary: {
+                        status: 'no',
+                        send_to_type: 'admin_email',
+                        custom_recipients: '',
+                        sending_day: 'Mon',
+                        subject: ''
                     }
                 }
             },
@@ -976,6 +1083,15 @@
                                     showLabel: false,
                                     showCount: false
                                 }
+                            }
+                            if (!settings.per_form_email_summary) {
+                                settings.per_form_email_summary = {
+                                    status: 'no',
+                                    send_to_type: 'admin_email',
+                                    custom_recipients: '',
+                                    sending_day: 'Mon',
+                                    subject: ''
+                                };
                             }
                             this.formSettings = settings;
                         } else {


### PR DESCRIPTION
# Email Report & Per-Form Summary – Change Summary

Summary of changes made to FluentForm’s email reporting (global and per-form summaries), including the “View Reports” link, draft counts, integration stats, and per-form footer.

---

## 1. View Reports link in email

- **What:** Per-form email summaries include a “View Reports” link next to “View entries”.
- **URL:** `admin.php?page=fluent_forms_reports&form_id={id}&range=week` (form ID and “Last 7 days” preset).
- **Where:** `app/Views/email/report/body.php` (per-form block); Reports page applies URL params in `resources/assets/admin/Reports/App.vue` via `applyUrlParams()` (reads `form_id`, `range` and sets form + date range after `fetchFormsList()`).

---

## 2. Draft / incomplete submissions in email

- **What:** Email reports show counts of draft (incomplete) submissions when the draft table exists.
- **Logic:** `Scheduler::getDraftSubmissionCounts($reportDateFrom, $formId)` in `app/Services/Scheduler/Scheduler.php`:
  - Checks existence of `{prefix}fluentform_draft_submissions` (e.g. via table/column check).
  - No Pro check; runs whenever the table exists.
  - Returns `form_id => count`; filter: `fluentform/email_summary_draft_counts`.
- **Display:** In `body.php`, an “Incomplete” column is shown when any row has `draft_total > 0`. If there are no completed entries but `draft_total > 0`, the message shows “No completed entries…” and “Incomplete (draft) submissions: **X**”.

---

## 3. Integration statistics (success, failed, processing)

- **What:** Per-form emails can show an “Integrations” section with Successful, Failed, and (when relevant) Processing counts per integration.
- **Data source:** `Scheduler::getIntegrationStats($formId, $dateRange)` in `app/Services/Scheduler/Scheduler.php`:
  - Queries `ff_scheduled_actions` for `fluentform/integration_notify_%` and `fluentform_integration_notify_%` actions.
  - Groups by action and status; maps to display names via `Helper::getLogInitiator(..., 'api')`.
  - Status mapping: `pending` / `processing` → **processing**; `success` / `completed` → **success**; others → **failed**.
  - Return shape: `[ integration_name => [ 'success' => n, 'failed' => n, 'processing' => n ] ]`.
  - Filter: `fluentform/get_integration_stats`.
- **Display:** In `body.php`, the Integrations block is shown only when `!empty($integration_stats) && is_array($integration_stats)`. The “Processing” column is shown only if any integration has `processing > 0`.

---

## 4. Per-form email summary footer

- **What:** For per-form summaries, the footer shows the actual site URL as text and link, and “Disable this email from here” points to that form’s settings.
- **Per-form footer (when `$single_form` and `$form_id` are set):**
  - **Site link:** “This email has been sent from **&lt;site_url&gt;** via Fluent Forms…” — the visible text and link both use `site_url()` (escaped).
  - **Disable link:** “You can disable this email from **here**” →  
    `admin.php?page=fluent_forms&form_id={form_id}&route=settings&sub_route=form_settings#/basic_settings`
- **Global summary:** Keeps generic “your website” and link to `admin.php?page=fluent_forms_settings`.
- **Where:** `app/Views/email/report/body.php` (footer block with conditional `$footerText`).

---

## 5. Files touched

| File | Role |
|------|------|
| `app/Services/Scheduler/Scheduler.php` | Draft counts, integration stats (including processing), per-form report data (draft_total, integration_stats). |
| `app/Views/email/report/body.php` | View Reports link, Incomplete column & copy, Integrations table (success/failed/processing), per-form footer (site URL + disable link). |
| `resources/assets/admin/Reports/App.vue` | `applyUrlParams()` for `form_id` and `range`; called after `fetchFormsList()` in `mounted()`. |

Other files (e.g. `actions.php`, `Form.php`, `SettingsService.php`, `globals.php`, `FormSettings.vue`) were already wired for per-form summaries and were not changed for these features.

---

## 6. Filters

- `fluentform/email_summary_draft_counts` – override draft counts (Scheduler).
- `fluentform/get_integration_stats` – override or extend integration stats (Scheduler).
- `fluentform/email_summary_footer_text` – override footer text (body.php).

---

## 7. Flow (per-form report)

1. Cron runs `fluentform_do_email_report_scheduled_tasks`; per-form handler calls `Scheduler::processPerFormEmailReports()`.
2. For each form with per-form email summary enabled and sending day matching, Scheduler:
   - Gets submission counts and draft counts for the period.
   - Gets `integration_stats` via `getIntegrationStats($formId, [ $reportDateFrom, $reportDateTo ])`.
   - Passes `single_form`, `form_id`, `draft_total`, `integration_stats`, etc. to the email view.
3. View renders body (entries, incomplete, integrations, View entries | View Reports) and footer (per-form: site URL + form settings link; global: generic footer).
4. “View Reports” link opens Reports with that form and “Last 7 days”; Vue applies `form_id` and `range` from the URL.
