### PR TITLE
Improve: Improve submission hook error handling for third-party

### DIFF
--- a/app/Modules/Form/FormHandler.php
+++ b/app/Modules/Form/FormHandler.php
@@ -2,7 +2,7 @@
 
 namespace FluentForm\App\Modules\Form;
 
-use FluentForm\App\Databases\Migrations\SubmissionDetails;
+use FluentForm\Database\Migrations\SubmissionDetails;
 use FluentForm\App\Helpers\Helper;
 use FluentForm\App\Modules\Activator;
 use FluentForm\App\Modules\ReCaptcha\ReCaptcha;
@@ -219,10 +219,19 @@ class FormHandler
             );
 
         } catch (\Exception $e) {
+            do_action('fluentform/submission_inserted_error', $insertId, $formData, $form, $e);
             if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('Fluent Forms: Exception in submission_inserted hook: ' . $e->getMessage());
                 $error = $e->getMessage();
             }
         }
+
+        /*
+         * Fires after all submission_inserted hooks have been attempted,
+         * regardless of whether an exception occurred.
+         * Use this hook if you need a guaranteed execution point after submission insertion.
+         */
+        do_action('fluentform/submission_inserted_completed', $insertId, $formData, $form);
 
         do_action_deprecated(
             'fluentform_before_submission_confirmation',

--- a/app/Services/Form/SubmissionHandlerService.php
+++ b/app/Services/Form/SubmissionHandlerService.php
@@ -251,10 +251,19 @@ class SubmissionHandlerService
             );
 
         } catch (\Exception $e) {
+            do_action('fluentform/submission_inserted_error', $insertId, $formData, $form, $e);
             if (defined('WP_DEBUG') && WP_DEBUG) {
+                error_log('Fluent Forms: Exception in submission_inserted hook: ' . $e->getMessage());
                 $error = $e->getMessage();
             }
         }
+
+        /*
+         * Fires after all submission_inserted hooks have been attempted,
+         * regardless of whether an exception occurred.
+         * Use this hook if you need a guaranteed execution point after submission insertion.
+         */
+        do_action('fluentform/submission_inserted_completed', $insertId, $formData, $form);
 
         do_action_deprecated(
             'fluentform_before_submission_confirmation', [

--- a/readme.txt
+++ b/readme.txt
@@ -438,6 +438,11 @@ You can get support from our official support thread at <a href="https://wpmanag
 
 == Changelog ==
 
+= 6.1.19 (Date: - , 2026) =
+- Adds fluentform/submission_inserted_error hook for third-party plugin error recovery
+- Adds fluentform/submission_inserted_completed hook that always fires after submission processing
+- Improves error logging in submission hook exception handling
+
 = 6.1.18 (Date: February 25, 2026) =
 - Improves file delete endpoint security
 - Adds input sanitization to all report data endpoints


### PR DESCRIPTION
Requested By: [nkb-bd](https://github.com/nkb-bd)

- Add fluentform/submission_inserted_error hook inside catch block
  - Add fluentform/submission_inserted_completed hook that always fires
  - Log exceptions to error_log when WP_DEBUG is enabled