### PR TITLE
Fix ordered/unordered list not rendering in form preview

### DIFF
--- a/resources/assets/preview/preview.scss
+++ b/resources/assets/preview/preview.scss
@@ -11,14 +11,20 @@ body{
   background-color: #F2F2F2;
   color: #000;
 }
-ul,
-ol{
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
 .el-button {
   text-decoration: none;
+}
+.ff_form_preview .fluentform {
+  ol {
+    list-style: decimal;
+    padding-left: 1.5em;
+    margin-bottom: 0.5em;
+  }
+  ul {
+    list-style: disc;
+    padding-left: 1.5em;
+    margin-bottom: 0.5em;
+  }
 }
 // form name
 .ff_form_name {


### PR DESCRIPTION
## Summary
- Removed global `ul, ol { list-style: none }` CSS reset from `preview.scss` that was stripping list markers from user-authored HTML content in Custom HTML fields and Terms & Conditions details blocks
- Added scoped `.ff_form_preview .fluentform ol/ul` rules to explicitly restore list styles (`decimal` for `ol`, `disc` for `ul`) with proper padding, matching how the public frontend renders them
- Existing UI components (`.ff_preview_menu`, `.ff_feature_list`) are unaffected as they already have their own scoped `list-style: none` rules

## Problem
When users added ordered or unordered lists inside Custom HTML fields or Terms & Conditions content, the list markers (numbers/bullets) were invisible on the form preview page. The public frontend rendered them correctly because it relies on theme defaults, but the preview page had an aggressive global CSS reset that stripped all list styling.

## Root Cause
`preview.scss` contained a global reset:
```css
ul, ol {
  padding: 0;
  margin: 0;
  list-style: none;
}
```
This was applied to ALL `ul` and `ol` elements on the preview page, including user-authored form content.

## Fix
1. Removed the global `ul, ol` reset (redundant — UI components already have scoped resets)
2. Added scoped rules inside `.ff_form_preview .fluentform` to restore list rendering with proper `list-style` and `padding-left`, overriding the universal `* { padding: 0 }` selector

## Test plan
- [ ] Open a form with a Custom HTML field containing `<ol>` or `<ul>` lists
- [ ] Preview the form — list markers (numbers/bullets) should be visible
- [ ] Verify the preview header navigation menu still has no bullet points
- [ ] Verify the styler sidebar feature list still has no bullet points
- [ ] Verify the public frontend form renders lists identically