### PR TITLE
Fix HTML5 validation tooltip not rendering on long forms

### DIFF
--- a/resources/assets/public/form-submission.js
+++ b/resources/assets/public/form-submission.js
@@ -592,6 +592,21 @@ jQuery(document).ready(function () {
                         formResetHandler($(this))
                     });
 
+                    var nativeInvalidHandled = false;
+                    $theForm[0].addEventListener('invalid', function (e) {
+                        if (nativeInvalidHandled) return;
+                        nativeInvalidHandled = true;
+                        var invalidField = e.target;
+                        setTimeout(function () {
+                            nativeInvalidHandled = false;
+                            var rect = invalidField.getBoundingClientRect();
+                            var inViewport = rect.top >= 0 && rect.bottom <= window.innerHeight;
+                            if (!inViewport) {
+                                $theForm.trigger('submit');
+                            }
+                        }, 300);
+                    }, true);
+
                     $(document).on('keydown', formSelector + ' input[type="radio"], ' + formSelector + ' input[type="checkbox"]', function (e) {
                         if (e.key === 'Enter') {
                             e.preventDefault();


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

## What does this PR do and why?

On long forms where the submit button is far below an email field, Chromium
browsers fail to render the native HTML5 validation tooltip after scrolling
to the invalid field. The browser fires the invalid event and scrolls
correctly, but the tooltip bubble does not appear. This leaves users with
no validation feedback when they enter an invalid email address.

This fix adds an invalid event listener that waits 300ms for the browser to
scroll and render the tooltip, then checks if the invalid field is visible
in the viewport. If the field is NOT in the viewport (meaning the browser
failed to scroll properly), FluentForm's own JS validation is triggered as
a fallback, showing inline error messages below each field.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] JS — form-submission.js: added invalid event listener with viewport
  check fallback in registerFormSubmissionHandler()

## How to test

1. Create a long form with 15+ fields and an email field near the top
2. Type an invalid email (e.g. "aaa") in the email field
3. Scroll to the bottom and click Submit
4. On short forms: native browser tooltip should appear (no inline errors)
5. On long forms where browser tooltip fails: FluentForm inline error
   messages should appear below each invalid field as a fallback

## Anything the reviewer should know?

This is a Chromium browser limitation where the native validation tooltip
fails to render when the scroll distance between the submit button and the
invalid field is large. The fix preserves native HTML5 validation (no
novalidate attribute added) and only triggers FluentForm's JS validation
as a fallback when the browser tooltip fails. A 300ms delay allows the
browser time to scroll before checking viewport visibility.