### PR TITLE
Fix character-limit validation showing raw field name instead of message

### DIFF
--- a/app/Services/Parser/Extractor.php
+++ b/app/Services/Parser/Extractor.php
@@ -356,9 +356,13 @@ class Extractor
         $shouldSetMaxValidation = $maxLength && !$fieldHasMaxValidation;
 
         if ($shouldSetMaxValidation) {
+            $message = Helper::getGlobalDefaultMessage('max');
+            if (!$message) {
+                $message = __('Validation fails for maximum value', 'fluentform');
+            }
             $this->result[$this->attribute]['rules']['max'] = [
                 'value'   => $maxLength,
-                "message" => Helper::getGlobalDefaultMessage('max'),
+                'message' => $message,
             ];
         }
 


### PR DESCRIPTION
## Summary

- When a field has a `maxlength` attribute but no explicit `max` validation rule, `handleMaxLengthValidation()` dynamically creates one using `Helper::getGlobalDefaultMessage('max')`
- This method can return an empty string when the user has global validation settings saved but hasn't explicitly configured a message for the `max` rule
- With an empty custom message, the WPFluent Validator falls back to its framework default: `"The :attribute may not be greater than :max characters."` — which replaces `:attribute` with the raw HTML input name (e.g. `resume_communication_1`), exposing it to the user

## Root Cause

In `GlobalDefaultMessages::getGlobalDefaultMessage()`, when `_fluentform_global_form_settings` exists in the database with a `default_messages` key, but `default_messages.max` is empty (user never explicitly saved it), the method returns an empty string instead of the hardcoded default.

This only affects the dynamically-created `max` rule from `handleMaxLengthValidation()`. All other validation rules (required, email, min, etc.) work correctly because they are defined through the form editor with explicit messages or the `global: true` flag.

## Fix

Added a fallback in `Extractor::handleMaxLengthValidation()` so the message is never empty. When `getGlobalDefaultMessage('max')` returns empty, it falls back to `"Validation fails for maximum value"` — the same default defined in `globalDefaultMessageSettingFields()`.

**Single file changed:** `app/Services/Parser/Extractor.php` (4 lines added)

## How to Reproduce

1. Create a form with a Rich Text Input (or any field with `maxlength` attribute)
2. Set a character limit (e.g. 1600) in the field's advanced settings
3. Go to Global Settings > Misc and save (without explicitly setting a max validation message)
4. Submit the form with text exceeding the character limit
5. **Before fix:** Error shows `"The resume_communication_1 may not be greater than 1600 characters."`
6. **After fix:** Error shows `"Validation fails for maximum value"` (or the user's custom global message if configured)

## Test Plan

- [ ] Verify Rich Text Input with maxlength shows user-friendly validation message on server-side validation
- [ ] Verify fields with explicit max validation rules still use their configured messages
- [ ] Verify fields with global: true flag still resolve global messages correctly
- [ ] Verify required, email, and other validation rules are unaffected