### PR TITLE
Fix conditional logic not migrating from Gravity Forms

### DIFF
--- a/app/Services/Migrator/Classes/BaseMigrator.php
+++ b/app/Services/Migrator/Classes/BaseMigrator.php
@@ -142,7 +142,7 @@ abstract class BaseMigrator
             'class'                 => '',
             'format'                => '',
             'validation_rules'      => [],
-            'conditional_logics'    => $args['conditional_logics'],
+            'conditional_logics'    => [],
             'enable_image_input'    => false,
             'calc_value_status'     => false,
             'dynamic_default_value' => '',

--- a/app/Services/Migrator/Classes/BaseMigrator.php
+++ b/app/Services/Migrator/Classes/BaseMigrator.php
@@ -142,7 +142,7 @@ abstract class BaseMigrator
             'class'                 => '',
             'format'                => '',
             'validation_rules'      => [],
-            'conditional_logics'    => [],
+            'conditional_logics'    => $args['conditional_logics'],
             'enable_image_input'    => false,
             'calc_value_status'     => false,
             'dynamic_default_value' => '',
@@ -193,7 +193,7 @@ abstract class BaseMigrator
                 'settings'       => [
                     'container_class'    => '',
                     'admin_field_label'  => 'Name',
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'label_placement'    => 'top'
                 ],
                 'fields'         => [
@@ -219,7 +219,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -249,7 +249,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -279,7 +279,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -311,7 +311,7 @@ abstract class BaseMigrator
                     'label_placement'           => $args['label_placement'],
                     'admin_field_label'         => $args['admin_field_label'],
                     'help_message'              => $args['help_message'],
-                    'conditional_logics'        => [],
+                    'conditional_logics'        => $args['conditional_logics'],
                     'validation_rules'          => [
                         'required' => [
                             'value'   => $args['required'],
@@ -364,7 +364,7 @@ abstract class BaseMigrator
                     'label_placement'    => $args['label_placement'],
                     'admin_field_label'  => $args['admin_field_label'],
                     'help_message'       => $args['help_message'],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'validation_rules'   => [
                         'required' => [
                             'value'   => $args['required'],
@@ -406,7 +406,7 @@ abstract class BaseMigrator
                             'message' => __('This field must contain a valid url', 'fluentform'),
                         ],
                     ],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
 
                 ],
                 'editor_options' => [
@@ -433,7 +433,7 @@ abstract class BaseMigrator
                     'label_placement'           => $args['label_placement'],
                     'admin_field_label'         => $args['admin_field_label'],
                     'help_message'              => $args['help_message'],
-                    'conditional_logics'        => [],
+                    'conditional_logics'        => $args['conditional_logics'],
                     'validation_rules'          => [
                         'required' => [
                             'value'   => $args['required'],
@@ -474,7 +474,7 @@ abstract class BaseMigrator
                     'label_placement'    => $args['label_placement'],
                     'admin_field_label'  => $args['admin_field_label'],
                     'help_message'       => $args['help_message'],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'validation_rules'   => [
                         'required' => [
                             'value'   => $args['required'],
@@ -516,7 +516,7 @@ abstract class BaseMigrator
                         ]
                     ],
                     'randomize_options'  => 'no',
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => 'Dropdown',
@@ -555,7 +555,7 @@ abstract class BaseMigrator
                             'message' => __('This field is required', 'fluentform'),
                         ],
                     ],
-                    'conditional_logics'    => [],
+                    'conditional_logics'    => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('Multiple Choice', 'fluentform'),
@@ -589,7 +589,7 @@ abstract class BaseMigrator
                             'message' => __('This field is required', 'fluentform'),
                         ],
                     ],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'layout_class'       => $args['layout_class']
                 ],
                 'editor_options' => [
@@ -627,7 +627,7 @@ abstract class BaseMigrator
                             'message' => __('This field is required', 'fluentform'),
                         ],
                     ],
