### PR TITLE
Fix WPML addon showing Invalid plugin error on activation from Suggested Plugins

### DIFF
--- a/app/Modules/AddOnModule.php
+++ b/app/Modules/AddOnModule.php
@@ -441,7 +441,7 @@ class AddOnModule
                 'title'       => __('Multilingual Forms for Fluent Forms (WPML)', 'fluentform'),
                 'description' => __('Make Fluent Forms multilingual with WPML integration', 'fluentform'),
                 'logo'        => 'wpml-ff.png',
-                'slug'        => 'multilingual-forms-fluent-forms-wpml/multilingual-forms-fluent-forms-wpml.php',
+                'slug'        => 'multilingual-forms-fluent-forms-wpml/multilingual-forms-for-fluent-forms-with-wpml.php',
                 'basename'    => 'multilingual-forms-fluent-forms-wpml',
                 'badge_type'  => 'official',
                 'wporg_url'   => 'https://wordpress.org/plugins/multilingual-forms-fluent-forms-wpml/',


### PR DESCRIPTION
Requested By: [Dhrupo Nil](https://github.com/dhrupo)

## What does this PR do and why?

When users click Activate on the Multilingual Forms for Fluent Forms (WPML)
addon in the Suggested Plugins page, they get an Invalid plugin error. The
root cause is a wrong plugin slug in AddOnModule.php. The configured slug
was multilingual-forms-fluent-forms-wpml.php but the actual plugin filename
is multilingual-forms-for-fluent-forms-with-wpml.php (missing for and with
in the name). Since the slug does not match the installed plugin path,
get_plugins() cannot find it and activatePlugin() returns Invalid plugin.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — AddOnModule.php: corrected the WPML addon slug from
  multilingual-forms-fluent-forms-wpml.php to
  multilingual-forms-for-fluent-forms-with-wpml.php

## How to test

1. Install the Multilingual Forms for Fluent Forms (WPML) plugin from
   the Suggested Plugins page (Integrations > Suggested Plugins)
2. Click Activate on the WPML addon
3. Before fix: shows Error Invalid plugin
4. After fix: activates successfully (or shows proper dependency error
   if WPML plugins are not installed)

## Anything the reviewer should know?

This was a simple filename mismatch. The WordPress.org plugin slug is
multilingual-forms-fluent-forms-wpml but the main PHP file inside the
plugin directory is multilingual-forms-for-fluent-forms-with-wpml.php.
The slug in AddOnModule needs to match the actual file path exactly for
WordPress get_plugins() to find it.