### PR TITLE
Fix subscription description when billing times is 1 with signup fee

### DIFF
--- a/resources/assets/admin/components/templates/inputSubscriptionPayment.vue
+++ b/resources/assets/admin/components/templates/inputSubscriptionPayment.vue
@@ -192,7 +192,9 @@
                         cases[casesKey] = cases[casesKey].replace(regexExpression, replacer)
                     }
 
-                    if (hasSignup) {
+                    if (hasSignup && plan.bill_times === 1) {
+                        message = cases.onetime_only;
+                    } else if (hasSignup) {
                         message = cases.has_signup_fee;
                     } else if (hasTrial) {
                         message = cases.has_trial;


### PR DESCRIPTION
Requested By: [Dhrupo](https://github.com/dhrupo)

Related issue: https://lounge.authlab.io/projects#/boards/16/tasks/20562

## What
Admin editor subscription payment description now shows one-time payment
text when billing times is 1, even when a signup fee is enabled.

## Why
The if/else chain checked hasSignup first, always using the recurring
template. The bill_times === 1 check was in a later else-if branch that
was unreachable when hasSignup was true.

## How
Added hasSignup && bill_times === 1 as the first condition, using the
existing onetime_only template which includes {first_interval_total}
(signup fee + subscription amount combined).