### PR TITLE
Fix fatal error when textarea field receives array value

### DIFF
--- a/app/Hooks/filters.php
+++ b/app/Hooks/filters.php
@@ -258,7 +258,13 @@ foreach ($fluentformRules as $fluentformRuleName) {
 
 
 $app->addFilter('fluentform/response_render_textarea', function ($value, $field, $formId, $isHtml) {
-    if (!$value || !is_string($value)) {
+    if (is_array($value) || is_object($value)) {
+        $value = fluentImplodeRecursive(', ', array_filter(array_values((array) $value)));
+    }
+
+    $value = $value ? nl2br($value) : $value;
+
+    if (!$isHtml || !$value) {
         return $value;
     }
 


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

## What does this PR do and why?
Fixes a PHP fatal error (TypeError) on PHP 8+ when viewing form submissions
where a textarea field's stored value is an array instead of a string. This
happens when a field type is changed after submissions exist (e.g., checkbox
→ textarea), leaving array data in older submissions.

## Scope
- [x] Free plugin
- [ ] Pro plugin

## Changes
- [x] PHP — `app/Hooks/filters.php`: added defensive type check before `nl2br()` call in `fluentform/response_render_textarea` filter

## How to Test
1. Create a form with a checkbox field, submit an entry
2. Change the field type to textarea
3. View the submission in admin — should no longer crash

## Reviewer Notes
Uses the same `fluentImplodeRecursive()` pattern already used by `FormDataParser::formatValue()`, `formatFileValues()`, and `formatImageValues()`.