### PR TITLE
Fix payment amount field accepting comma as decimal separator

### DIFF
--- a/resources/assets/admin/components/editor-field-settings/templates/pricing-options.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/pricing-options.vue
@@ -26,7 +26,7 @@
                     :label="$t('Payment Amount')"
                     :helpText="$t('Please Provide the payment amount. Max 2 decimal point is excepted')"
                 />
-                <el-input type="text" v-model="editItem.attributes.value" />
+                <el-input type="number" min="0" step="any" v-model="editItem.attributes.value" />
             </el-form-item>
 
             <el-form-item>


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

Changed the single payment amount input from type="text" to
type="number" with step="any" to prevent invalid numeric formats
like "10,33" which the frontend parses as zero.