### PR TITLE
support nested capability structures in Acl

### DIFF
--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -202,9 +202,17 @@ class Acl
             return false;
         }
 
-        foreach ($capabilities as $capability) {
-            if ($user->has_cap($capability)) {
-                return $capability;
+        foreach ($capabilities as $roleOrCap => $value) {
+            if (is_array($value)) {
+                // Nested format: { role: { cap: true, ... } }
+                foreach ($value as $cap => $enabled) {
+                    if ($enabled && is_string($cap) && $user->has_cap($cap)) {
+                        return $cap;
+                    }
+                }
+            } elseif (is_string($value) && $user->has_cap($value)) {
+                // Flat format: [ 'cap1', 'cap2' ]
+                return $value;
             }
         }
 


### PR DESCRIPTION
Requested By: [dhrupo](https://github.com/dhrupo)

Update capability checking loop to handle both flat lists and nested role=>capability maps. The code now accepts formats like { role: { cap: true, ... } } as well as flat arrays of capability strings, returning the first matching capability the user has. Adds input checks for enabled flags and string keys to avoid false positives and preserves previous flat-array behavior.

https://github.com/fluentform/fluentform/issues/770