### PR TITLE
fix: handle nested capability array in Acl::findUserCapability()

### DIFF
--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -202,9 +202,11 @@ class Acl
             return false;
         }
 
-        foreach ($capabilities as $capability) {
-            if ($user->has_cap($capability)) {
-                return $capability;
+        foreach ($capabilities as $key => $capability) {
+            // Handle both flat ['cap1', 'cap2'] and nested {role: {cap: true}} formats
+            $capToCheck = is_array($capability) ? $key : $capability;
+            if (is_string($capToCheck) && $user->has_cap($capToCheck)) {
+                return $capToCheck;
             }
         }
 

--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -202,11 +202,20 @@ class Acl
             return false;
         }
 
-        foreach ($capabilities as $key => $capability) {
-            // Handle both flat ['cap1', 'cap2'] and nested {role: {cap: true}} formats
-            $capToCheck = is_array($capability) ? $key : $capability;
-            if (is_string($capToCheck) && $user->has_cap($capToCheck)) {
-                return $capToCheck;
+        foreach ($capabilities as $capability) {
+            // Nested {role: {cap: true, ...}} format — check each inner capability name.
+            if (is_array($capability)) {
+                foreach (array_keys($capability) as $nestedCap) {
+                    if (is_string($nestedCap) && $user->has_cap($nestedCap)) {
+                        return $nestedCap;
+                    }
+                }
+                continue;
+            }
+
+            // Flat ['cap1', 'cap2'] format.
+            if (is_string($capability) && $user->has_cap($capability)) {
+                return $capability;
             }
         }
 


### PR DESCRIPTION
## Summary

- Fixes #770 — fatal `TypeError: Illegal offset type` that blocks all admin access for non-administrator users (e.g. Editor) with Fluent Forms permissions
- `_fluentform_form_permission` can be stored as a nested associative array `{role: {cap: true}}` by `RolesService::setCapability()`, but `findUserCapability()` iterated it as a flat array, passing an array to `WP_User::has_cap()` instead of a string
- The fix detects the storage format and extracts the correct capability string before calling `has_cap()`

## Test plan

- [ ] Assign Fluent Forms permissions to an Editor role (e.g. `fluentform_forms_manager`, `fluentform_entries_viewer`)
- [ ] Log in as an Editor user — should no longer produce a fatal error
- [ ] Verify Editor can access Fluent Forms features matching their assigned capabilities
- [ ] Verify Administrator access is unaffected