### PR TITLE
ADD: Add fluent-pdf bridge

### DIFF
--- a/app/Hooks/actions.php
+++ b/app/Hooks/actions.php
@@ -579,6 +579,39 @@ $app->addAction('fluentform/addons_page_render_fluentform_pdf', function () use 
     ]);
 });
 
+// Bootstrap fluent-pdf / fluentforms-pdf integration (follows WPPayForm pattern).
+// Whichever PDF plugin is active defines FLUENT_PDF — this bridge
+// provides the backward-compat constants and loads the integration.
+add_action('plugins_loaded', function () use ($app) {
+    if (!defined('FLUENT_PDF')) {
+        return;
+    }
+
+    if (!defined('FLUENTFORM_PDF_VERSION')) {
+        define('FLUENTFORM_PDF_VERSION', FLUENT_PDF_VERSION);
+    }
+    if (!defined('FLUENTFORM_PDF_PATH')) {
+        define('FLUENTFORM_PDF_PATH', FLUENT_PDF_PATH);
+    }
+    if (!defined('FLUENTFORM_PDF_URL')) {
+        define('FLUENTFORM_PDF_URL', FLUENT_PDF_URL);
+    }
+
+    if (!class_exists('FluentPdf\Modules\FluentForms\FluentFormsIntegration')) {
+        $moduleFile = FLUENTFORM_DIR_PATH . 'app/Modules/FluentPdf/FluentForms/FluentFormsIntegration.php';
+        if (!file_exists($moduleFile)) {
+            return;
+        }
+        require_once FLUENTFORM_DIR_PATH . 'app/Modules/FluentPdf/FluentForms/Migration.php';
+        require_once FLUENTFORM_DIR_PATH . 'app/Modules/FluentPdf/FluentForms/Templates/TemplateManager.php';
+        require_once FLUENTFORM_DIR_PATH . 'app/Modules/FluentPdf/FluentForms/Templates/GeneralTemplate.php';
+        require_once FLUENTFORM_DIR_PATH . 'app/Modules/FluentPdf/FluentForms/Templates/InvoiceTemplate.php';
+        require_once $moduleFile;
+    }
+
+    (new FluentPdf\Modules\FluentForms\FluentFormsIntegration($app))->register();
+}, 20);
+
 $app->addAction('fluentform/installed_by', function ($by) {
     if (is_string($by) && !get_option('_ff_ins_by')) {
         update_option('_ff_ins_by', sanitize_text_field($by), 'no');

--- a/app/Modules/FluentPdf/FluentForms/FluentFormsIntegration.php
+++ b/app/Modules/FluentPdf/FluentForms/FluentFormsIntegration.php
@@ -1,0 +1,978 @@
+<?php
+
+namespace FluentPdf\Modules\FluentForms;
+
+use FluentForm\App\Modules\Acl\Acl;
+use FluentForm\App\Helpers\Protector;
+use FluentForm\Framework\Helpers\ArrayHelper;
+use FluentForm\Framework\Foundation\Application;
+use FluentForm\App\Services\FormBuilder\ShortCodeParser;
+use FluentPdf\Classes\Controller\AvailableOptions;
+
+class FluentFormsIntegration
+{
+    protected $app = null;
+
+    protected $optionKey = '_fluent_pdf_settings';
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    public function register()
+    {
+        // Always show notice if old plugin is active
+        add_action('admin_notices', [$this, 'maybeShowOldPluginNotice']);
+
+        // Run migration if not done yet (covers edge case where old plugin
+        // was deactivated before fluent-pdf was activated)
+        Migration::maybeRun();
+
+        // If old fluentforms-pdf plugin already registered hooks, skip ours
+        if (has_action('wp_ajax_fluentform_pdf_admin_ajax_actions')) {
+            return;
+        }
+
+        $this->registerHooks();
+    }
+
+    protected function registerHooks()
+    {
+        add_action('fluentform_pdf_cleanup_tmp_dir', [$this, 'cleanupTempDir']);
+
+        // Global settings register
+        add_filter('fluentform/global_settings_components', [$this, 'globalSettingMenu']);
+        add_filter('fluentform/form_settings_menu', [$this, 'formSettingsMenu']);
+
+        // Single form pdf settings fields ajax
+        add_action(
+            'wp_ajax_fluentform_get_form_pdf_template_settings',
+            [$this, 'getFormTemplateSettings']
+        );
+
+        add_action('wp_ajax_fluentform_pdf_admin_ajax_actions', [$this, 'ajaxRoutes']);
+
+        add_filter('fluentform/submissions_widgets', [$this, 'pushPdfButtons'], 10, 3);
+        add_filter('fluentform/email_attachments', [$this, 'maybePushToEmail'], 10, 5);
+
+        add_action('fluentform/addons_page_render_fluentform_pdf_settings', [$this, 'renderGlobalPage']);
+
+        add_action('admin_notices', function () {
+            $hasSettings = get_option($this->optionKey) || get_option('_fluentform_pdf_settings');
+            $dirs = AvailableOptions::getDirStructure();
+            $hasFonts = is_dir($dirs['fontDir']) && glob($dirs['fontDir'] . '/*.ttf');
+            if (!$hasSettings && !$hasFonts && Acl::hasAnyFormPermission()) {
+                // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fluentform_sanitize_html() escapes output
+                echo fluentform_sanitize_html(
+                    '<div class="notice notice-warning"><p>'
+                    . esc_html__('Fluent PDF requires fonts to be downloaded. Please ', 'fluent-pdf')
+                    . '<a href="' . admin_url('admin.php?page=fluent_forms_add_ons&sub_page=fluentform_pdf') . '">'
+                    . esc_html__('click here', 'fluent-pdf') . '</a>'
+                    . esc_html__(' to download and configure the settings', 'fluent-pdf')
+                    . '</p></div>'
+                );
+            }
+        });
+
+        add_filter('fluentform/pdf_body_parse', function ($content, $entryId, $formData, $form) {
+            if (!defined('FLUENTFORMPRO')) {
+                return $content;
+            }
+            $processor = new \FluentFormPro\classes\ConditionalContent();
+            return $processor::initiate($content, $entryId, $formData, $form);
+        }, 10, 4);
+
+        add_filter('fluentform/will_return_html', function ($isHtml, $provider) {
+            if ($provider == 'pdfFeed') {
+                return true;
+            }
+            return $isHtml;
+        }, 10, 2);
+
+        add_filter('fluentform/all_editor_shortcodes', [$this, 'pushShortCode'], 10, 2);
+        add_filter(
+            'fluentform/shortcode_parser_callback_pdf.download_link',
+            [$this, 'createLink'],
+            10,
+            2
+        );
+
+        add_filter(
+            'fluentform/shortcode_parser_callback_pdf.download_link.public',
+            [$this, 'createPublicLink'],
+            10,
+            2
+        );
+
+        add_action('wp_ajax_fluentform_pdf_download', [$this, 'download']);
+        add_action('wp_ajax_fluentform_pdf_download_public', [$this, 'downloadPublic']);
+        add_action('wp_ajax_nopriv_fluentform_pdf_download_public', [$this, 'downloadPublic']);
+
+        // Report PDF download — guard since ReportPdfGenerator is not yet ported
+        add_action('wp_ajax_fluentform_report_download_pdf', [$this, 'handleReportPdfDownload']);
+    }
+
+    public function maybeShowOldPluginNotice()
+    {
+        // No-op: fluentforms-pdf IS the PDF plugin now (2.0.0+).
+        // This method is kept to avoid fatal errors if called externally.
+    }
+
+    public function globalSettingMenu($setting)
+    {
+        $setting['pdf_settings'] = [
+            'hash'  => 'pdf_settings',
+            'title' => __('PDF Settings', 'fluent-pdf'),
+        ];
+
+        return $setting;
+    }
+
+    public function formSettingsMenu($settingsMenus)
+    {
+        $settingsMenus['pdf'] = [
+            'title' => __('PDF Feeds', 'fluent-pdf'),
+            'slug'  => 'pdf-feeds',
+            'hash'  => 'pdf',
+            'route' => '/pdf-feeds',
+        ];
+
+        return $settingsMenus;
+    }
+
+    public function getFormTemplateSettings()
+    {
+        // placeholder for form template settings AJAX
+    }
+
+    public function ajaxRoutes()
+    {
+        $maps = [
+            'get_global_settings' => 'getGlobalSettingsAjax',
+            'save_global_settings' => 'saveGlobalSettings',
+            'get_feeds'           => 'getFeedsAjax',
+            'feed_lists'          => 'getFeedListAjax',
+            'create_feed'         => 'createFeedAjax',
+            'get_feed'            => 'getFeedAjax',
+            'save_feed'           => 'saveFeedAjax',
+            'delete_feed'         => 'deleteFeedAjax',
+            'download_pdf'        => 'getPdf',
+            'downloadFonts'       => 'downloadFonts',
+        ];
+
+        Acl::verify('fluentform_forms_manager');
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified in Acl::verify
+        $route = isset($_REQUEST['route']) ? sanitize_text_field(wp_unslash($_REQUEST['route'])) : '';
+
+        if ($route && isset($maps[$route])) {
+            $this->{$maps[$route]}();
+        }
+    }
+
+    public function getGlobalSettingsAjax()
+    {
+        wp_send_json_success([
+            'settings' => $this->globalSettings(),
+            'fields'   => $this->getGlobalFields(),
+        ]);
+    }
+
+    private function globalSettings()
+    {
+        $defaults = [
+            'paper_size'         => 'A4',
+            'orientation'        => 'P',
+            'font'               => 'default',
+            'font_size'          => '14',
+            'font_color'         => '#323232',
+            'accent_color'       => '#989797',
+            'heading_color'      => '#000000',
+            'language_direction' => 'ltr',
+        ];
+
+        $option = get_option($this->optionKey);
+        // Fallback to old option key in case migration hasn't run yet
+        if (!$option || !is_array($option)) {
+            $option = get_option('_fluentform_pdf_settings');
+        }
+        if (!$option || !is_array($option)) {
+            return $defaults;
+        }
+
+        return wp_parse_args($option, $defaults);
+    }
+
+    public function saveGlobalSettings()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verified in previous function
+        $settings = isset($_REQUEST['settings']) ? wp_unslash($_REQUEST['settings']) : [];
+
+        $sanitizerMap = [
+            'accent_color'       => 'sanitize_text_field',
+            'font'               => 'sanitize_text_field',
+            'font_color'         => 'sanitize_text_field',
+            'font_size'          => 'intval',
+            'heading_color'      => 'sanitize_text_field',
+            'language_direction' => 'sanitize_text_field',
+            'orientation'        => 'sanitize_text_field',
+            'font_family'        => 'fluentform_sanitize_html',
+        ];
+        $settings = $this->sanitizeData($settings, $sanitizerMap);
+
+        update_option($this->optionKey, $settings);
+        wp_send_json_success([
+            'message' => __('Settings successfully updated', 'fluent-pdf'),
+        ], 200);
+    }
+
+    public function getFeedsAjax()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $formId = isset($_REQUEST['form_id']) ? intval($_REQUEST['form_id']) : 0;
+
+        if (!$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No form found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $form = wpFluent()->table('fluentform_forms')
+            ->where('id', $formId)
+            ->first();
+
+        $feeds = $this->getFeeds($form->id);
+
+        wp_send_json_success([
+            'pdf_feeds' => $feeds,
+            'templates' => $this->getAvailableTemplates($form),
+        ], 200);
+    }
+
+    public function getFeedListAjax()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $formId = isset($_REQUEST['form_id']) ? intval($_REQUEST['form_id']) : 0;
+        if (!$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No form found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $feeds = $this->getFeeds($formId);
+
+        $formattedFeeds = [];
+        foreach ($feeds as $feed) {
+            $formattedFeeds[] = [
+                'label' => $feed['name'],
+                'id'    => $feed['id'],
+            ];
+        }
+
+        wp_send_json_success([
+            'pdf_feeds' => $formattedFeeds,
+        ], 200);
+    }
+
+    public function createFeedAjax()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $templateName = sanitize_text_field(isset($_REQUEST['template']) ? wp_unslash($_REQUEST['template']) : '');
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $formId = isset($_REQUEST['form_id']) ? intval($_REQUEST['form_id']) : 0;
+
+        if (!$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No form found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $form = wpFluent()->table('fluentform_forms')
+            ->where('id', $formId)
+            ->first();
+
+        $templates = $this->getAvailableTemplates($form);
+
+        if (!isset($templates[$templateName]) || !$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No template found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $template = $templates[$templateName];
+
+        $class = $template['class'];
+        if (!class_exists($class)) {
+            wp_send_json_error([
+                'message' => __('Sorry! No template Class found!', 'fluent-pdf'),
+            ], 423);
+        }
+        $instance = new $class($this->app);
+
+        $defaultSettings = $instance->getDefaultSettings($form);
+
+        $sanitizerMap = [
+            'header' => 'fluentform_sanitize_html',
+            'footer' => 'fluentform_sanitize_html',
+            'body'   => 'fluentform_sanitize_html',
+        ];
+        $defaultSettings = $this->sanitizeData($defaultSettings, $sanitizerMap);
+
+        $data = [
+            'name'         => $template['name'],
+            'template_key' => $templateName,
+            'settings'     => $defaultSettings,
+            'appearance'   => $this->globalSettings(),
+        ];
+
+        $insertId = wpFluent()->table('fluentform_form_meta')
+            ->insertGetId([
+                'meta_key' => '_pdf_feeds', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+                'form_id'  => $formId,
+                'value'    => wp_json_encode($data),
+            ]);
+
+        wp_send_json_success([
+            'feed_id' => $insertId,
+            'message' => esc_html__('Feed has been created, edit the feed now', 'fluent-pdf'),
+        ], 200);
+    }
+
+    private function getFeeds($formId)
+    {
+        $feeds = wpFluent()->table('fluentform_form_meta')
+            ->where('form_id', $formId)
+            ->where('meta_key', '_pdf_feeds')
+            ->get();
+
+        $formattedFeeds = [];
+        foreach ($feeds as $feed) {
+            $settings = json_decode($feed->value, true);
+            $settings['id'] = $feed->id;
+            $formattedFeeds[] = $settings;
+        }
+
+        return $formattedFeeds;
+    }
+
+    public function getFeedAjax()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $formId = isset($_REQUEST['form_id']) ? intval($_REQUEST['form_id']) : 0;
+        if (!$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No form found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $form = wpFluent()->table('fluentform_forms')
+            ->where('id', $formId)
+            ->first();
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $feedId = isset($_REQUEST['feed_id']) ? intval($_REQUEST['feed_id']) : 0;
+        if (!$feedId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No feed found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $feed = wpFluent()->table('fluentform_form_meta')
+            ->where('id', $feedId)
+            ->where('meta_key', '_pdf_feeds')
+            ->first();
+
+        $settings = json_decode($feed->value, true);
+
+        $settings['appearance']['watermark_img_behind'] = ArrayHelper::isTrue($settings, 'appearance.watermark_img_behind');
+
+        $templateName = ArrayHelper::get($settings, 'template_key');
+
+        $templates = $this->getAvailableTemplates($form);
+
+        if (!isset($templates[$templateName]) || !$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No template found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $template = $templates[$templateName];
+
+        $class = $template['class'];
+        if (!class_exists($class)) {
+            wp_send_json_error([
+                'message' => __('Sorry! No template Class found!', 'fluent-pdf'),
+            ], 423);
+        }
+        $instance = new $class($this->app);
+
+        $globalFields = $this->getGlobalFields();
+
+        $globalFields['watermark_image'] = [
+            'key'       => 'watermark_image',
+            'label'     => __('Watermark Image', 'fluent-pdf'),
+            'component' => 'image_widget',
+        ];
+
+        $globalFields['watermark_text'] = [
+            'key'         => 'watermark_text',
+            'label'       => __('Watermark Text', 'fluent-pdf'),
+            'component'   => 'text',
+            'placeholder' => __('Watermark text', 'fluent-pdf'),
+        ];
+
+        $globalFields['watermark_opacity'] = [
+            'key'        => 'watermark_opacity',
+            'label'      => __('Watermark Opacity', 'fluent-pdf'),
+            'component'  => 'number',
+            'inline_tip' => __('Value should be between 1 to 100', 'fluent-pdf'),
+        ];
+        $globalFields['watermark_img_behind'] = [
+            'key'        => 'watermark_img_behind',
+            'label'      => __('Watermark Position', 'fluent-pdf'),
+            'component'  => 'checkbox-single',
+            'inline_tip' => __('Set as background', 'fluent-pdf'),
+        ];
+
+        $globalFields['security_pass'] = [
+            'key'        => 'security_pass',
+            'label'      => 'PDF Password',
+            'component'  => 'text',
+            'inline_tip' => __('If you want to set password please enter password otherwise leave it empty', 'fluent-pdf'),
+        ];
+
+        $settingsFields = $instance->getSettingsFields();
+
+        $settingsFields[] = [
+            'key'       => 'allow_download',
+            'label'     => __('Allow Download', 'fluent-pdf'),
+            'tips'      => __('Allow this feed to be downloaded on form submission. Only logged in users will be able to download.', 'fluent-pdf'),
+            'component' => 'radio_choice',
+            'options'   => [
+                true  => __('Yes', 'fluent-pdf'),
+                false => __('No', 'fluent-pdf'),
+            ],
+        ];
+
+        $settingsFields[] = [
+            'key'       => 'shortcode',
+            'label'     => __('Shortcode', 'fluent-pdf'),
+            'tips'      => __('Use this shortcode on submission message to generate PDF link.', 'fluent-pdf'),
+            'component' => 'text',
+            'readonly'  => true,
+        ];
+
+        $settings['settings']['shortcode'] = '{pdf.download_link.' . $feedId . '}';
+
+        wp_send_json_success([
+            'feed'              => $settings,
+            'settings_fields'   => $settingsFields,
+            'appearance_fields' => $globalFields,
+        ], 200);
+    }
+
+    public function saveFeedAjax()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $formId = isset($_REQUEST['form_id']) ? intval($_REQUEST['form_id']) : 0;
+        if (!$formId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No form found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $form = wpFluent()->table('fluentform_forms')
+            ->where('id', $formId)
+            ->first();
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $feedId = isset($_REQUEST['feed_id']) ? intval($_REQUEST['feed_id']) : 0;
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verified previously
+        $feed = isset($_REQUEST['feed']) ? wp_unslash($_REQUEST['feed']) : [];
+
+        if (empty($feed['name'])) {
+            wp_send_json_error([
+                'message' => __('Feed name is required', 'fluent-pdf'),
+            ], 423);
+        }
+
+        $sanitizerMap = [
+            'name'                 => 'sanitize_text_field',
+            'header'               => 'fluentform_sanitize_html',
+            'footer'               => 'fluentform_sanitize_html',
+            'body'                 => 'fluentform_sanitize_html',
+            'shortcode'            => 'sanitize_text_field',
+            'allow_download'       => 'rest_sanitize_boolean',
+            'logo'                 => 'sanitize_url',
+            'invoice_upper_text'   => 'sanitize_text_field',
+            'invoice_thanks'       => 'sanitize_text_field',
+            'invoice_prefix'       => 'sanitize_text_field',
+            'customer_name'        => 'sanitize_text_field',
+            'customer_email'       => 'sanitize_email',
+            'watermark_img_behind' => 'rest_sanitize_boolean',
+            'customer_address'     => 'sanitize_text_field',
+        ];
+        $feed = $this->sanitizeData($feed, $sanitizerMap);
+
+        wpFluent()->table('fluentform_form_meta')
+            ->where('id', $feedId)
+            ->update([
+                'value' => wp_json_encode($feed),
+            ]);
+
+        wp_send_json_success([
+            'message' => __('Settings successfully updated', 'fluent-pdf'),
+        ], 200);
+    }
+
+    public function deleteFeedAjax()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $feedId = isset($_REQUEST['feed_id']) ? intval($_REQUEST['feed_id']) : 0;
+        if (!$feedId) {
+            wp_send_json_error([
+                'message' => __('Sorry! No feed found!', 'fluent-pdf'),
+            ], 423);
+        }
+
+        wpFluent()->table('fluentform_form_meta')
+            ->where('id', $feedId)
+            ->where('meta_key', '_pdf_feeds')
+            ->delete();
+
+        wp_send_json_success([
+            'message' => __('Feed successfully deleted', 'fluent-pdf'),
+        ], 200);
+    }
+
+    public function getAvailableTemplates($form)
+    {
+        $templates = [
+            'general' => [
+                'name'    => 'General',
+                'class'   => '\FluentPdf\Modules\FluentForms\Templates\GeneralTemplate',
+                'key'     => 'general',
+                'preview' => FLUENT_PDF_URL . 'assets/images/basic_template.png',
+            ],
+        ];
+
+        if ($form->has_payment) {
+            $templates['invoice'] = [
+                'name'    => 'Invoice',
+                'class'   => '\FluentPdf\Modules\FluentForms\Templates\InvoiceTemplate',
+                'key'     => 'invoice',
+                'preview' => FLUENT_PDF_URL . 'assets/images/tabular.png',
+            ];
+        }
+
+        // Support old filter name for backwards compatibility with custom templates
+        $templates = apply_filters_deprecated(
+            'fluentform_pdf_templates',
+            [$templates, $form],
+            FLUENTFORM_FRAMEWORK_UPGRADE,
+            'fluentform/pdf_templates',
+            'Use fluentform/pdf_templates instead of fluentform_pdf_templates.'
+        );
+
+        return apply_filters('fluentform/pdf_templates', $templates, $form);
+    }
+
+    public function getGlobalFields()
+    {
+        return [
+            [
+                'key'       => 'paper_size',
+                'label'     => __('Paper size', 'fluent-pdf'),
+                'component' => 'dropdown',
+                'tips'      => __('All available templates are shown here, select a default template', 'fluent-pdf'),
+                'options'   => AvailableOptions::getPaperSizes(),
+            ],
+            [
+                'key'       => 'orientation',
+                'label'     => __('Orientation', 'fluent-pdf'),
+                'component' => 'dropdown',
+                'options'   => AvailableOptions::getOrientations(),
+            ],
+            [
+                'key'         => 'font_family',
+                'label'       => __('Font Family', 'fluent-pdf'),
+                'component'   => 'dropdown-group',
+                'placeholder' => __('Select Font', 'fluent-pdf'),
+                'options'     => AvailableOptions::getInstalledFonts(),
+            ],
+            [
+                'key'       => 'font_size',
+                'label'     => __('Font size', 'fluent-pdf'),
+                'component' => 'number',
+            ],
+            [
+                'key'       => 'font_color',
+                'label'     => __('Font color', 'fluent-pdf'),
+                'component' => 'color_picker',
+            ],
+            [
+                'key'       => 'heading_color',
+                'label'     => __('Heading color', 'fluent-pdf'),
+                'tips'      => __('Select Heading Color', 'fluent-pdf'),
+                'component' => 'color_picker',
+            ],
+            [
+                'key'       => 'accent_color',
+                'label'     => __('Accent color', 'fluent-pdf'),
+                'tips'      => __('The accent color is used for the borders, breaks etc.', 'fluent-pdf'),
+                'component' => 'color_picker',
+            ],
+            [
+                'key'       => 'language_direction',
+                'label'     => __('Language Direction', 'fluent-pdf'),
+                'tips'      => __('Script like Arabic and Hebrew are written right to left. For Arabic/Hebrew please select RTL', 'fluent-pdf'),
+                'component' => 'radio_choice',
+                'options'   => [
+                    'ltr' => __('LTR', 'fluent-pdf'),
+                    'rtl' => __('RTL', 'fluent-pdf'),
+                ],
+            ],
+        ];
+    }
+
+    public function pushPdfButtons($widgets, $data, $submission)
+    {
+        $formId = $submission->form_id;
+        if (!$formId) {
+            return $widgets;
+        }
+
+        if (
+            isset($submission->type) &&
+            (
+                $submission->type === 'step_data' ||
+                $submission->type === 'saved_state_data'
+            )
+        ) {
+            return $widgets;
+        }
+
+        if (!isset($submission->serial_number)) {
+            return $widgets;
+        }
+
+        $feeds = $this->getFeeds($formId);
+        if (!$feeds) {
+            return $widgets;
+        }
+
+        $widgetData = [
+            'title' => __('PDF Downloads', 'fluent-pdf'),
+            'type'  => 'html_content',
+        ];
+
+        $fluent_forms_admin_nonce = wp_create_nonce('fluent_forms_admin_nonce');
+
+        $contents = '<ul class="ff_list_items">';
+        foreach ($feeds as $feed) {
+            $fileName = ShortCodeParser::parse(
+                $feed['name'],
+                $submission->id,
+                json_decode($submission->response, true)
+            );
+
+            $contents .= '<li><a href="' . admin_url('admin-ajax.php?action=fluentform_pdf_admin_ajax_actions&fluent_forms_admin_nonce=' . $fluent_forms_admin_nonce . '&route=download_pdf&submission_id=' . $submission->id . '&id=' . $feed['id']) . '" target="_blank"><span style="font-size: 12px;" class="dashicons dashicons-arrow-down-alt"></span>' . esc_html($fileName) . '</a></li>';
+        }
+        $contents .= '</ul>';
+        $widgetData['content'] = $contents;
+
+        $widgets['pdf_feeds'] = $widgetData;
+        return $widgets;
+    }
+
+    public function getPdfConfig($settings, $default)
+    {
+        return [
+            'mode'        => 'utf-8',
+            'format'      => ArrayHelper::get($settings, 'paper_size', ArrayHelper::get($default, 'paper_size')),
+            'orientation' => ArrayHelper::get($settings, 'orientation', ArrayHelper::get($default, 'orientation')),
+        ];
+    }
+
+    public function getPdf()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $feedId = isset($_REQUEST['id']) ? intval($_REQUEST['id']) : 0;
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+        $submissionId = isset($_REQUEST['submission_id']) ? intval($_REQUEST['submission_id']) : 0;
+
+        if (!$feedId || !$submissionId) {
+            die(esc_html__('Sorry! No feed found', 'fluent-pdf'));
+        }
+
+        $feed = wpFluent()->table('fluentform_form_meta')
+            ->where('id', $feedId)
+            ->where('meta_key', '_pdf_feeds')
+            ->first();
+
+        $settings = json_decode($feed->value, true);
+        $settings['id'] = $feed->id;
+
+        $form = wpFluent()->table('fluentform_forms')
+            ->where('id', $feed->form_id)
+            ->first();
+
+        $templateName = ArrayHelper::get($settings, 'template_key');
+        $templates = $this->getAvailableTemplates($form);
+
+        if (!isset($templates[$templateName])) {
+            die(esc_html__('Sorry! No template found', 'fluent-pdf'));
+        }
+
+        $template = $templates[$templateName];
+
+        $class = $template['class'];
+        if (!class_exists($class)) {
+            die(esc_html__('Sorry! No template class found', 'fluent-pdf'));
+        }
+
+        $instance = new $class($this->app);
+        $instance->viewPDF($submissionId, $settings);
+    }
+
+    public function maybePushToEmail($emailAttachments, $emailData, $formData, $entry, $form)
+    {
+        if (!ArrayHelper::get($emailData, 'pdf_attachments')) {
+            return $emailAttachments;
+        }
+
+        $pdfFeedIds = ArrayHelper::get($emailData, 'pdf_attachments');
+
+        $feeds = wpFluent()->table('fluentform_form_meta')
+            ->whereIn('id', $pdfFeedIds)
+            ->where('meta_key', '_pdf_feeds')
+            ->where('form_id', $form->id)
+            ->get();
+
+        $templates = $this->getAvailableTemplates($form);
+
+        foreach ($feeds as $feed) {
+            $settings = json_decode($feed->value, true);
+            $settings['id'] = $feed->id;
+            $templateName = ArrayHelper::get($settings, 'template_key');
+
+            if (!isset($templates[$templateName])) {
+                continue;
+            }
+            $template = $templates[$templateName];
+            $class = $template['class'];
+            if (!class_exists($class)) {
+                continue;
+            }
+            $instance = new $class($this->app);
+
+            $fileName = $settings['name'] . '_' . $entry->id . '_' . $feed->id;
+            $fileName = ShortCodeParser::parse($fileName, $entry->id, $formData);
+            $fileName = sanitize_title($fileName, 'pdf-file', 'display');
+
+            if (is_multisite()) {
+                $fileName .= '_' . get_current_blog_id();
+            }
+
+            $file = $instance->outputPDF($entry->id, $settings, $fileName, false);
+            if ($file) {
+                $emailAttachments[] = $file;
+            }
+        }
+
+        return $emailAttachments;
+    }
+
+    public function renderGlobalPage()
+    {
+        // Delegate to fluent-pdf's existing font manager UI
+        (new \FluentPdf\Classes\Controller\GlobalFontManager())->renderGlobalPage();
+    }
+
+    public function downloadFonts()
+    {
+        // Delegate to fluent-pdf's existing font download handler
+        (new \FluentPdf\Classes\Controller\GlobalFontManager())->downloadFonts();
+    }
+
+    public function cleanupTempDir()
+    {
+        $max_file_age = time() - 6 * 3600;
+        $dirs = AvailableOptions::getDirStructure();
+        $cleanUpDirs = [
+            $dirs['tempDir'] . '/ttfontdata/',
+            $dirs['pdfCacheDir'] . '/',
+        ];
+
+        foreach ($cleanUpDirs as $tmp_directory) {
+            if (is_dir($tmp_directory)) {
+                try {
+                    $directory_list = new \RecursiveIteratorIterator(
+                        new \RecursiveDirectoryIterator($tmp_directory, \RecursiveDirectoryIterator::SKIP_DOTS),
+                        \RecursiveIteratorIterator::CHILD_FIRST
+                    );
+
+                    foreach ($directory_list as $file) {
+                        if (in_array($file->getFilename(), ['.htaccess', 'index.html'], true)) {
+                            continue;
+                        }
+
+                        if ($file->isReadable() && $file->getMTime() < $max_file_age) {
+                            if (!$file->isDir()) {
+                                wp_delete_file($file);
+                            }
+                        }
+                    }
+                } catch (\Exception $e) {
+                    //
+                }
+            }
+        }
+    }
+
+    public function pushShortCode($shortCodes, $formID)
+    {
+        $feeds = wpFluent()->table('fluentform_form_meta')
+            ->where('form_id', $formID)
+            ->where('meta_key', '_pdf_feeds')
+            ->get();
+
+        $feedShortCodes = [
+            '{pdf.download_link}' => 'Submission PDF link',
+        ];
+
+        foreach ($feeds as $feed) {
+            $feedSettings = json_decode($feed->value);
+            $key = '{pdf.download_link.' . $feed->id . '}';
+            $feedShortCodes[$key] = $feedSettings->name . ' feed PDF link';
+        }
+
+        $shortCodes[] = [
+            'title'      => __('PDF', 'fluent-pdf'),
+            'shortcodes' => $feedShortCodes,
+        ];
+
+        return $shortCodes;
+    }
+
+    public function createLink($shortCode, $parser)
+    {
+        $form = $parser->getForm();
+        $entry = $parser->getEntry();
+
+        $feed = wpFluent()->table('fluentform_form_meta')
+            ->where('form_id', $form->id)
+            ->where('meta_key', '_pdf_feeds')
+            ->first();
+
+        if ($feed) {
+            $feedSettings = json_decode($feed->value, true);
+
+            if (ArrayHelper::get($feedSettings, 'settings.allow_download')) {
+                $nonce = wp_create_nonce('fluent_forms_admin_nonce');
+
+                $url = admin_url('admin-ajax.php?action=fluentform_pdf_download&fluent_forms_admin_nonce=' . $nonce . '&submission_id=' . $entry->id . '&id=' . $feed->id);
+
+                return $url;
+            }
+        }
+    }
+
+    public function download()
+    {
+        Acl::verifyNonce();
+
+        if (!is_user_logged_in()) {
+            wp_send_json_error([
+                'message' => __('Sorry! You have to login first.', 'fluent-pdf'),
+            ], 422);
+        }
+
+        $hasPermission = Acl::hasPermission('fluentform_entries_viewer');
+
+        if (!$hasPermission) {
+            // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified previously
+            $submissionId = isset($_REQUEST['submission_id']) ? intval($_REQUEST['submission_id']) : 0;
+            $submission = null;
+            if ($submissionId) {
+                $submission = wpFluent()->table('fluentform_submissions')
+                    ->where('id', $submissionId)
+                    ->where('user_id', get_current_user_id())
+                    ->first();
+            }
+
+            if (!$submission) {
+                wp_send_json_error([
+                    'message' => __("You don't have permission to download the PDF.", 'fluent-pdf'),
+                ], 422);
+            }
+        }
+
+        return $this->getPdf();
+    }
+
+    public function createPublicLink($shortCode, $parser)
+    {
+        $feedID = str_replace('pdf.download_link.', '', $shortCode);
+
+        if ($feedID) {
+            $feed = wpFluent()->table('fluentform_form_meta')
+                ->where('id', $feedID)
+                ->first();
+
+            if ($feed) {
+                $entry = $parser->getEntry();
+                $hashedEntryID = base64_encode(Protector::encrypt($entry->id));
+                $hashedFeedID = base64_encode(Protector::encrypt($feedID));
+
+                return admin_url('admin-ajax.php?action=fluentform_pdf_download_public&submission_id=' . $hashedEntryID . '&id=' . $hashedFeedID);
+            }
+        }
+    }
+
+    public function downloadPublic()
+    {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $feedId = isset($_REQUEST['id']) ? intval(Protector::decrypt(base64_decode($_REQUEST['id']))) : 0;
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+        $submissionId = isset($_REQUEST['submission_id']) ? intval(Protector::decrypt(base64_decode($_REQUEST['submission_id']))) : 0;
+
+        $_REQUEST['id'] = $feedId;
+        $_REQUEST['submission_id'] = $submissionId;
+
+        return $this->getPdf();
+    }
+
+    /**
+     * Handle report PDF download. Guards against missing ReportPdfGenerator
+     * since it has not been ported yet.
+     */
+    public function handleReportPdfDownload()
+    {
+        Acl::verify('fluentform_entries_viewer');
+
+        // Try the old plugin's class first (if still installed but deactivated files remain)
+        if (class_exists('\FluentFormPdf\Classes\Report\ReportPdfGenerator')) {
+            try {
+                $pdfGenerator = new \FluentFormPdf\Classes\Report\ReportPdfGenerator();
+                $pdfGenerator->generatePdf($_REQUEST); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+                return;
+            } catch (\Exception $e) {
+                // fall through to error
+            }
+        }
+
+        wp_send_json_error([
+            'message' => __('Report PDF generation is not available yet. Please check for plugin updates.', 'fluent-pdf'),
+        ], 422);
+    }
+
+    private function sanitizeData($settings, $sanitizerMap)
+    {
+        if (fluentformCanUnfilteredHTML()) {
+            return $settings;
+        }
+
+        return fluentform_backend_sanitizer($settings, $sanitizerMap);
+    }
+}

--- a/app/Modules/FluentPdf/FluentForms/Migration.php
+++ b/app/Modules/FluentPdf/FluentForms/Migration.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace FluentPdf\Modules\FluentForms;
+
+class Migration
+{
+    const MIGRATION_KEY = '_fluent_pdf_migration_completed';
+    const OLD_SETTINGS  = '_fluentform_pdf_settings';
+    const NEW_SETTINGS  = '_fluent_pdf_settings';
+
+    /**
+     * Run migration if old plugin settings exist and migration hasn't been done yet.
+     */
+    public static function maybeRun()
+    {
+        if (get_option(self::MIGRATION_KEY)) {
+            return;
+        }
+
+        $oldSettings = get_option(self::OLD_SETTINGS);
+
+        if (!$oldSettings) {
+            // No old settings to migrate
+            return;
+        }
+
+        self::migrateGlobalSettings($oldSettings);
+        self::cleanupOldCron();
+
+        update_option(self::MIGRATION_KEY, [
+            'migrated_at' => current_time('mysql'),
+            'from_plugin' => 'fluentforms-pdf',
+        ]);
+    }
+
+    /**
+     * Copy global settings from old option key to new one.
+     * Only copies if new settings don't already exist.
+     */
+    private static function migrateGlobalSettings($oldSettings)
+    {
+        $existingSettings = get_option(self::NEW_SETTINGS);
+
+        if ($existingSettings) {
+            // New settings already exist — don't overwrite
+            return;
+        }
+
+        update_option(self::NEW_SETTINGS, $oldSettings, 'no');
+    }
+
+    /**
+     * Clear old plugin's cron and ensure new one is registered.
+     */
+    private static function cleanupOldCron()
+    {
+        wp_clear_scheduled_hook('fluentform_pdf_cleanup_tmp_dir');
+
+        if (!wp_next_scheduled('fluent_pdf_cleanup_tmp_dir')) {
+            wp_schedule_event(time(), 'daily', 'fluent_pdf_cleanup_tmp_dir');
+        }
+    }
+}

--- a/app/Modules/FluentPdf/FluentForms/Templates/GeneralTemplate.php
+++ b/app/Modules/FluentPdf/FluentForms/Templates/GeneralTemplate.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace FluentPdf\Modules\FluentForms\Templates;
+
+use FluentForm\App\Services\FormBuilder\ShortCodeParser;
+use FluentForm\Framework\Foundation\Application;
+
+class GeneralTemplate extends TemplateManager
+{
+    public $headerHtml = '';
+
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getDefaultSettings($form)
+    {
+        return [
+            'header' => '<h2>PDF Title</h2>',
+            'footer' => '<table width="100%"><tr><td width="50%">{DATE j-m-Y}</td><td width="50%"  style="text-align: right;" align="right">{PAGENO}/{nbpg}</td></tr></table>',
+            'body'   => '{all_data}',
+        ];
+    }
+
+    public function getSettingsFields()
+    {
+        return [
+            [
+                'key'       => 'header',
+                'label'     => __('Header Content', 'fluent-pdf'),
+                'tips'      => __('Write your header content which will be shown every page of the PDF', 'fluent-pdf'),
+                'component' => 'wp-editor',
+            ],
+            [
+                'key'        => 'body',
+                'label'      => __('PDF Body Content', 'fluent-pdf'),
+                'tips'       => __('Write your Body content for actual PDF body', 'fluent-pdf'),
+                'component'  => 'wp-editor',
+                'inline_tip' => defined('FLUENTFORMPRO') ?
+                    sprintf(
+                        '%1$s %2$s.',
+                        __('You can use Conditional Content in PDF body, for details please check this', 'fluent-pdf'),
+                        '<a target="_blank" href="https://wpmanageninja.com/docs/fluent-form/advanced-features-functionalities-in-wp-fluent-form/conditional-shortcodes-in-email-notifications-form-confirmation/">Documentation</a>'
+                    )
+                    : __('Conditional PDF Body Content is supported in Fluent Forms Pro Version', 'fluent-pdf'),
+            ],
+            [
+                'key'        => 'footer',
+                'label'      => __('Footer Content', 'fluent-pdf'),
+                'tips'       => __('Write your Footer content which will be shown every page of the PDF', 'fluent-pdf'),
+                'component'  => 'wp-editor',
+                'inline_tip' => __('Write your Footer content which will be shown every page of the PDF', 'fluent-pdf'),
+            ],
+        ];
+    }
+
+    public function generatePdf($submissionId, $feed, $outPut = 'I', $fileName = '')
+    {
+        $settings = $feed['settings'];
+        $submission = wpFluent()->table('fluentform_submissions')
+            ->where('id', $submissionId)
+            ->where('status', '!=', 'trashed')
+            ->first();
+        if (!$submission) {
+            return '';
+        }
+
+        $formData = json_decode($submission->response, true);
+
+        $settings = ShortCodeParser::parse($settings, $submissionId, $formData, null, false, 'pdfFeed');
+
+        if (!empty($settings['header'])) {
+            $this->headerHtml = $settings['header'];
+        }
+
+        $htmlBody = $settings['body'];
+
+        $form = wpFluent()->table('fluentform_forms')->find($submission->form_id);
+
+        $htmlBody = apply_filters_deprecated(
+            'ff_pdf_body_parse',
+            [$htmlBody, $submissionId, $formData, $form],
+            FLUENTFORM_FRAMEWORK_UPGRADE,
+            'fluentform/pdf_body_parse',
+            'Use fluentform/pdf_body_parse instead of ff_pdf_body_parse.'
+        );
+
+        $htmlBody = apply_filters('fluentform/pdf_body_parse', $htmlBody, $submissionId, $formData, $form);
+
+        $footer = $settings['footer'];
+
+        if (!$fileName) {
+            $fileName = ShortCodeParser::parse($feed['name'], $submissionId, $formData);
+            $fileName = sanitize_title($fileName, 'pdf-file', 'display');
+        }
+
+        return $this->pdfBuilder($fileName, $feed, $htmlBody, $footer, $outPut);
+    }
+}

--- a/app/Modules/FluentPdf/FluentForms/Templates/InvoiceTemplate.php
+++ b/app/Modules/FluentPdf/FluentForms/Templates/InvoiceTemplate.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace FluentPdf\Modules\FluentForms\Templates;
+
+use FluentForm\App\Services\FormBuilder\ShortCodeParser;
+use FluentForm\Framework\Foundation\Application;
+use FluentForm\Framework\Helpers\ArrayHelper as Arr;
+
+class InvoiceTemplate extends TemplateManager
+{
+    public function __construct(Application $app)
+    {
+        parent::__construct($app);
+    }
+
+    public function getDefaultSettings($form)
+    {
+        return [
+            'logo'               => '',
+            'invoice_upper_text' => '',
+            'invoice_thanks'     => 'Thank you for your order',
+            'invoice_prefix'     => '',
+            'customer_name'      => '',
+            'customer_email'     => '',
+            'customer_address'   => '',
+        ];
+    }
+
+    public function getSettingsFields()
+    {
+        return [
+            [
+                'key'       => 'logo',
+                'label'     => __('Business Logo', 'fluent-pdf'),
+                'tips'      => __('Your Business Logo which will be shown in the invoice header', 'fluent-pdf'),
+                'component' => 'image_widget',
+            ],
+            [
+                'key'       => 'customer_name',
+                'label'     => __('Customer Name', 'fluent-pdf'),
+                'tips'      => __('Please select the customer name field from the smartcode dropdown', 'fluent-pdf'),
+                'component' => 'value_text',
+            ],
+            [
+                'key'       => 'customer_email',
+                'label'     => __('Customer Email', 'fluent-pdf'),
+                'tips'      => __('Please select the customer email field from the smartcode dropdown', 'fluent-pdf'),
+                'component' => 'value_text',
+            ],
+            [
+                'key'       => 'customer_address',
+                'label'     => __('Customer Address', 'fluent-pdf'),
+                'tips'      => __('Please select the customer address field from the smartcode dropdown', 'fluent-pdf'),
+                'component' => 'value_text',
+            ],
+            [
+                'key'       => 'invoice_prefix',
+                'label'     => __('Invoice Prefix', 'fluent-pdf'),
+                'tips'      => __('Add your invoice prefix which will be prepended with the invoice number', 'fluent-pdf'),
+                'component' => 'value_text',
+            ],
+            [
+                'key'       => 'invoice_upper_text',
+                'label'     => __('Invoice Body Text', 'fluent-pdf'),
+                'tips'      => __('Write Invoice body text. This will show before the invoice items', 'fluent-pdf'),
+                'component' => 'wp-editor',
+            ],
+            [
+                'key'       => 'invoice_thanks',
+                'label'     => __('Invoice Footer Text', 'fluent-pdf'),
+                'tips'      => __('Write Invoice Footer Text. This will show at the end of the invoice', 'fluent-pdf'),
+                'component' => 'value_textarea',
+            ],
+        ];
+    }
+
+    public function generatePdf($submissionId, $feed, $outPut, $fileName = '')
+    {
+        $settings = $feed['settings'];
+        $submission = wpFluent()->table('fluentform_submissions')
+            ->where('id', $submissionId)
+            ->where('status', '!=', 'trashed')
+            ->first();
+        if (!$submission) {
+            return '';
+        }
+        $formData = json_decode($submission->response, true);
+
+        $settings['invoice_lines'] = '{payment.order_items}';
+        $invoiceUpperText = Arr::get($settings, 'invoice_upper_text', '');
+        if (
+            false !== strpos($invoiceUpperText, '{payment.receipt}') ||
+            false !== strpos($invoiceUpperText, '{payment.order_items}')
+        ) {
+            $settings['invoice_lines'] = '';
+        }
+        $settings['payment_summary'] = '{payment.summary_list}';
+        $settings = ShortCodeParser::parse($settings, $submissionId, $formData, null, false, 'pdfFeed');
+
+        $htmlBody = $this->generateInvoiceHTML($submission, $settings, $feed);
+
+        $htmlBody = str_replace('{page_break}', '<page_break />', $htmlBody);
+
+        $form = wpFluent()->table('fluentform_forms')->find($submission->form_id);
+
+        $htmlBody = apply_filters_deprecated(
+            'ff_pdf_body_parse',
+            [$htmlBody, $submissionId, $formData, $form],
+            FLUENTFORM_FRAMEWORK_UPGRADE,
+            'fluentform/pdf_body_parse',
+            'Use fluentform/pdf_body_parse instead of ff_pdf_body_parse.'
+        );
+
+        $htmlBody = apply_filters('fluentform/pdf_body_parse', $htmlBody, $submissionId, $formData, $form);
+
+        if (!$fileName) {
+            $fileName = ShortCodeParser::parse($feed['name'], $submissionId, $formData);
+            $fileName = sanitize_title($fileName, 'pdf-file', 'display');
+        }
+
+        return $this->pdfBuilder($fileName, $feed, $htmlBody, '', $outPut);
+    }
+
+    private function generateInvoiceHTML($submission, $settings, $feed)
+    {
+        $paymentSettings = false;
+        $logo = Arr::get($settings, 'logo');
+        if (class_exists('\FluentFormPro\Payments\PaymentHelper')) {
+            $paymentSettings = \FluentFormPro\Payments\PaymentHelper::getPaymentSettings();
+            if (!$logo) {
+                $logo = Arr::get($paymentSettings, 'business_logo');
+            }
+        }
+
+        ob_start();
+        ?>
+        <table style="width: 100%; border: 0px solid transparent;">
+            <tr>
+                <td style="width: 40%" class="business_details">
+                    <?php if ($logo): ?>
+                    <div class="business_logo">
+                        <img src="<?php echo esc_url($logo); ?>" alt="Business logo"/>
+                    </div>
+                    <?php endif; ?>
+                    <?php if ($paymentSettings): ?>
+                    <div class="business_address">
+                        <div class="business_name"><?php echo fluentform_sanitize_html(Arr::get($paymentSettings, 'business_name')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                        <div class="business_address"><?php echo fluentform_sanitize_html(Arr::get($paymentSettings, 'business_address')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                    </div>
+                    <?php endif; ?>
+                </td>
+                <td style="width: 20%"></td>
+                <td style="width: 40%" class="customer_row">
+                    <?php if (Arr::get($settings, 'invoice_prefix')): ?>
+                        <h2 style="padding-bottom: 30px" class="invoice_title"><?php esc_html_e('RECEIPT:', 'fluent-pdf'); ?> <?php echo fluentform_sanitize_html(Arr::get($settings, 'invoice_prefix')) . '-' . esc_html($submission->serial_number); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></h2>
+                        <br/>
+                    <?php endif; ?>
+
+                    <div class="heading_items">
+                        <div class="order_number"><b><?php esc_html_e('Order Number:', 'fluent-pdf'); ?></b> <?php echo fluentform_sanitize_html($submission->id); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                        <div class="payment_date"><b><?php esc_html_e('Payment Date:', 'fluent-pdf'); ?></b> <?php echo fluentform_sanitize_html(date(get_option('date_format'), strtotime($submission->created_at))); // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date, WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+                        <br />
+                        <div class="customer_details">
+                            <?php if (Arr::get($settings, 'customer_name') || Arr::get($settings, 'customer_address') || Arr::get($settings, 'customer_email')): ?>
+                                <p style="font-weight: bold; margin-bottom:10px;" class="customer_heading"><?php esc_html_e('Customer Details', 'fluent-pdf'); ?></p>
+                                <p class="customer_name"><?php echo fluentform_sanitize_html(Arr::get($settings, 'customer_name')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+                                <p class="customer_address"><?php echo fluentform_sanitize_html(Arr::get($settings, 'customer_address')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+                                <p class="customer_email"><?php echo fluentform_sanitize_html(Arr::get($settings, 'customer_email')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+        </table>
+        <hr />
+        <div class="receipt_upper_text"><?php echo fluentform_sanitize_html(Arr::get($settings, 'invoice_upper_text')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+
+        <div class="invoice_lines"><?php echo fluentform_sanitize_html(Arr::get($settings, 'invoice_lines')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></div>
+
+        <?php if (strpos(Arr::get($settings, 'payment_summary'), 'class="ffp_payment_info_table"') !== false): ?>
+            <div class="invoice_summary">
+                <h3><?php esc_html_e('Payment Details', 'fluent-pdf'); ?></h3>
+                <?php echo fluentform_sanitize_html(Arr::get($settings, 'payment_summary')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </div>
+        <?php endif; ?>
+
+        <div class="invoice_thanks">
+            <?php echo fluentform_sanitize_html(Arr::get($settings, 'invoice_thanks')); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        </div>
+        <style>
+            .business_logo {
+                max-width: 200px;
+                margin-bottom: 20px;
+            }
+            .business_logo img {
+                margin-bottom: 20px;
+                max-width: 200px;
+                max-height: 100px;
+            }
+            .business_name {
+                font-weight: bold;
+                margin-bottom: 10px;
+            }
+            td.customer_row {
+                text-align: right;
+            }
+            td.customer_row ul, td.customer_row ul li {
+                list-style: none;
+            }
+            td.customer_row ul li {
+                padding-bottom: 7px;
+            }
+        </style>
+        <?php
+        return ob_get_clean();
+    }
+}

--- a/app/Modules/FluentPdf/FluentForms/Templates/TemplateManager.php
+++ b/app/Modules/FluentPdf/FluentForms/Templates/TemplateManager.php
@@ -1,0 +1,320 @@
+<?php
+
+namespace FluentPdf\Modules\FluentForms\Templates;
+
+use FluentForm\App\Services\Emogrifier\Emogrifier;
+use FluentForm\Framework\Foundation\Application;
+use FluentForm\Framework\Helpers\ArrayHelper;
+use FluentForm\Framework\Helpers\ArrayHelper as Arr;
+use FluentPdf\Classes\Controller\AvailableOptions;
+
+abstract class TemplateManager
+{
+    protected $app;
+
+    public $workingDir = '';
+    public $tempDir = '';
+    public $pdfCacheDir = '';
+    public $fontDir = '';
+
+    public $headerHtml = '';
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+
+        $dirStructure = AvailableOptions::getDirStructure();
+
+        $this->workingDir = $dirStructure['workingDir'];
+        $this->tempDir = $dirStructure['tempDir'];
+        $this->pdfCacheDir = $dirStructure['pdfCacheDir'];
+        $this->fontDir = $dirStructure['fontDir'];
+    }
+
+    abstract public function getSettingsFields();
+
+    abstract public function generatePdf($submissionId, $settings, $outPut, $fileName = '');
+
+    public function viewPDF($submissionId, $settings)
+    {
+        $this->generatePdf($submissionId, $settings, 'I');
+    }
+
+    public function outputPDF($submissionId, $settings, $fileName = '', $forceClear = false)
+    {
+        $fileName = $this->pdfCacheDir . '/' . $fileName;
+        if (!$forceClear && file_exists($fileName . '.pdf')) {
+            return $fileName . '.pdf';
+        }
+
+        $this->generatePdf($submissionId, $settings, 'F', $fileName);
+
+        if (file_exists($fileName . '.pdf')) {
+            return $fileName . '.pdf';
+        }
+
+        return false;
+    }
+
+    public function downloadPDF($submissionId, $settings)
+    {
+        return $this->generatePdf($submissionId, $settings, 'D');
+    }
+
+    public function getGenerator($mpdfConfig)
+    {
+        $defaults = [
+            'fontDir'                => [
+                $this->fontDir,
+                FLUENT_PDF_PATH . 'vendor/mpdf/mpdf/ttfonts',
+            ],
+            'tempDir'                => $this->tempDir,
+            'curlCaCertificate'      => ABSPATH . WPINC . '/certificates/ca-bundle.crt',
+            'curlFollowLocation'     => true,
+            'allow_output_buffering' => true,
+            'autoLangToFont'         => true,
+            'autoScriptToLang'       => true,
+            'useSubstitutions'       => true,
+            'ignore_invalid_utf8'    => true,
+            'setAutoTopMargin'       => 'stretch',
+            'setAutoBottomMargin'    => 'stretch',
+            'enableImports'          => true,
+            'use_kwt'                => true,
+            'keepColumns'            => true,
+            'biDirectional'          => true,
+            'showWatermarkText'      => true,
+            'showWatermarkImage'     => true,
+        ];
+
+        $mpdfConfig = wp_parse_args($mpdfConfig, $defaults);
+
+        $mpdfConfig = apply_filters_deprecated(
+            'fluentform_mpdf_config',
+            [$mpdfConfig],
+            FLUENTFORM_FRAMEWORK_UPGRADE,
+            'fluentform/mpdf_config',
+            'Use fluentform/mpdf_config instead of fluentform_mpdf_config.'
+        );
+
+        $mpdfConfig = apply_filters('fluentform/mpdf_config', $mpdfConfig);
+
+        if (!class_exists('\Mpdf\Mpdf')) {
+            require_once FLUENT_PDF_PATH . 'vendor/autoload.php';
+        }
+
+        try {
+            return new \Mpdf\Mpdf($mpdfConfig);
+        } catch (\Mpdf\MpdfException $e) {
+            $settingsUrl = admin_url('admin.php?page=fluent_forms_add_ons&sub_page=fluentform_pdf');
+            wp_die(
+                '<h2>' . esc_html__('Fluent PDF - Font Error', 'fluent-pdf') . '</h2>'
+                . '<p>' . esc_html($e->getMessage()) . '</p>'
+                . '<p>' . esc_html__('Please download the required fonts from the ', 'fluent-pdf')
+                . '<a href="' . esc_url($settingsUrl) . '">'
+                . esc_html__('Fluent PDF Settings', 'fluent-pdf')
+                . '</a>.</p>',
+                esc_html__('Fluent PDF Error', 'fluent-pdf'),
+                ['response' => 500, 'back_link' => true]
+            );
+        }
+    }
+
+    public function pdfBuilder($fileName, $feed, $body = '', $footer = '', $outPut = 'I')
+    {
+        $body = str_replace('{page_break}', '<page_break />', $body);
+
+        $appearance = Arr::get($feed, 'appearance');
+        $mpdfConfig = [
+            'mode'          => 'utf-8',
+            'format'        => Arr::get($appearance, 'paper_size'),
+            'margin_header' => 10,
+            'margin_footer' => 10,
+            'orientation'   => Arr::get($appearance, 'orientation'),
+        ];
+
+        if ($fontFamily = ArrayHelper::get($appearance, 'font_family')) {
+            $mpdfConfig['default_font'] = $fontFamily;
+        }
+
+        if (!defined('FLUENTFORMPRO')) {
+            $footer .= '<p style="text-align: center;">Powered By <a target="_blank" href="https://wpmanageninja.com/downloads/fluentform-pro-add-on/">Fluent Forms</a></p>';
+        }
+
+        $pdfGenerator = $this->getGenerator($mpdfConfig);
+        if (ArrayHelper::get($appearance, 'security_pass')) {
+            $password = ArrayHelper::get($appearance, 'security_pass');
+            $pdfGenerator->SetProtection([], $password, $password);
+        }
+
+        if (ArrayHelper::get($appearance, 'language_direction') == 'rtl') {
+            $pdfGenerator->SetDirectionality('rtl');
+            $body = '<div class="ff_rtl">' . $body . '</div>';
+            if ($footer) {
+                $footer = '<div class="ff_rtl">' . $footer . '</div>';
+            }
+            if ($this->headerHtml) {
+                $this->headerHtml = '<div class="ff_rtl">' . $this->headerHtml . '</div>';
+            }
+        }
+        if ($this->headerHtml) {
+            $this->headerHtml = $this->applyInlineCssStyles($this->headerHtml, $appearance);
+            $pdfGenerator->SetHTMLHeader($this->headerHtml);
+        }
+
+        $body = $this->applyInlineCssStyles($body, $appearance, true);
+        if (!empty($appearance['watermark_text']) || !empty($appearance['watermark_image'])) {
+            $alpha = Arr::get($appearance, 'watermark_opacity');
+            if (!$alpha || $alpha > 100) {
+                $alpha = 5;
+            }
+            $alpha = $alpha / 100;
+
+            if (!empty($appearance['watermark_image'])) {
+                $feedId = ArrayHelper::get($feed, 'id');
+                $watermarkImageSize = apply_filters('fluentform/pdf_watermark_image_size', 'D', $feedId);
+                $watermarkImagePosition = apply_filters('fluentform/pdf_watermark_image_position', 'F', $feedId);
+                $pdfGenerator->SetWatermarkImage($appearance['watermark_image'], $alpha, $watermarkImageSize, $watermarkImagePosition);
+
+                if (Arr::isTrue($appearance, 'watermark_img_behind')) {
+                    $pdfGenerator->watermarkImgBehind = true;
+                }
+
+                $pdfGenerator->showWatermarkImage = true;
+            } else {
+                $pdfGenerator->SetWatermarkText($appearance['watermark_text'], $alpha);
+                $pdfGenerator->showWatermarkText = true;
+            }
+        }
+        $footer = $this->applyInlineCssStyles($footer, $appearance);
+
+        $pdfGenerator->SetHTMLFooter($footer);
+        $pdfGenerator->WriteHTML('<div class="ff_pdf_wrapper">' . $body . '</div>', \Mpdf\HTMLParserMode::HTML_BODY);
+
+        if ($outPut == 'S') {
+            return $pdfGenerator->Output($fileName . '.pdf', $outPut);
+        }
+
+        $pdfGenerator->Output($fileName . '.pdf', $outPut);
+    }
+
+    public function getPdfCss($appearance)
+    {
+        $mainColor = Arr::get($appearance, 'font_color');
+        if (!$mainColor) {
+            $mainColor = '#4F4F4F';
+        }
+        $secondaryColor = Arr::get($appearance, 'accent_color');
+        if (!$secondaryColor) {
+            $secondaryColor = '#EAEAEA';
+        }
+        $headingColor = Arr::get($appearance, 'heading_color');
+
+        $fontSize = Arr::get($appearance, 'font_size', 14);
+
+        ob_start();
+        ?>
+        .ff_pdf_wrapper, p, li, td, th {
+        color: <?php echo esc_attr($mainColor); ?>;
+        font-size: <?php echo esc_attr($fontSize); ?>px;
+        }
+
+        .ff_all_data, table {
+        empty-cells: show;
+        border-collapse: collapse;
+        border: 1px solid <?php echo esc_attr($secondaryColor); ?>;
+        width: 100%;
+        color: <?php echo esc_attr($mainColor); ?>;
+        }
+        hr {
+        color: <?php echo esc_attr($secondaryColor); ?>;
+        background-color: <?php echo esc_attr($secondaryColor); ?>;
+        }
+        h1, h2, h3, h4, h5, h6 {
+        color: <?php echo esc_attr($headingColor); ?>;
+        }
+        .ff_all_data th {
+        border-bottom: 1px solid <?php echo esc_attr($secondaryColor); ?>;
+        border-top: 1px solid <?php echo esc_attr($secondaryColor); ?>;
+        padding-bottom: 10px !important;
+        }
+        .ff_all_data tr td {
+        padding-left: 30px !important;
+        padding-top: 15px !important;
+        padding-bottom: 15px !important;
+        }
+
+        .ff_all_data tr td, .ff_all_data tr th {
+        border: 1px solid <?php echo esc_attr($secondaryColor); ?>;
+        text-align: left;
+        }
+
+        table, .ff_all_data {width: 100%; overflow:wrap;} img.alignright { float: right; margin: 0 0 1em 1em; }
+        img.alignleft { float: left; margin: 0 10px 10px 0; }
+        .center-image-wrapper {text-align:center;}
+        .center-image-wrapper img.aligncenter {display: initial; margin: 0; text-align: center;}
+        .alignright { float: right; }
+        .alignleft { float: left; }
+        .aligncenter { display: block; margin-left: auto; margin-right: auto; text-align: center; }
+
+        .invoice_title {
+        padding-bottom: 10px;
+        display: block;
+        }
+        .ffp_table thead th {
+        background-color: #e3e8ee;
+        color: #000;
+        text-align: left;
+        vertical-align: bottom;
+        }
+        table th {
+        padding: 5px 10px;
+        }
+        .ff_rtl table th, .ff_rtl table td {
+            text-align: right !important;
+        }
+        <?php
+        $css = ob_get_clean();
+
+        $pdfGeneratorCss = apply_filters_deprecated(
+            'fluentform_pdf_generator_css',
+            [$css, $appearance],
+            FLUENTFORM_FRAMEWORK_UPGRADE,
+            'fluentform/pdf_generator_css',
+            'Use fluentform/pdf_generator_css instead of fluentform_pdf_generator_css.'
+        );
+        return apply_filters('fluentform/pdf_generator_css', $pdfGeneratorCss, $appearance);
+    }
+
+    private function applyInlineCssStyles($html, $appearance, $keepBodyTag = false)
+    {
+        $html = $this->resolveCenteredImage($html);
+        try {
+            $emogrifier = new Emogrifier($html, $this->getPdfCss($appearance));
+            if ($keepBodyTag) {
+                $html = $emogrifier->emogrify();
+            } else {
+                $html = $emogrifier->emogrifyBodyContent();
+            }
+        } catch (\Exception $e) {
+        }
+        return $html;
+    }
+
+    private function resolveCenteredImage($html)
+    {
+        if (strpos($html, '<img') === false) {
+            return $html;
+        }
+        preg_match_all('/(<img[^>]+>)/i', $html, $matches);
+        foreach ($matches[0] as $image) {
+            if (strpos($image, 'aligncenter') !== false) {
+                $newImg = "<div class='center-image-wrapper'> $image </div>";
+                $newHtml = str_replace($image, $newImg, $html);
+                if ($newHtml) {
+                    $html = $newHtml;
+                }
+            }
+        }
+        return $html;
+    }
+}


### PR DESCRIPTION
Requested By: [Lukman Nakib](https://github.com/nkb-bd)

When fluentforms-pdf 2.0.0 is active, this bridge defines backward-compat
FLUENTFORM_PDF_* constants and loads FluentFormsIntegration at
plugins_loaded priority 20.

Module files ship with fluentform (app/Modules/FluentPdf/) as fallback
when the active PDF plugin doesn't include them. Uses require_once
with file_exists guard — silently skips if files are missing.

Also updates PDF promo install URL to point to fluent-pdf.