### PR TITLE
Fix help message position, label alignment, and asterisk placement in conversational forms

### DIFF
--- a/app/Services/FluentConversational/Classes/Form.php
+++ b/app/Services/FluentConversational/Classes/Form.php
@@ -908,7 +908,7 @@ class Form
         return $paymentConfig;
     }
 
-    protected function getFormLayoutSettings($formId, $keys)
+    protected function getFormLayoutSettings($formId, $keysWithDefaults)
     {
         $formSettings = wpFluent()
             ->table('fluentform_form_meta')
@@ -919,11 +919,13 @@ class Form
         $layout = [];
         if ($formSettings) {
             $decoded = json_decode($formSettings->value, true);
-            $layout = isset($decoded['layout']) ? $decoded['layout'] : [];
+            if (isset($decoded['layout']) && is_array($decoded['layout'])) {
+                $layout = $decoded['layout'];
+            }
         }
 
         $result = [];
-        foreach ($keys as $key => $default) {
+        foreach ($keysWithDefaults as $key => $default) {
             $result[$key] = isset($layout[$key]) ? $layout[$key] : $default;
         }
 

--- a/app/Services/FluentConversational/Classes/Form.php
+++ b/app/Services/FluentConversational/Classes/Form.php
@@ -124,10 +124,18 @@ class Form
             'hide_media_on_mobile'  => 'no',
             'key_hint'              => 'yes',
             'enable_scroll_to_top'  => 'no',
-            'asteriskPlacement'     => $this->getAsteriskPlacement($formId)
         ];
 
-        return wp_parse_args($settings, $defaults);
+        $result = wp_parse_args($settings, $defaults);
+
+        // Always read from form layout settings — stale values in design meta must not override
+        $layoutSettings = $this->getFormLayoutSettings($formId, [
+            'asteriskPlacement'    => 'asterisk-right',
+            'helpMessagePlacement' => 'with_label',
+            'labelPlacement'       => 'top',
+        ]);
+
+        return array_merge($result, $layoutSettings);
     }
 
     public function getMetaSettings($formId)
@@ -900,27 +908,26 @@ class Form
         return $paymentConfig;
     }
 
-    protected function getAsteriskPlacement($formId)
+    protected function getFormLayoutSettings($formId, $keys)
     {
-        $asteriskPlacement = 'asterisk-right';
-
         $formSettings = wpFluent()
             ->table('fluentform_form_meta')
             ->where('form_id', $formId)
             ->where('meta_key', 'formSettings')
             ->first();
 
-        if (!$formSettings) {
-            return '';
+        $layout = [];
+        if ($formSettings) {
+            $decoded = json_decode($formSettings->value, true);
+            $layout = isset($decoded['layout']) ? $decoded['layout'] : [];
         }
 
-        $formSettings = json_decode($formSettings->value, true);
-
-        if (isset($formSettings['layout']['asteriskPlacement'])) {
-            $asteriskPlacement = $formSettings['layout']['asteriskPlacement'];
+        $result = [];
+        foreach ($keys as $key => $default) {
+            $result[$key] = isset($layout[$key]) ? $layout[$key] : $default;
         }
 
-        return $asteriskPlacement;
+        return $result;
     }
 
     private function getLocalizedForm($form)


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

## Summary

- Conversational forms now respect all 4 help message positions (with_label tooltip, after_label, under_input, on_focus) matching normal form behavior
- Left/right label alignment supported via CSS Grid with responsive mobile fallback
- Asterisk placement reads from authoritative form layout settings, preventing stale design meta overrides
- Refactored getAsteriskPlacement into generic getFormLayoutSettings helper (single DB query for all layout keys)

## Changes

**Form.php**
- Read helpMessagePlacement, labelPlacement, and asteriskPlacement from formSettings layout after wp_parse_args
- New getFormLayoutSettings() method fetches all layout keys in one DB query with per-key defaults
- Replaces old getAsteriskPlacement() single-purpose method

## Backward Compatibility

- Default values (top label, with_label help, asterisk-right) match existing behavior exactly
- No CSS classes added unless user explicitly sets left/right label placement
- Help message rendering guarded by question.tagline check - no impact on fields without help text
- Old forms without layout keys in formSettings meta safely fall back to defaults
- Verified with screenshots: default settings render identically to before

## Related PR

- Conversational JS frontend: WPManageNinja/fluent-conversational-js PR #30 (same branch name)

## Testing

- Verified default settings (top/with_label/asterisk-right) render identically to before
- Verified all 4 help positions work with left/right/top label placement
- Verified on_focus mode has no layout shift (uses visibility:hidden)
- Verified tooltip hover works for with_label mode
- Verified forms without help messages are unaffected