### PR TITLE
Fix HubSpot custom field dropdown UI for long labels

### DIFF
--- a/resources/assets/admin/components/settings/GeneralIntegration/_DropdownManyFields.vue
+++ b/resources/assets/admin/components/settings/GeneralIntegration/_DropdownManyFields.vue
@@ -11,7 +11,7 @@
             <tbody>
             <tr v-for="(item, itemIndex) in settings[field.key]" :key="'item_'+itemIndex">
                 <td>
-                    <el-select class="w-100" v-model="item.label">
+                    <el-select class="w-100" v-model="item.label" filterable popper-class="ff_dropdown_wide">
                         <el-option
                             v-for="(optionLabel, optionValue) in field.options"
                             :key="optionValue"

--- a/resources/assets/admin/styles/_globals.scss
+++ b/resources/assets/admin/styles/_globals.scss
@@ -634,6 +634,20 @@ a.lead-text{
   z-index: 99999999999 !important;
 }
 
+.ff_dropdown_wide {
+  min-width: 200px;
+  max-width: 450px;
+
+  .el-select-dropdown__item {
+    white-space: normal;
+    word-break: break-word;
+    height: auto;
+    line-height: 1.4;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+}
+
 ul.ff_entry_list {
   list-style: disc;
   margin-left: 20px;


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

When configuring HubSpot integration feeds, the "Other Fields" dropdown
truncates long custom field labels with ellipsis (Element UI's default
`text-overflow: ellipsis; white-space: nowrap`), making it impossible to
distinguish between similarly-named fields. For example, two fields like
"Contact - Custom Property - Annual Revenue from Primary Source" and
"Contact - Custom Property - Annual Revenue from Secondary Source" both
appear as "Contact - Custom Property - Annual Re..." — users cannot tell
them apart or select the correct one.

Fix:
- Add `filterable` prop to el-select so users can type to search fields
- Add `popper-class` with CSS that wraps long labels instead of truncating
- Constrain dropdown width with min/max to prevent layout overflow