-                    'conditional_logics'    => [],
+                    'conditional_logics'    => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('Radio Field', 'fluentform'),
@@ -699,7 +699,7 @@ abstract class BaseMigrator
                             'message' => __('This field is required', 'fluentform'),
                         ]
                     ],
-                    'conditional_logics'      => [],
+                    'conditional_logics'      => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('Mask Input', 'fluentform'),
@@ -725,7 +725,7 @@ abstract class BaseMigrator
                     'label_placement'    => $args['label_placement'],
                     'admin_field_label'  => $args['admin_field_label'],
                     'help_message'       => $args['help_message'],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'validation_rules'   => [
                         'required' => [
                             'value'   => $args['required'],
@@ -779,7 +779,7 @@ abstract class BaseMigrator
                             'message' => 'Maximum value is ' . $args['max'],
                         ],
                     ],
-                    'conditional_logics'   => [],
+                    'conditional_logics'   => $args['conditional_logics'],
                     'calculation_settings' => [
                         'status'  => $args['enable_calculation'],
                         'formula' => $args['calculation_formula']
@@ -828,7 +828,7 @@ abstract class BaseMigrator
                             'message' => __('Phone number is not valid', 'fluentform')
                         ]
                     ],
-                    'conditional_logics'  => []
+                    'conditional_logics'  => $args['conditional_logics']
                 ],
                 'editor_options' => [
                     'title'      => 'Phone Field',
@@ -874,7 +874,7 @@ abstract class BaseMigrator
                             'message' => __('Invalid file type', 'fluentform')
                         ]
                     ],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('File Upload', 'fluentform'),
@@ -889,7 +889,7 @@ abstract class BaseMigrator
                 'attributes'     => [],
                 'settings'       => [
                     'html_codes'         => $args['html_codes'],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'container_class'    => ArrayHelper::get($args, 'container_class', '')
                 ],
                 'editor_options' => [
@@ -910,7 +910,7 @@ abstract class BaseMigrator
                     'label'              => $args['label'],
                     'description'        => $args['section_break_desc'],
                     'align'              => 'left',
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('Section Break', 'fluentform'),
@@ -938,7 +938,7 @@ abstract class BaseMigrator
                     'label_placement'    => $args['label_placement'],
                     'admin_field_label'  => $args['admin_field_label'],
                     'container_class'    => '',
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'validation_rules'   => [
                         'required' => [
                             'value'   => $args['required'],
@@ -968,7 +968,7 @@ abstract class BaseMigrator
                     'label_placement'    => $args['label_placement'],
                     'admin_field_label'  => $args['admin_field_label'],
                     'container_class'    => '',
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                     'validation_rules'   => [
                         'required' => [
                             'value'   => $args['required'],
@@ -1006,7 +1006,7 @@ abstract class BaseMigrator
                         ],
                     ],
                     'required_field_message' => '',
-                    'conditional_logics'     => [],
+                    'conditional_logics'     => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('GDPR Agreement', 'fluentform'),
@@ -1069,7 +1069,7 @@ abstract class BaseMigrator
                         'visible_list' => [],
                         'hidden_list'  => [],
                     ],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                 ],
                 'options'        => [
                     'US' => 'United States of America',
@@ -1096,7 +1096,7 @@ abstract class BaseMigrator
                     'container_class'    => '',
                     'label_placement'    => '',
                     'validation_rules'   => array(),
-                    'conditional_logics' => array(),
+                    'conditional_logics' => $args['conditional_logics'],
                     'max_repeat_field'   => ''
                 ),
                 'editor_options' => array(
@@ -1143,7 +1143,7 @@ abstract class BaseMigrator
                             'message' => __('This field is required', 'fluentform'),
                         ],
                     ],
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                 ],
                 'editor_options' => [
                     'title'      => __('Terms & Conditions', 'fluentform'),
@@ -1163,7 +1163,7 @@ abstract class BaseMigrator
                 'settings'       => [
                     'label'              => $args['label'],
                     'admin_field_label'  => 'Address',
-                    'conditional_logics' => [],
+                    'conditional_logics' => $args['conditional_logics'],
                 ],
                 'fields'         => [
                     'address_line_1' => [
@@ -1188,7 +1188,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -1216,7 +1216,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -1245,7 +1245,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -1274,7 +1274,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -1304,7 +1304,7 @@ abstract class BaseMigrator
                                     'message' => __('This field is required', 'fluentform'),
                                 ],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'editor_options' => [
                             'template' => 'inputText'
@@ -1338,7 +1338,7 @@ abstract class BaseMigrator
                                 'visible_list' => [],
                                 'hidden_list'  => [],
                             ],
-                            'conditional_logics' => [],
+                            'conditional_logics' => $args['conditional_logics'],
                         ],
                         'options'        => [
                             'US' => 'US of America',
@@ -1385,7 +1385,7 @@ abstract class BaseMigrator
                             'message' => __('This field is required', 'fluentform'),
                         ]
                     ],
