### PR TITLE
Fix RTL alignment in email notifications and print views

### DIFF
--- a/app/Services/FormBuilder/ShortCodeParser.php
+++ b/app/Services/FormBuilder/ShortCodeParser.php
@@ -450,14 +450,17 @@ class ShortCodeParser
                 }
             }
 
-            $html = '<table class="ff_all_data" width="600" cellpadding="0" cellspacing="0"><tbody>';
+            $isRtl = is_rtl();
+            $textAlign = $isRtl ? 'right' : 'left';
+            $direction = $isRtl ? ' dir="rtl"' : '';
+            $html = '<table class="ff_all_data" width="600" cellpadding="0" cellspacing="0"' . $direction . '><tbody>';
             foreach ($inputLabels as $inputKey => $label) {
                 if (array_key_exists($inputKey, $response->user_inputs) && '' !== ArrayHelper::get($response->user_inputs, $inputKey)) {
                     $data = ArrayHelper::get($response->user_inputs, $inputKey);
                     if (is_array($data) || is_object($data)) {
                         continue;
                     }
-                    $html .= '<tr class="field-label"><th style="padding: 6px 12px; background-color: #f8f8f8; text-align: left;"><strong>' . $label . '</strong></th></tr><tr class="field-value"><td style="padding: 6px 12px 12px 12px;">' . $data . '</td></tr>';
+                    $html .= '<tr class="field-label"><th style="padding: 6px 12px; background-color: #f8f8f8; text-align: ' . $textAlign . ';"><strong>' . $label . '</strong></th></tr><tr class="field-value"><td style="padding: 6px 12px 12px 12px;">' . $data . '</td></tr>';
                 }
             }
 

--- a/app/Services/Submission/SubmissionPrint.php
+++ b/app/Services/Submission/SubmissionPrint.php
@@ -51,14 +51,17 @@ class SubmissionPrint
     {
         $notes = (new SubmissionService())->getNotes($submission->id, ['form_id' => $form->id]);
         if ($notes && count($notes) > 0) {
-            $notesHtml = '<br\><h3>Submission Notes</h3><table class="ff_all_data" width="600" cellpadding="0" cellspacing="0"><tbody>';
+            $isRtl = is_rtl();
+            $textAlign = $isRtl ? 'right' : 'left';
+            $direction = $isRtl ? ' dir="rtl"' : '';
+            $notesHtml = '<br\><h3>Submission Notes</h3><table class="ff_all_data" width="600" cellpadding="0" cellspacing="0"' . $direction . '><tbody>';
             foreach ($notes as $note) {
                 if (isset($note->created_by)) {
                     $label = '' . $note->created_by . ' - ' . $note->created_at;
                 } else {
                     $label = '' . $note->name . ' - ' . $note->created_at;
                 }
-                $notesHtml .= '<tr class="field-label"><th style="padding: 6px 12px; background-color: #f8f8f8; text-align: left;"><strong>' . $label . '</strong></th></tr><tr class="field-value"><td style="padding: 6px 12px 12px 12px;">' . $note->value . '</td></tr>';
+                $notesHtml .= '<tr class="field-label"><th style="padding: 6px 12px; background-color: #f8f8f8; text-align: ' . $textAlign . ';"><strong>' . $label . '</strong></th></tr><tr class="field-value"><td style="padding: 6px 12px 12px 12px;">' . $note->value . '</td></tr>';
             }
             $htmlBody = $htmlBody . $notesHtml . '</tbody></table>';
         }


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

Bug: When WordPress is set to an RTL locale (Arabic, Hebrew, etc.),
the {all_data} shortcode in email notifications renders field labels
with hardcoded left text-alignment, breaking the layout for RTL users.

Fix:
- ShortCodeParser.php: Replace hardcoded `text-align: left` with
  dynamic `is_rtl()` check for the {all_data} email table. Also adds
  `dir="rtl"` attribute on the table element for better email client
  RTL rendering (Outlook, Gmail).
- SubmissionPrint.php: Apply the same RTL-aware text-align and dir
  attribute to the submission notes table used in print/PDF views.

Both changes compute `is_rtl()` once outside the loop and reuse the
cached value for text-align and direction attributes.

Fixes #20053