### PR TITLE
Fix: All Entries page localStorage issue

### DIFF
--- a/resources/assets/admin/AllEntries/Components/AllEntries.vue
+++ b/resources/assets/admin/AllEntries/Components/AllEntries.vue
@@ -252,7 +252,11 @@ export default {
             chart_status: 'yes',
             entry_status: '',
             search: '',
-            radioOption: localStorage.getItem('ff_entries_date_filter') || 'last-month',
+            radioOption: (() => {
+                const stored = localStorage.getItem('ff_entries_date_filter');
+                const validOptions = ['all', 'today', 'yesterday', 'last-week', 'last-month'];
+                return validOptions.includes(stored) ? stored : 'last-month';
+            })(),
             showImportEntriesModal: false,
             app: window.fluent_forms_global_var
         }
@@ -373,10 +377,9 @@ export default {
 				        number = 30;
 				        break;
 			        case 'all':
+			        default:
 				        this.filter_date_range = 'all';
 				        this.fetchEntries();
-				        return;
-			        default:
 				        return;
 		        }
 		        start.setTime(start.getTime() - 3600 * 1000 * 24 * number);


### PR DESCRIPTION
Requested By: [Lukman Nakib](https://github.com/nkb-bd)

When localStorage stored an unrecognized value for ff_entries_date_filter
(e.g. from a previous plugin version), the radioOption watcher hit the
default case and returned without ever calling fetchEntries(), leaving the
table permanently empty while the chart still loaded independently.

- Validate stored date filter against known options, fallback to last-month
- Make the switch default case fall through to 'all' instead of silently returning