-                    'conditional_logics' => []
+                    'conditional_logics' => $args['conditional_logics']
                 ],
                 'editor_options' => [
                     'title'      => __('Rich Text Input', 'fluentform'),

--- a/app/Services/Migrator/Classes/GravityFormsMigrator.php
+++ b/app/Services/Migrator/Classes/GravityFormsMigrator.php
@@ -733,8 +733,9 @@ class GravityFormsMigrator extends BaseMigrator
             '<='             => '>',
             'contains'       => 'doNotContains',
             'doNotContains'  => 'contains',
-            'startsWith'     => '!=',
-            'endsWith'       => '!=',
+            // FF has no 'doesNotStartWith'/'doesNotEndWith', using doNotContains as closest match
+            'startsWith'     => 'doNotContains',
+            'endsWith'       => 'doNotContains',
         ];
 
         return isset($invertMap[$operator]) ? $invertMap[$operator] : $operator;

--- a/app/Services/Migrator/Classes/GravityFormsMigrator.php
+++ b/app/Services/Migrator/Classes/GravityFormsMigrator.php
@@ -14,6 +14,16 @@ class GravityFormsMigrator extends BaseMigrator
      */
     protected $hasStep = false;
 
+    /**
+     * @var array Current form being migrated
+     */
+    protected $currentForm = [];
+
+    /**
+     * @var bool Flag to prevent recursive conditional logic resolution
+     */
+    private $resolvingFieldName = false;
+
     public function __construct()
     {
         $this->key = 'gravityform';
@@ -33,6 +43,7 @@ class GravityFormsMigrator extends BaseMigrator
      */
     public function getFields($form)
     {
+        $this->currentForm = $form;
         $fluentFields = [];
         $fields = $form['fields'];
 
@@ -80,6 +91,7 @@ class GravityFormsMigrator extends BaseMigrator
             'class'             => $field['cssClass'],
             'value'             => ArrayHelper::get($field, 'defaultValue'),
             'help_message'      => ArrayHelper::get($field, 'description'),
+            'conditional_logics' => $this->resolvingFieldName ? [] : $this->getFieldConditionals($field),
         ];
 
         $type = ArrayHelper::get($this->fieldTypes(), $field['type'], '');
@@ -641,6 +653,93 @@ class GravityFormsMigrator extends BaseMigrator
         ];
     }
 
