### PR TITLE
Fix Google Fonts not loading for multi-word font families in conversational forms

### DIFF
--- a/resources/assets/admin/conversion_templates/Parts/DesignPreview.vue
+++ b/resources/assets/admin/conversion_templates/Parts/DesignPreview.vue
@@ -229,7 +229,7 @@ export default {
 
             if (googleFont) {
                 const variations = googleFont.variants.join(',');
-                let fontSrc = "https://fonts.googleapis.com/css?family=" + encodeURI(fontFamily) + ":" + variations;
+                let fontSrc = "https://fonts.googleapis.com/css?family=" + fontFamily.replace(/ /g, '+') + ":" + variations;
                 let fontSheet = this.iframe.contents().find('#ffc_google_font');
 
                 if (fontSheet.length) {


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

## What does this PR do and why?

Replaces encodeURI() with space-to-plus replacement when building the Google
Fonts URL in the conversational form design settings. encodeURI() converts
spaces to %20, but Google Fonts API expects + for spaces in family names.
The %20 encoding breaks after PHP esc_url sanitization on the landing page,
causing multi-word fonts like "Bai Jamjuree" to fail to load.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] Vue — DesignPreview.vue: replaced encodeURI(fontFamily) with fontFamily.replace(/ /g, '+')

## How to test

1. Create a conversational form
2. Go to Design settings and select a Google Font with a multi-word name (e.g. Bai Jamjuree, Source Sans Pro)
3. Save and visit the conversational form landing page URL
4. Verify the font loads correctly on the landing page

## Anything the reviewer should know?

The preview iframe worked fine because the browser handles %20 in link hrefs
natively. The landing page broke because the URL passes through PHP esc_url()
which can mangle the %20 encoding. Using + is the standard Google Fonts URL
format and survives all sanitization layers.