### PR TITLE
Change Upgrade to Pro buttons from danger to primary color

### DIFF
--- a/resources/assets/admin/components/modals/ItemDisabled.vue
+++ b/resources/assets/admin/components/modals/ItemDisabled.vue
@@ -53,7 +53,7 @@
             <div v-else>
                 <p>{{ $t('This field is only available on Fluent Forms Pro add-on') }}</p>
                 <a target="_blank"
-                   class="el-button el-button--danger"
+                   class="el-button el-button--primary"
                    :href="campaignUrl" >
                     {{ $t('Upgrade to Pro Now') }}
                 </a>
@@ -65,7 +65,7 @@
                         <h2 class="mb-3">{{ $t('Fluent Forms Payment Module') }}</h2>
                         <p>{{ $t('Accept Payment online as part of the Forms submission process. With Fluent Forms Powerful payment integration, you can easily accept and process payments in your Fluent Forms via Stripe/PayPal. Payment Module is available on Pro Version.') }}</p>
                         <a  target="_blank"
-                            class="el-button el-button--danger"
+                            class="el-button el-button--primary"
                             :href="campaignUrl" >
                             {{ $t('Upgrade to Pro Now') }}
                         </a>
@@ -76,7 +76,7 @@
                     <div v-else>
                         <p>{{ $t('This field is only available on Fluent Forms Pro add-on') }}</p>
                         <a target="_blank"
-                            class="el-button el-button--danger"
+                            class="el-button el-button--primary"
                             :href="campaignUrl" >
                             {{ $t('Upgrade to Pro Now') }}
                         </a>

--- a/resources/assets/admin/components/modals/PostTypeSelectionModal.vue
+++ b/resources/assets/admin/components/modals/PostTypeSelectionModal.vue
@@ -29,7 +29,7 @@
             <notice v-else class="mt-4" type="danger-soft">
                 <h6 class="title mb-2">{{ $t('Post type form is a Pro features') }}</h6>
                 <p class="text">{{ $t('Please upgrade to PRO to unlock the feature.') }}</p>
-                <a target="_blank" href="https://fluentforms.com/pricing/?utm_source=plugin&utm_medium=wp_install&utm_campaign=ff_upgrade" class="el-button el-button--danger el-button--small">{{ $t('Upgrade to Pro') }}</a>
+                <a target="_blank" href="https://fluentforms.com/pricing/?utm_source=plugin&utm_medium=wp_install&utm_campaign=ff_upgrade" class="el-button el-button--primary el-button--small">{{ $t('Upgrade to Pro') }}</a>
             </notice>
         </el-dialog>
     </div>

--- a/resources/assets/admin/components/settings/Confirmations.vue
+++ b/resources/assets/admin/components/settings/Confirmations.vue
@@ -149,7 +149,7 @@
                             <h6 class="title">{{ $t('You are using the free version of Fluent Forms.') }}</h6>
                             <p class="text">{{ $t('Upgrade to get access to all the advanced features.') }}</p>
                         </div>
-                        <a target="_blank" href="https://fluentforms.com/pricing/?utm_source=plugin&amp;utm_medium=wp_install&amp;utm_campaign=ff_upgrade&amp;theme_style=twentytwentythree" class="el-button el-button--danger el-button--small">
+                        <a target="_blank" href="https://fluentforms.com/pricing/?utm_source=plugin&amp;utm_medium=wp_install&amp;utm_campaign=ff_upgrade&amp;theme_style=twentytwentythree" class="el-button el-button--primary el-button--small">
                             {{ $t('Upgrade to Pro') }}
                         </a>
                     </notice>

--- a/resources/assets/admin/components/settings/Notifications.vue
+++ b/resources/assets/admin/components/settings/Notifications.vue
@@ -261,7 +261,7 @@
                                 </div>
                                 <a target="_blank"
                                    href="https://fluentforms.com/pricing/?utm_source=plugin&amp;utm_medium=wp_install&amp;utm_campaign=ff_upgrade&amp;theme_style=twentytwentythree"
-                                   class="el-button el-button--danger el-button--small">
+                                   class="el-button el-button--primary el-button--small">
                                     {{ $t('Upgrade to Pro') }}
                                 </a>
                             </notice>

--- a/resources/assets/admin/views/EditEntry.vue
+++ b/resources/assets/admin/views/EditEntry.vue
@@ -33,7 +33,7 @@
                 <h6 class="title">{{$t('This is a Pro Feature')}}</h6> 
                 <p class="text">{{$t('Please upgrade to pro to unlock this feature.')}}</p>
             </div>
-            <a target="_blank" :href="upgrade_url" class="el-button el-button--danger el-button--small">
+            <a target="_blank" :href="upgrade_url" class="el-button el-button--primary el-button--small">
                 {{$t('Upgrade to Pro')}}
             </a>
         </notice>

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -319,7 +319,7 @@
 					    <h6 class="title">{{ $t('You are using the free version of Fluent Forms.') }}</h6>
 					    <p class="text">{{ $t('Upgrade to get access to all the advanced features.') }}</p>
 				    </div>
-				    <a target="_blank" href="https://fluentforms.com/pricing/?utm_source=plugin&amp;utm_medium=wp_install&amp;utm_campaign=ff_upgrade&amp;theme_style=twentytwentythree" class="el-button el-button--danger el-button--small">
+				    <a target="_blank" href="https://fluentforms.com/pricing/?utm_source=plugin&amp;utm_medium=wp_install&amp;utm_campaign=ff_upgrade&amp;theme_style=twentytwentythree" class="el-button el-button--primary el-button--small">
 					    {{ $t('Upgrade to Pro') }}
 				    </a>
 			    </notice>

--- a/resources/assets/admin/views/Helpers/_ManualEntryActions.vue
+++ b/resources/assets/admin/views/Helpers/_ManualEntryActions.vue
@@ -87,7 +87,7 @@
                     <h6 class="title">{{$t('This is a Pro Feature')}}</h6> 
                     <p class="text">{{$t('Please upgrade to pro to unlock this feature.')}}</p>
                 </div>
-                <a target="_blank" :href="upgrade_url" class="el-button el-button--danger el-button--small">
+                <a target="_blank" :href="upgrade_url" class="el-button el-button--primary el-button--small">
                     {{$t('Upgrade to Pro')}}
                 </a>
             </notice>

--- a/resources/assets/admin/views/Helpers/_ResentEmailNotification.vue
+++ b/resources/assets/admin/views/Helpers/_ResentEmailNotification.vue
@@ -60,7 +60,7 @@
                     <h6 class="title">{{$t('This is a Pro Feature')}}</h6> 
                     <p class="text">{{$t('Please upgrade to pro to unlock this feature.')}}</p>
                 </div>
-                <a target="_blank" :href="upgrade_url" class="el-button el-button--danger el-button--small">
+                <a target="_blank" :href="upgrade_url" class="el-button el-button--primary el-button--small">
                     {{$t('Upgrade to Pro')}}
                 </a>
             </notice>


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

Upgrade to Pro CTA buttons across the admin UI were using red/danger
styling, which implies a destructive action. Changed to primary (blue)
to properly signal a positive call-to-action.