+    /**
+     * Convert Gravity Forms field-level conditional logic to Fluent Forms format.
+     *
+     * GF stores field conditionals as: { actionType: 'show'|'hide', logicType: 'any'|'all', rules: [...] }
+     * FF expects: { status: bool, type: 'any'|'all', conditions: [...] }
+     *
+     * FF conditional logic means "show field when conditions match". For GF 'hide' actionType,
+     * we invert operators and swap logic type (De Morgan's law) to achieve the same effect.
+     */
+    private function getFieldConditionals(array $field)
+    {
+        $conditionalLogic = ArrayHelper::get($field, 'conditionalLogic');
+
+        if (!$conditionalLogic || !is_array($conditionalLogic)) {
+            return [];
+        }
+
+        $rules = ArrayHelper::get($conditionalLogic, 'rules', []);
+        if (empty($rules)) {
+            return [];
+        }
+
+        $actionType = ArrayHelper::get($conditionalLogic, 'actionType', 'show');
+        $logicType = ArrayHelper::get($conditionalLogic, 'logicType', 'any');
+        $isHide = $actionType === 'hide';
+
+        // For 'hide' actionType, invert logic type (De Morgan's law)
+        if ($isHide) {
+            $logicType = ($logicType === 'any') ? 'all' : 'any';
+        }
+
+        $conditions = [];
+        foreach ($rules as $rule) {
+            $fieldName = $this->getFormFieldName(ArrayHelper::get($rule, 'fieldId', ''), $this->currentForm);
+            if (!$fieldName) {
+                continue;
+            }
+
+            $operator = $this->getResolveOperator(ArrayHelper::get($rule, 'operator', ''));
+            if (!$operator) {
+                continue;
+            }
+
+            // For 'hide' actionType, invert operator
+            if ($isHide) {
+                $operator = $this->getInvertedOperator($operator);
+            }
+
+            $conditions[] = [
+                'field'    => $fieldName,
+                'operator' => $operator,
+                'value'    => ArrayHelper::get($rule, 'value', ''),
+            ];
+        }
+
+        if (empty($conditions)) {
+            return [];
+        }
+
+        return [
+            'type'       => $logicType,
+            'status'     => true,
+            'conditions' => $conditions,
+        ];
+    }
+
+    /**
+     * Invert a conditional operator for converting GF 'hide' actionType to FF 'show' logic.
+     */
+    private function getInvertedOperator($operator)
+    {
+        $invertMap = [
+            '='              => '!=',
+            '!='             => '=',
+            '>'              => '<=',
+            '<'              => '>=',
+            '>='             => '<',
+            '<='             => '>',
+            'contains'       => 'doNotContains',
+            'doNotContains'  => 'contains',
+            'startsWith'     => '!=',
+            'endsWith'       => '!=',
+        ];
+
+        return isset($invertMap[$operator]) ? $invertMap[$operator] : $operator;
+    }
+
     private function getConfirmations($form, $defaultValues)
     {
         $confirmationsFormatted = [];
@@ -685,6 +784,14 @@ class GravityFormsMigrator extends BaseMigrator
      * @return string
      */
     private function getFormFieldName($str, $form)
+    {
+        $this->resolvingFieldName = true;
+        $name = $this->resolveFormFieldName($str, $form);
+        $this->resolvingFieldName = false;
+        return $name;
+    }
+
+    private function resolveFormFieldName($str, $form)
     {
         preg_match('/[0-9]+[.]?[0-9]*/', $str, $fieldId);
         $fieldId = ArrayHelper::get($fieldId, 0, '0');


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

When migrating forms from Gravity Forms, field-level conditional logic
(show/hide rules) was completely discarded — every field received empty
conditional_logics. This caused migrated forms to lose all conditional
visibility behavior.

Changes:
- GravityFormsMigrator: Add getFieldConditionals() to extract and convert
  GF field conditionalLogic to FF format. Handles both 'show' (direct
  mapping) and 'hide' (operator inversion via De Morgan's law) actionTypes.
  Includes recursion guard to prevent infinite loops when resolving field
  names that reference each other's conditionals.
- BaseMigrator: Replace 35 hardcoded 'conditional_logics' => [] in
  defaultFieldConfig() with $args['conditional_logics'], allowing migrators
  to pass through conditional logic. Other migrators (WpForms, Caldera)
  are unaffected as they use the default empty array from $defaults.