### PR TITLE
Fix: Policy tightening for notes and integration routes

### DIFF
--- a/app/Http/Controllers/FormIntegrationController.php
+++ b/app/Http/Controllers/FormIntegrationController.php
@@ -47,8 +47,9 @@ class FormIntegrationController extends Controller
     public function delete(FormIntegrationService $integrationService)
     {
         try {
+            $formId = intval($this->request->get('form_id'));
             $id = intval($this->request->get('integration_id'));
-            $integrationService->delete($id);
+            $integrationService->delete($id, $formId);
             return $this->sendSuccess([
                 'message' => __('Successfully deleted the Integration.', 'fluentform'),
             ], 200);

--- a/app/Http/Policies/FormPolicy.php
+++ b/app/Http/Policies/FormPolicy.php
@@ -29,10 +29,26 @@ class FormPolicy extends Policy
         return Acl::hasAnyFormPermission($request->get('form_id'));
     }
 
+    public function find(Request $request)
+    {
+        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+    }
+
+    public function delete(Request $request)
+    {
+        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+    }
+
+    public function integrationListComponent(Request $request)
+    {
+        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+    }
+
     public function updateModuleStatus(Request $request)
     {
         return Acl::hasPermission('fluentform_settings_manager', $request->get('form_id'));
     }
+
     public function updateIntegration(Request $request)
     {
         return Acl::hasPermission('fluentform_settings_manager', $request->get('form_id'));

--- a/app/Http/Policies/SubmissionPolicy.php
+++ b/app/Http/Policies/SubmissionPolicy.php
@@ -27,6 +27,11 @@ class SubmissionPolicy extends Policy
         return Acl::hasPermission('fluentform_manage_entries', $formId);
     }
 
+    public function store(Request $request)
+    {
+        return $this->handleBulkActions($request);
+    }
+
     public function updateStatus(Request $request)
     {
         return $this->handleBulkActions($request);

--- a/app/Services/Integrations/FormIntegrationService.php
+++ b/app/Services/Integrations/FormIntegrationService.php
@@ -248,9 +248,13 @@ class FormIntegrationService
         ]);
     }
     
-    public function delete($id)
+    public function delete($id, $formId = null)
     {
-        FormMeta::where('id',$id)->delete();
+        $query = FormMeta::where('id', $id);
+        if ($formId) {
+            $query->where('form_id', $formId);
+        }
+        $query->delete();
     }
     
 }


### PR DESCRIPTION
Improve: Policy tightening for notes and integration routes - Add store() policy to SubmissionPolicy requiring manage_entries for note creation
- Add find, delete, integrationListComponent policy methods to FormPolicy
- Scope integration delete to form_id to prevent cross-form deletion