### PR TITLE
Fix "xlsv" typo to "xlsx" in export dropdown

### DIFF
--- a/app/Modules/Registerer/TranslationString.php
+++ b/app/Modules/Registerer/TranslationString.php
@@ -1727,7 +1727,7 @@ class TranslationString
             'Bulk Actions' => __('Bulk Actions', 'fluentform'),
             'Export ' => __('Export ', 'fluentform'),
             'Export as CSV' => __('Export as CSV', 'fluentform'),
-            'Export as Excel(xlsv)' => __('Export as Excel(xlsv)', 'fluentform'),
+            'Export as Excel(xlsx)' => __('Export as Excel(xlsx)', 'fluentform'),
             'Export as ODS' => __('Export as ODS', 'fluentform'),
             'Step Completed' => __('Step Completed', 'fluentform'),
             'Back to All' => __('Back to All', 'fluentform'),

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -20,7 +20,7 @@
                             </el-button>
                             <el-dropdown-menu slot="dropdown">
                                 <el-dropdown-item command="csv">{{ $t('Export as %s', 'CSV') }}</el-dropdown-item>
-                                <el-dropdown-item command="xlsx">{{ $t('Export as %s', 'Excel (xlsv)') }}</el-dropdown-item>
+                                <el-dropdown-item command="xlsx">{{ $t('Export as %s', 'Excel (xlsx)') }}</el-dropdown-item>
                                 <el-dropdown-item command="ods">{{ $t('Export as %s', 'ODS') }}</el-dropdown-item>
                                 <el-dropdown-item command="json">{{ $t('Export as %s', 'JSON Data') }}</el-dropdown-item>
                             </el-dropdown-menu>


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

The Excel export dropdown label showed "xlsv" instead of the correct
"xlsx" file extension. Fixed in both the Vue template and the PHP
translation string registry.