### PR TITLE
Wrap "Click to Copy" tooltip in translation function

### DIFF
--- a/app/Modules/Registerer/Menu.php
+++ b/app/Modules/Registerer/Menu.php
@@ -1184,7 +1184,7 @@ class Menu
         if (Helper::isConversionForm($formId)) {
             $shortcode = '[fluentform type="conversational" id="' . $formId . '"]';
         }
-        echo '<button title="Click to Copy" class="ff_shortcode_btn ff_shortcode_btn_md copy truncate" data-clipboard-text=\'' . $shortcode . '\'><i class="el-icon el-icon-document-copy"></i> ' . $shortcode . '</button>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $shortcode is escaped before being passed in.
+        echo '<button title="' . esc_attr__('Click to Copy', 'fluentform') . '" class="ff_shortcode_btn ff_shortcode_btn_md copy truncate" data-clipboard-text=\'' . $shortcode . '\'><i class="el-icon el-icon-document-copy"></i> ' . $shortcode . '</button>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $shortcode is escaped before being passed in.
         return;
     }
 


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

The shortcode copy button title attribute was hardcoded in English.
Wrapped it with esc_attr__() for proper i18n support.