### PR TITLE
Fix "Offline" payment method label not translatable in notifications

### DIFF
--- a/app/Modules/Payments/Components/PaymentMethods.php
+++ b/app/Modules/Payments/Components/PaymentMethods.php
@@ -29,7 +29,7 @@ class PaymentMethods extends BaseFieldManager
 
         add_filter('fluentform/response_render_' . $this->key, function ($value) {
             if ($value == 'test') {
-                return 'Offline';
+                return __('Offline', 'fluentform');
             }
             return $value;
         });


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

- Wrap hardcoded "Offline" string in __() in PaymentMethods response
  render filter so it's translatable via Loco Translate / .po files
- Fix dead code in ShortCodeParser where $key was compared to both
  "payment_method" and "test" simultaneously (impossible condition);
  now correctly checks $entry->{$key} for the "test" value