### PR TITLE
Fix _load_textdomain_just_in_time notice on WordPress 6.7+ with WP Staging

### DIFF
--- a/boot/app.php
+++ b/boot/app.php
@@ -97,10 +97,12 @@ return function ($file) {
     (new FluentConversational)->boot();
     (new FormsMigrator())->boot();
     
-    /* Plugin Meta Links */
-    
-    add_filter('plugin_row_meta', 'fluentform_plugin_row_meta', 10, 2);
-    
+    /* Plugin Meta Links — registered on init to avoid early textdomain loading (WP 6.7+) */
+
+    add_action('init', function () {
+        add_filter('plugin_row_meta', 'fluentform_plugin_row_meta', 10, 2);
+    });
+
     function fluentform_plugin_row_meta($links, $file)
     {
         if ('fluentform/fluentform.php' == $file) {


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

## What does this PR do and why?
Fixes the `_load_textdomain_just_in_time` PHP notice that appears on WordPress 6.7+
when Fluent Forms is active alongside WP Staging (or any plugin that triggers
`wp_get_schedules()` or `plugin_row_meta` before the `init` hook).

WordPress 6.7 introduced just-in-time translation loading and warns when `__()`
is called before `init`. Two places in Fluent Forms had translation calls in
callbacks for hooks that can fire before `init`:

1. `cron_schedules` filter — `esc_html__()` in the display string. This filter
   fires whenever `wp_get_schedules()` is called, which WP Staging does early.
2. `plugin_row_meta` filter — registered at file load time with 8 translation
   calls in its callback. Some plugins trigger this filter before `init`.

## Related Issue
Conflict with WP Staging plugin (v4.5.0+) on WordPress 6.7+ / PHP 8.3.

## Scope
- [x] Free plugin
- [ ] Pro plugin (audited — no issues found)

## Changes
- [x] PHP — `app/Hooks/actions.php`: removed `esc_html__()` from cron schedule
  display string (internal/debug-only label, not user-facing)
- [x] PHP — `app/Hooks/Handlers/ActivationHandler.php`: same fix for the
  duplicate cron schedule registration during plugin activation
- [x] PHP — `boot/app.php`: deferred `plugin_row_meta` filter registration to
  `init` hook (filter only fires on plugins admin page, well after `init`)

## How to Test
1. Install WordPress 6.7+ with PHP 8.3+
2. Activate both Fluent Forms and WP Staging plugins
3. Enable `WP_DEBUG` and `WP_DEBUG_LOG`
4. Navigate to any admin page
5. Check `debug.log` — the `_load_textdomain_just_in_time` notice for
   `fluentform` domain should no longer appear
6. Verify plugins page still shows Docs/Support/Developer Docs links under
   Fluent Forms

## Reviewer Notes
- The `cron_schedules` display string is only visible in debug tools like
  WP Crontrol — WordPress core's own cron schedules also use untranslated strings.
  The `interval` and schedule key that control actual cron behavior are unchanged.
- The `plugin_row_meta` callback function is unchanged — only its registration
  timing moved from file-load to `init`. The filter only fires when rendering
  `wp-admin/plugins.php`, which is well after `init`.
- Pro plugin was fully audited — all its translation calls are already inside
  `init` or later hooks.