### PR TITLE
Fix editor back button navigation loop

### DIFF
--- a/app/Views/admin/form/form_wrapper.php
+++ b/app/Views/admin/form/form_wrapper.php
@@ -20,14 +20,13 @@
 	<div class="form_internal_menu">
         <?php
         if ( is_array($menu_items) && count($menu_items) < 5){
-            if (isset($_SERVER['HTTP_REFERER'])): ?>
+            ?>
                 <div class="ff_menu_back">
-                    <?php // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash -- sanitize_url() handles unslashing ?>
-                    <a class="ff_menu_link" href="<?php echo esc_url(sanitize_url($_SERVER['HTTP_REFERER'])) ;?>">
+                    <a class="ff_menu_link" href="<?php echo esc_url(admin_url('admin.php?page=fluent_forms')); ?>" onclick="if (window.history.length > 1) { window.history.back(); return false; }">
                         <span class="el-icon-arrow-left"></span>
                     </a>
                 </div>
-            <?php endif;
+            <?php
         }
         ?>
         <div title="<?php echo esc_html($form->title); ?>" class="ff_form_name" id="js-ff-nav-title">

--- a/app/Views/admin/form/form_wrapper.php
+++ b/app/Views/admin/form/form_wrapper.php
@@ -22,7 +22,7 @@
         if ( is_array($menu_items) && count($menu_items) < 5){
             ?>
                 <div class="ff_menu_back">
-                    <a class="ff_menu_link" href="<?php echo esc_url(admin_url('admin.php?page=fluent_forms')); ?>" onclick="if (window.history.length > 1) { window.history.back(); return false; }">
+                    <a class="ff_menu_link" href="<?php echo esc_url(admin_url('admin.php?page=fluent_forms')); ?>" onclick="try { if (document.referrer && new URL(document.referrer).origin === window.location.origin) { window.history.back(); return false; } } catch(e) {}">
                         <span class="el-icon-arrow-left"></span>
                     </a>
                 </div>


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

Replace HTTP_REFERER-based back button with history.back() to prevent
navigation loop between editor and settings pages. Falls back to forms
list URL when no browser history is available.