### PR TITLE
Fix textarea extra blank lines in {all_data} email notifications

### DIFF
--- a/app/Hooks/filters.php
+++ b/app/Hooks/filters.php
@@ -257,13 +257,15 @@ foreach ($fluentformRules as $fluentformRuleName) {
 
 
 $app->addFilter('fluentform/response_render_textarea', function ($value, $field, $formId, $isHtml) {
-    $value = $value ? nl2br($value) : $value;
-
-    if (!$isHtml || !$value) {
+    if (!$value) {
         return $value;
     }
 
-    return '<span style="white-space: pre-line">' . $value . '</span>';
+    if ($isHtml) {
+        return '<span style="white-space: pre-line">' . $value . '</span>';
+    }
+
+    return nl2br($value);
 }, 10, 4);
 
 $app->addFilter('fluentform/response_render_input_file', function ($response, $field, $form_id, $isHtml = false) {

--- a/app/Views/email/template/styles.php
+++ b/app/Views/email/template/styles.php
@@ -151,7 +151,6 @@ background-color: #f8f8f8;
 
 #body_content_inner tr.field-value td {
 padding: 6px 12px 12px 12px;
-white-space: pre-line;
 }
 
 .link {


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

Root cause: three layers were all preserving newlines simultaneously:
1. nl2br() in the textarea response filter (converts \n to <br>)
2. <span style="white-space: pre-line"> wrapper in the same filter
3. white-space: pre-line in the email template CSS on .field-value td

Each \n was rendered as a line break by all three mechanisms, causing
double/triple spacing in emails.

Fix: separate HTML and non-HTML rendering paths in the textarea filter.
HTML contexts (entries, emails) use only the <span> wrapper with
pre-line CSS. Non-HTML contexts use only nl2br(). Removed the global
pre-line from email template CSS since the per-field <span> handles it.