### PR TITLE
Fix payment status filter not working on translated sites

### DIFF
--- a/app/Modules/Payments/Classes/PaymentEntries.php
+++ b/app/Modules/Payments/Classes/PaymentEntries.php
@@ -306,7 +306,10 @@ class PaymentEntries
         $statusTypes = PaymentHelper::getPaymentStatuses();
         $formattedStatuses = [];
         foreach ($statuses as $status) {
-            $formattedStatuses[] = ArrayHelper::get($statusTypes, $status->status, $status->status);
+            $formattedStatuses[] = [
+                'key'   => $status->status,
+                'value' => ArrayHelper::get($statusTypes, $status->status, $status->status),
+            ];
         }
         $formsQuery = Transaction::select('fluentform_transactions.form_id', 'fluentform_forms.title');
         if ($selectedFormId) {

--- a/resources/assets/admin/PaymentEntries/Components/payments.vue
+++ b/resources/assets/admin/PaymentEntries/Components/payments.vue
@@ -64,7 +64,7 @@
                             <el-option
                                 v-for="item in available_statuses"
                                 :key="item.key"
-                                :label="$t(item.value)"
+                                :label="item.value"
                                 :value="item.key">
                             </el-option>
                         </el-select>

--- a/resources/assets/admin/PaymentEntries/Components/payments.vue
+++ b/resources/assets/admin/PaymentEntries/Components/payments.vue
@@ -63,9 +63,9 @@
                         <el-select class="ff-input-s1" @change="fetchPayments()" clearable v-model="selectedPaymentStatuses" :placeholder="$t('Select Status')">
                             <el-option
                                 v-for="item in available_statuses"
-                                :key="item"
-                                :label="item"
-                                :value="item">
+                                :key="item.key"
+                                :label="$t(item.value)"
+                                :value="item.key">
                             </el-option>
                         </el-select>
                     </div>


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

The payment transactions page sent translated status labels (e.g. "Bezahlt")
as filter values instead of database slugs (e.g. "paid"), causing the SQL
query to return no results on translated admin sites.

Changed the status filter dropdown to use key/value objects (matching the
existing pattern used by payment methods and transaction types dropdowns)
so translated labels display correctly while database slugs are sent to
the backend.