### PR TITLE
Prevent double action execution when Double Optin is active with payment forms

### DIFF
--- a/app/Modules/Form/FormHandler.php
+++ b/app/Modules/Form/FormHandler.php
@@ -183,40 +183,43 @@ class FormHandler
         $returnData = $this->getReturnData($insertId, $form, $formData);
 
         $error = '';
+        $shouldRunActions = apply_filters('fluentform/should_run_form_actions', true, $insertId, $form);
         try {
 
-            /*
-             * We will keep this old hook for backward compatability.
-             */
-            do_action('fluentform_submission_inserted', $insertId, $formData, $form);
+            if ($shouldRunActions) {
+                /*
+                 * We will keep this old hook for backward compatability.
+                 */
+                do_action('fluentform_submission_inserted', $insertId, $formData, $form);
 
-            do_action(
-                'fluentform/submission_inserted',
-                $insertId,
-                $formData,
-                $form
-            );
-
-            Helper::setSubmissionMeta($insertId, 'is_form_action_fired', 'yes');
-
-            do_action_deprecated(
-                'fluentform_submission_inserted_' . $form->type . '_form',
-                [
+                do_action(
+                    'fluentform/submission_inserted',
                     $insertId,
                     $formData,
                     $form
-                ],
-                FLUENTFORM_FRAMEWORK_UPGRADE,
-                'fluentform/submission_inserted',
-                'Use fluentform/submission_inserted_' . $form->type . '_form' . ' instead of fluentform_submission_inserted_' . $form->type . '_form'
-            );
+                );
 
-            do_action(
-                'fluentform/submission_inserted_' . $form->type . '_form',
-                $insertId,
-                $formData,
-                $form
-            );
+                Helper::setSubmissionMeta($insertId, 'is_form_action_fired', 'yes');
+
+                do_action_deprecated(
+                    'fluentform_submission_inserted_' . $form->type . '_form',
+                    [
+                        $insertId,
+                        $formData,
+                        $form
+                    ],
+                    FLUENTFORM_FRAMEWORK_UPGRADE,
+                    'fluentform/submission_inserted',
+                    'Use fluentform/submission_inserted_' . $form->type . '_form' . ' instead of fluentform_submission_inserted_' . $form->type . '_form'
+                );
+
+                do_action(
+                    'fluentform/submission_inserted_' . $form->type . '_form',
+                    $insertId,
+                    $formData,
+                    $form
+                );
+            }
 
         } catch (\Exception $e) {
             if (defined('WP_DEBUG') && WP_DEBUG) {

--- a/app/Modules/Payments/PaymentMethods/BaseProcessor.php
+++ b/app/Modules/Payments/PaymentMethods/BaseProcessor.php
@@ -287,7 +287,7 @@ abstract class BaseProcessor
         $submission = $this->getSubmission();
         try {
             $submissionService = new SubmissionHandlerService();
-            if ($this->getMetaData('is_form_action_fired') == 'yes') {
+            if ($this->getMetaData('is_form_action_fired') == 'yes' || $this->getMetaData('_double_optin_pending') == 'yes') {
                 $data = $submissionService->getReturnData($submission->id, $this->getForm(),
                     $submission->response);
                 
@@ -307,7 +307,9 @@ abstract class BaseProcessor
                 $returnData = $submissionService->processSubmissionData(
                     $this->submissionId, $submission->response, $this->getForm()
                 );
-                $this->setMetaData('is_form_action_fired', 'yes');
+                if ($this->getMetaData('_double_optin_pending') !== 'yes') {
+                    $this->setMetaData('is_form_action_fired', 'yes');
+                }
             }
             return $returnData;
         

--- a/app/Services/Form/SubmissionHandlerService.php
+++ b/app/Services/Form/SubmissionHandlerService.php
@@ -226,32 +226,35 @@ class SubmissionHandlerService
             }
         }
         $error = '';
+        $shouldRunActions = apply_filters('fluentform/should_run_form_actions', true, $insertId, $form);
         try {
             $formData = apply_filters('fluentform/submission_form_data', $formData, $insertId, $form);
 
-            do_action('fluentform_submission_inserted', $insertId, $formData, $form);
+            if ($shouldRunActions) {
+                do_action('fluentform_submission_inserted', $insertId, $formData, $form);
 
-            do_action('fluentform/submission_inserted', $insertId, $formData, $form);
+                do_action('fluentform/submission_inserted', $insertId, $formData, $form);
 
-            Helper::setSubmissionMeta($insertId, 'is_form_action_fired', 'yes');
+                Helper::setSubmissionMeta($insertId, 'is_form_action_fired', 'yes');
 
-            do_action_deprecated(
-                'fluentform_submission_inserted_' . $form->type . '_form', [
-                $insertId,
-                $formData,
-                $form
-            ],
-                FLUENTFORM_FRAMEWORK_UPGRADE,
-                'fluentform/submission_inserted_' . $form->type . '_form',
-                'Use fluentform/submission_inserted_' . $form->type . '_form instead of fluentform_submission_inserted_' . $form->type . '_form'
-            );
+                do_action_deprecated(
+                    'fluentform_submission_inserted_' . $form->type . '_form', [
+                    $insertId,
+                    $formData,
+                    $form
+                ],
+                    FLUENTFORM_FRAMEWORK_UPGRADE,
+                    'fluentform/submission_inserted_' . $form->type . '_form',
+                    'Use fluentform/submission_inserted_' . $form->type . '_form instead of fluentform_submission_inserted_' . $form->type . '_form'
+                );
 
-            $this->app->doAction(
-                'fluentform/submission_inserted_' . $form->type . '_form',
-                $insertId,
-                $formData,
-                $form
-            );
+                $this->app->doAction(
+                    'fluentform/submission_inserted_' . $form->type . '_form',
+                    $insertId,
+                    $formData,
+                    $form
+                );
+            }
 
         } catch (\Exception $e) {
             if (defined('WP_DEBUG') && WP_DEBUG) {


### PR DESCRIPTION
Requested By: [Habibur Rahman Delwar](https://github.com/HrDelwar)

## What does this PR do and why?

When Double Optin and a payment gateway (Stripe/PayPal hosted checkout) are both active, form actions and integrations (email notifications, CRM pushes, webhooks) could fire twice: once during the payment redirect-back and again when the user confirms the double optin email. This PR adds a filter and guard to defer form actions until optin confirmation.

**Related issue:** fluentform/fluentformpro#119

## Scope

- [x] Free plugin

## Changes

- [x] PHP (FormHandler, SubmissionHandlerService, BaseProcessor)

## How to test

1. Enable Double Optin + Stripe Hosted Checkout on a form with email notification
2. Submit form, complete payment on Stripe
3. Verify: payment confirmation page shows, email notification does NOT fire yet
4. Click double optin confirmation link in email
5. Verify: email notification fires once, not twice
6. Verify normal forms without Double Optin are unaffected

## Anything the reviewer should know?

- Adds "fluentform/should_run_form_actions" filter (defaults to true) checked before firing submission_inserted actions
- BaseProcessor::getReturnData() checks "_double_optin_pending" meta to skip processSubmissionData() on payment redirect-back
- These changes are safe standalone: if pro is not updated, the filter is never added so default true applies with no behavior change