### PR TITLE
Fix untranslatable strings in Loco Translate

### DIFF
--- a/app/Modules/Registerer/TranslationString.php
+++ b/app/Modules/Registerer/TranslationString.php
@@ -1982,6 +1982,10 @@ class TranslationString
             'Default Currency' => __('Default Currency', 'fluentform'),
             'Provide your default currency.You can also change your currency to each form in form\'s payment settings' => __('Provide your default currency.You can also change your currency to each form in form\'s payment settings', 'fluentform'),
             'Currency Sign Position' => __('Currency Sign Position', 'fluentform'),
+            'Left ($100)' => __('Left ($100)', 'fluentform'),
+            'Right (100$)' => __('Right (100$)', 'fluentform'),
+            'Left Space ($ 100)' => __('Left Space ($ 100)', 'fluentform'),
+            'Right Space 100 $' => __('Right Space 100 $', 'fluentform'),
             'Currency Separators' => __('Currency Separators', 'fluentform'),
             'Comma as Thousand and Dot as Decimal (EG: 12,000.00)' => __('Comma as Thousand and Dot as Decimal (EG: 12,000.00)', 'fluentform'),
             'Dot as Thousand and Comma as Decimal ( EG: 12.000,00 )' => __('Dot as Thousand and Comma as Decimal ( EG: 12.000,00 )', 'fluentform'),
@@ -2001,9 +2005,9 @@ class TranslationString
             'PayPal IPN Settings(Recommended for Subscription Payment)' => __('PayPal IPN Settings(Recommended for Subscription Payment)', 'fluentform'),
             'In order to function completely for subscription / recurring payments, you must configure your PayPal IPN.' => __('In order to function completely for subscription / recurring payments, you must configure your PayPal IPN.', 'fluentform'),
             /* translators: 1-2: HTML tags for label formatting, 3: the IPN URL */
-            '%1$sIPN URL:%2$s %3$s' => __('%1$sIPN URL:%2$s %3$s', 'fluentform'),
+            '%sIPN URL:%s %s' => __('%1$sIPN URL:%2$s %3$s', 'fluentform'),
             /* translators: 1-2: HTML tags for documentation link, 3-4: HTML tags for PayPal IPN link */
-            '%1$sPlease read the documentation%2$s to learn how to setup %3$sPayPal IPN%4$s' => __('%1$sPlease read the documentation%2$s to learn how to setup %3$sPayPal IPN%4$s', 'fluentform'),
+            '%sPlease read the documentation%s to learn how to setup %sPayPal IPN%s' => __('%1$sPlease read the documentation%2$s to learn how to setup %3$sPayPal IPN%4$s', 'fluentform'),
             'Enable Stripe Payment Method' => __('Enable Stripe Payment Method', 'fluentform'),
             'Stripe Test API Keys' => __('Stripe Test API Keys', 'fluentform'),
             'Test Publishable key' => __('Test Publishable key', 'fluentform'),
@@ -2016,7 +2020,7 @@ class TranslationString
             'account dashboard' => __('account dashboard', 'fluentform'),
             'to configure them.Please add a webhook endpoint for the URL below.' => __('to configure them.Please add a webhook endpoint for the URL below.', 'fluentform'),
             /* translators: 1-2: HTML tags for label formatting, 3: the webhook URL */
-            '%1$sWebhook URL:%2$s %3$s' => __('%1$sWebhook URL:%2$s %3$s', 'fluentform'),
+            '%sWebhook URL:%s %s' => __('%1$sWebhook URL:%2$s %3$s', 'fluentform'),
             'Stripe IPN' => __('Stripe IPN', 'fluentform'),
             'Please enable the following Webhook events for this URL: ' => __('Please enable the following Webhook events for this URL:', 'fluentform'),
             'Sorry! No settings found.Maybe your payment module is disabled!' => __('Sorry! No settings found.Maybe your payment module is disabled!', 'fluentform'),
@@ -2109,7 +2113,7 @@ class TranslationString
             'Currency' => __('Currency', 'fluentform'),
             'Enable Debug Log (Recommended for debug purpose only)' => __('Enable Debug Log (Recommended for debug purpose only)', 'fluentform'),
             /* translators: 1-2: HTML tags for documentation link, 3-4: HTML tags for Stripe IPN link */
-            '%1$sPlease read the documentation%2$s to learn how to setup %3$sStripe IPN%4$s' => __('%1$sPlease read the documentation%2$s to learn how to setup %3$sStripe IPN%4$s', 'fluentform'),
+            '%sPlease read the documentation%s to learn how to setup %sStripe IPN%s' => __('%1$sPlease read the documentation%2$s to learn how to setup %3$sStripe IPN%4$s', 'fluentform'),
         );
 
         return apply_filters('fluentform/payments_i18n', $i18n);

--- a/app/Modules/Registerer/TranslationString.php
+++ b/app/Modules/Registerer/TranslationString.php
@@ -1985,7 +1985,7 @@ class TranslationString
             'Left ($100)' => __('Left ($100)', 'fluentform'),
             'Right (100$)' => __('Right (100$)', 'fluentform'),
             'Left Space ($ 100)' => __('Left Space ($ 100)', 'fluentform'),
