### PR TITLE
Fix: PHP error in textarea entries page

### DIFF
--- a/app/Hooks/filters.php
+++ b/app/Hooks/filters.php
@@ -257,13 +257,15 @@ foreach ($fluentformRules as $fluentformRuleName) {
 
 
 $app->addFilter('fluentform/response_render_textarea', function ($value, $field, $formId, $isHtml) {
-    $value = $value ? nl2br($value) : $value;
-
-    if (!$isHtml || !$value) {
+    if (!$value || !is_string($value)) {
         return $value;
     }
 
-    return '<span style="white-space: pre-line">' . $value . '</span>';
+    if ($isHtml) {
+        return '<span style="white-space: pre-line">' . $value . '</span>';
+    }
+
+    return nl2br($value);
 }, 10, 4);
 
 $app->addFilter('fluentform/response_render_input_file', function ($response, $field, $form_id, $isHtml = false) {


### PR DESCRIPTION
Requested By: [Lukman Nakib](https://github.com/nkb-bd)

nl2br() was called without checking if $value is a string first,
causing a fatal TypeError when a textarea field stores array data
(e.g. inside repeater fields or corrupted submission data).

Bug existed since cc45341a (April 2023).