### PR TITLE
SECURITY: Security & optimization audit fixes

### DIFF
--- a/app/Http/Controllers/FormIntegrationController.php
+++ b/app/Http/Controllers/FormIntegrationController.php
@@ -25,7 +25,7 @@ class FormIntegrationController extends Controller
         try {
             $integration = $integrationService->find($this->request->all());
             return $this->sendSuccess($integration);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->sendError([
                 'message' => $e->getMessage(),
             ], 422);
@@ -37,7 +37,7 @@ class FormIntegrationController extends Controller
         try {
             $integration = $integrationService->update($this->request->all());
             return $this->sendSuccess($integration);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->sendError([
                 'message' => $e->getMessage()
             ], 422);
@@ -52,7 +52,7 @@ class FormIntegrationController extends Controller
             return $this->sendSuccess([
                 'message' => __('Successfully deleted the Integration.', 'fluentform'),
             ], 200);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->sendError([
                 'message' => $e->getMessage(),
             ], 422);
@@ -91,7 +91,7 @@ class FormIntegrationController extends Controller
             return $this->sendSuccess([
                 'merge_fields' => $merge_fields,
             ]);
-        } catch (Exception $e) {
+        } catch (\Exception $e) {
             return $this->sendError([
                 'message' => $e->getMessage(),
             ], 422);

--- a/app/Http/Controllers/GlobalIntegrationController.php
+++ b/app/Http/Controllers/GlobalIntegrationController.php
@@ -8,13 +8,6 @@ use Exception;
 
 class GlobalIntegrationController extends Controller
 {
-    /**
-     * Request object
-     *
-     * @var \FluentForm\Framework\Request\Request $request
-     */
-    protected $request;
-    
   
     public function index(GlobalIntegrationService $globalIntegrationService)
     {

--- a/app/Http/Controllers/SubmissionNoteController.php
+++ b/app/Http/Controllers/SubmissionNoteController.php
@@ -32,7 +32,14 @@ class SubmissionNoteController extends Controller
     {
         try {
             $attributes = $this->request->all();
-            
+
+            if (isset($attributes['note']['content'])) {
+                $attributes['note']['content'] = wp_kses_post($attributes['note']['content']);
+            }
+            if (isset($attributes['note']['status'])) {
+                $attributes['note']['status'] = sanitize_text_field($attributes['note']['status']);
+            }
+
             return $this->sendSuccess(
                 $submissionService->storeNote($submissionId, $attributes)
             );

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -65,7 +65,8 @@ class Entry extends Model
         $search = Arr::get($attributes, 'search');
         $wheres = Arr::get($attributes, 'wheres');
 
-        $query = $this->orderBy('id', $attributes['sort_by'])
+        $sortBy = \FluentForm\App\Helpers\Helper::sanitizeOrderValue(Arr::get($attributes, 'sort_by', 'DESC'));
+        $query = $this->orderBy('id', $sortBy)
             ->when($formId, function ($q) use ($formId) {
                 return $q->where('form_id', $formId);
             })
@@ -89,11 +90,13 @@ class Entry extends Model
                     ->where('created_at', '<=', $endDate);
             })
             ->when($search, function ($q) use ($search) {
-                return $q->where(function ($q) use ($search) {
-                    return $q->where('id', 'LIKE', "%{$search}%")
-                        ->orWhere('response', 'LIKE', "%{$search}%")
-                        ->orWhere('status', 'LIKE', "%{$search}%")
-                        ->orWhere('created_at', 'LIKE', "%{$search}%");
+                global $wpdb;
+                $escaped = $wpdb->esc_like($search);
+                return $q->where(function ($q) use ($escaped) {
+                    return $q->where('id', 'LIKE', "%{$escaped}%")
+                        ->orWhere('response', 'LIKE', "%{$escaped}%")
+                        ->orWhere('status', 'LIKE', "%{$escaped}%")
+                        ->orWhere('created_at', 'LIKE', "%{$escaped}%");
                 });
             })
             ->when($wheres, function ($q) use ($wheres) {

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -113,7 +113,7 @@ class Submission extends Model
         $startDate = Arr::get($dateRange, 0);
         $endDate = Arr::get($dateRange, 1);
         $search = Arr::get($attributes, 'search');
-        $sortBy = Arr::get($attributes, 'sort_by', 'DESC');
+        $sortBy = \FluentForm\App\Helpers\Helper::sanitizeOrderValue(Arr::get($attributes, 'sort_by', 'DESC'));
 
         $wheres = [];
         $paymentStatuses = Arr::get($attributes, 'payment_statuses');
@@ -321,10 +321,12 @@ class Submission extends Model
             ->paginate()
             ->toArray();
 
+        $useHumanDate = apply_filters('fluentform/entries_human_date', false);
+
         foreach ($result['data'] as &$entry) {
             $entry['entry_url'] = admin_url('admin.php?page=fluent_forms&route=entries&form_id=' . $entry['form_id'] . '#/entries/' . $entry['id']);
 
-            if (apply_filters('fluentform/entries_human_date', false)) {
+            if ($useHumanDate) {
                 $entry['human_date'] = human_time_diff(strtotime($entry['created_at']), strtotime(current_time('mysql')));
             }
         }

--- a/app/Modules/Logger/DataLogger.php
+++ b/app/Modules/Logger/DataLogger.php
@@ -329,7 +329,7 @@ class DataLogger
             ], 423);
         }
 
-        if (!$actionFeed->status == 'success') {
+        if ($actionFeed->status == 'success') {
             wp_send_json_error([
                 'message' => 'API log already in success mode'
             ], 423);
@@ -344,7 +344,7 @@ class DataLogger
         $entry = $this->getEntry($submission, $form);
         $formData = json_decode($submission->response, true);
 
-        wpFluent()->table($this->table)
+        wpFluent()->table('ff_scheduled_actions')
             ->where('id', $actionFeed->id)
             ->update([
                 'status'      => 'manual_retry',

--- a/app/Services/Form/SubmissionHandlerService.php
+++ b/app/Services/Form/SubmissionHandlerService.php
@@ -133,7 +133,7 @@ class SubmissionHandlerService
         if (!$formData) {
             $formData = $this->formData;
         }
-        $previousItem = Submission::where('form_id', $formId)->orderBy('id', 'DESC')->first();
+        $previousItem = Submission::select('serial_number')->where('form_id', $formId)->orderBy('id', 'DESC')->first();
         $serialNumber = 1;
         if ($previousItem) {
             $serialNumber = $previousItem->serial_number + 1;

--- a/app/Services/FormBuilder/ShortCodeParser.php
+++ b/app/Services/FormBuilder/ShortCodeParser.php
@@ -372,7 +372,7 @@ class ShortCodeParser
             if ('total_paid' == $key || 'payment_total' == $key) {
                 return round($entry->{$key} / 100, 2);
             }
-            if ('payment_method' == $key && 'test' == $key) {
+            if ('payment_method' == $key && 'test' == $entry->{$key}) {
                 return __('Offline', 'fluentform');
             }
             return $entry->{$key};

--- a/app/Services/Logger/Logger.php
+++ b/app/Services/Logger/Logger.php
@@ -18,7 +18,7 @@ class Logger
         $statuses = Arr::get($attributes, 'status');
         $formIds = Arr::get($attributes, 'form_id');
         $components = Arr::get($attributes, 'component');
-        $sortBy = Arr::get($attributes, 'sort_by', 'DESC');
+        $sortBy = \FluentForm\App\Helpers\Helper::sanitizeOrderValue(Arr::get($attributes, 'sort_by', 'DESC'));
         $type = Arr::get($attributes, 'type', 'log');
         $dateRange = Arr::get($attributes, 'date_range', []);
         $startDate = Arr::get($dateRange, 0);

--- a/app/Services/Submission/SubmissionService.php
+++ b/app/Services/Submission/SubmissionService.php
@@ -493,13 +493,21 @@ class SubmissionService
             ->orderBy('id', 'DESC')
             ->get();
 
+        // Batch-fetch users to avoid N+1 queries
+        $userIds = $notes->pluck('user_id')->filter()->unique()->values()->toArray();
+        $usersMap = [];
+        if (!empty($userIds)) {
+            $users = get_users(['include' => $userIds, 'fields' => ['ID', 'display_name']]);
+            foreach ($users as $user) {
+                $usersMap[$user->ID] = $user->display_name;
+            }
+        }
+
         foreach ($notes as $note) {
             if ($note->user_id) {
                 $note->pemalink = get_edit_user_link($note->user_id);
-                $user = get_user_by('ID', $note->user_id);
-
-                if ($user) {
-                    $note->created_by = $user->display_name;
+                if (isset($usersMap[$note->user_id])) {
+                    $note->created_by = $usersMap[$note->user_id];
                 } else {
                     $note->created_by = __('Fluent Forms Bot', 'fluentform');
                 }

--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -95,6 +95,9 @@ class TransferService
                             if ("ffc_form_settings_generated_css" == $metaKey || "ffc_form_settings_meta" == $metaKey) {
                                 $metaValue = str_replace('ff_conv_app_' . Arr::get($formItem, 'id'), 'ff_conv_app_' . $formId, $metaValue);
                             }
+                            if (is_string($metaValue)) {
+                                $metaValue = wp_kses_post($metaValue);
+                            }
                             $settings = [
                                 'form_id'  => $formId,
                                 'meta_key' => $metaKey,
@@ -323,9 +326,11 @@ class TransferService
 
             $searchString = Arr::get($args, 'search');
             if ($searchString) {
-                $query->where(function ($q) use ($searchString) {
-                    $q->where('id', 'LIKE', "%{$searchString}%")
-                        ->orWhere('response', 'LIKE', "%{$searchString}%");
+                global $wpdb;
+                $escaped = $wpdb->esc_like($searchString);
+                $query->where(function ($q) use ($escaped) {
+                    $q->where('id', 'LIKE', "%{$escaped}%")
+                        ->orWhere('response', 'LIKE', "%{$escaped}%");
                 });
             }
         } else {

--- a/vendor/wpfluent/framework/src/WPFluent/Foundation/RequestGuard.php
+++ b/vendor/wpfluent/framework/src/WPFluent/Foundation/RequestGuard.php
@@ -97,7 +97,7 @@ abstract class RequestGuard
     protected function shouldThrowException()
     {
         $isTrue = $this->isRest();
-        $isTrue = $isTrue || str_contains('test', App::make()->env());
+        $isTrue = $isTrue || str_contains(App::make()->env(), 'test');
         $isTrue = $isTrue || str_contains(strtolower(php_sapi_name()), 'cli');
         return $isTrue;
     }


### PR DESCRIPTION
- SEC-C1/C2: Sanitize sort_by via Helper::sanitizeOrderValue() in Logger, Entry, Submission
- SEC-H1/H2: Apply $wpdb->esc_like() to LIKE search in Entry model and TransferService
- SEC-M10: Sanitize meta values with wp_kses_post() on form import
- RC-C1: Use \Exception in FormIntegrationController catch blocks
- RC-H4: Remove shadowed $request property in GlobalIntegrationController
- RC-M2: Apply wp_kses_post() to submission note content
- OPT-H1: Add ->select('serial_number') to avoid fetching LONGTEXT column
- OPT-L4: Fix unreachable payment_method/test condition in ShortCodeParser
- OPT-M5: Cache apply_filters('fluentform/entries_human_date') outside loop
- OPT-C2: Batch get_users() instead of N+1 get_user_by() per note
- DB-M3: Fix inverted boolean guard in DataLogger::retryApiAction()
- Framework: Fix reversed str_contains args in RequestGuard::shouldThrowException()