-            'Right Space 100 $' => __('Right Space 100 $', 'fluentform'),
+            'Right Space (100 $)' => __('Right Space (100 $)', 'fluentform'),
             'Currency Separators' => __('Currency Separators', 'fluentform'),
             'Comma as Thousand and Dot as Decimal (EG: 12,000.00)' => __('Comma as Thousand and Dot as Decimal (EG: 12,000.00)', 'fluentform'),
             'Dot as Thousand and Comma as Decimal ( EG: 12.000,00 )' => __('Dot as Thousand and Comma as Decimal ( EG: 12.000,00 )', 'fluentform'),
@@ -2005,9 +2005,9 @@ class TranslationString
             'PayPal IPN Settings(Recommended for Subscription Payment)' => __('PayPal IPN Settings(Recommended for Subscription Payment)', 'fluentform'),
             'In order to function completely for subscription / recurring payments, you must configure your PayPal IPN.' => __('In order to function completely for subscription / recurring payments, you must configure your PayPal IPN.', 'fluentform'),
             /* translators: 1-2: HTML tags for label formatting, 3: the IPN URL */
-            '%sIPN URL:%s %s' => __('%1$sIPN URL:%2$s %3$s', 'fluentform'),
+            '%sIPN URL:%s %s' => __('%sIPN URL:%s %s', 'fluentform'),
             /* translators: 1-2: HTML tags for documentation link, 3-4: HTML tags for PayPal IPN link */
-            '%sPlease read the documentation%s to learn how to setup %sPayPal IPN%s' => __('%1$sPlease read the documentation%2$s to learn how to setup %3$sPayPal IPN%4$s', 'fluentform'),
+            '%sPlease read the documentation%s to learn how to setup %sPayPal IPN%s' => __('%sPlease read the documentation%s to learn how to setup %sPayPal IPN%s', 'fluentform'),
             'Enable Stripe Payment Method' => __('Enable Stripe Payment Method', 'fluentform'),
             'Stripe Test API Keys' => __('Stripe Test API Keys', 'fluentform'),
             'Test Publishable key' => __('Test Publishable key', 'fluentform'),
@@ -2020,7 +2020,7 @@ class TranslationString
             'account dashboard' => __('account dashboard', 'fluentform'),
             'to configure them.Please add a webhook endpoint for the URL below.' => __('to configure them.Please add a webhook endpoint for the URL below.', 'fluentform'),
             /* translators: 1-2: HTML tags for label formatting, 3: the webhook URL */
-            '%sWebhook URL:%s %s' => __('%1$sWebhook URL:%2$s %3$s', 'fluentform'),
+            '%sWebhook URL:%s %s' => __('%sWebhook URL:%s %s', 'fluentform'),
             'Stripe IPN' => __('Stripe IPN', 'fluentform'),
             'Please enable the following Webhook events for this URL: ' => __('Please enable the following Webhook events for this URL:', 'fluentform'),
             'Sorry! No settings found.Maybe your payment module is disabled!' => __('Sorry! No settings found.Maybe your payment module is disabled!', 'fluentform'),
@@ -2113,7 +2113,7 @@ class TranslationString
             'Currency' => __('Currency', 'fluentform'),
             'Enable Debug Log (Recommended for debug purpose only)' => __('Enable Debug Log (Recommended for debug purpose only)', 'fluentform'),
             /* translators: 1-2: HTML tags for documentation link, 3-4: HTML tags for Stripe IPN link */
-            '%sPlease read the documentation%s to learn how to setup %sStripe IPN%s' => __('%1$sPlease read the documentation%2$s to learn how to setup %3$sStripe IPN%4$s', 'fluentform'),
+            '%sPlease read the documentation%s to learn how to setup %sStripe IPN%s' => __('%sPlease read the documentation%s to learn how to setup %sStripe IPN%s', 'fluentform'),
         );
 
         return apply_filters('fluentform/payments_i18n', $i18n);

--- a/resources/assets/admin/components/settings/Includes/AddConfirmation.vue
+++ b/resources/assets/admin/components/settings/Includes/AddConfirmation.vue
@@ -24,7 +24,7 @@
                 border 
                 :key="optionName"
             >
-                {{ redirectOption }}
+                {{ $t(redirectOption) }}
             </el-radio>
 
             <error-view field="redirectTo" :errors="errors" />

--- a/resources/assets/admin/settings/Payments/GeneralSettings.vue
+++ b/resources/assets/admin/settings/Payments/GeneralSettings.vue
@@ -115,7 +115,7 @@
                                 <el-radio 
                                     v-for="(sign, sign_key) in currency_sign_positions" 
                                     :key="sign_key"
-                                    :label="sign_key">{{sign}}
+                                    :label="sign_key">{{ $t(sign) }}
                                 </el-radio>
                             </el-radio-group>
                         </el-form-item>

--- a/resources/assets/admin/settings/Payments/GeneralSettings.vue
+++ b/resources/assets/admin/settings/Payments/GeneralSettings.vue
@@ -172,7 +172,7 @@ export default {
                 left: 'Left ($100)',
                 right: 'Right (100$)',
                 left_space: 'Left Space ($ 100)',
-                right_space: 'Right Space 100 $'
+                right_space: 'Right Space (100 $)'
             },
             general_settings: this.settings.general,
             current_page: 'general'


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

Fix translation key format mismatch in TranslationString.php where keys
used %1$s format but Vue $t() sends %s format, causing lookup failures.
Add missing currency sign position strings. Wrap unwrapped display strings
in AddConfirmation.vue and GeneralSettings.vue with $t() for translation.