### PR TITLE
Remove auto-correction of custom payment amount on min/max violation

### DIFF
--- a/resources/assets/public/payment_handler.js
+++ b/resources/assets/public/payment_handler.js
@@ -55,14 +55,6 @@ export class Payment_handler {
         });
         this.calculatePayments();
         this.$form.find('.ff_payment_item,.ff_quantity_item').on('change', (event) => {
-            if (event.target.min && +event.target.value < +event.target.min) {
-                event.target.value = event.target.min;
-            }
-
-            if (event.target.max && +event.target.value > +event.target.max) {
-                event.target.value = event.target.max;
-            }
-
             this.calculatePayments();
 
             this.mayBeToggleSubscriptionRelatedThings(event);


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

The payment handler's change event listener was silently clamping
the input value to min/max bounds before the user could see any
validation error. For payment fields this is deceptive — a user
entering $100 on a $250 minimum field would have their input
silently changed to $250 without any warning.

Removed the auto-correction so FluentForm's built-in validation
can show the configured error message (e.g. "The minimum donation
amount is $250") instead of silently changing the amount.

The HTML min/max attributes remain on the input for native browser
validation tooltips on form submit.