### PR TITLE
Fix: Prevent fatal error on servers without PHP mbstring extension

### DIFF
--- a/fluentform.php
+++ b/fluentform.php
@@ -14,6 +14,16 @@ defined('ABSPATH') or die;
  */
 
 defined('ABSPATH') or die;
+
+if (!extension_loaded('mbstring')) {
+    error_log('Fluent Forms: Plugin disabled because the PHP mbstring extension is not loaded. Please enable it.');
+    add_action('admin_notices', function () {
+        $message = __('The PHP mbstring extension is required but not available. All Fluent Forms functionality is disabled until this is resolved. Please contact your hosting provider to enable it.', 'fluentform');
+        echo '<div class="notice notice-error"><p><strong>Fluent Forms:</strong> ' . esc_html($message) . '</p></div>';
+    });
+    return;
+}
+
 defined('FLUENTFORM') or define('FLUENTFORM', true);
 define('FLUENTFORM_DIR_PATH', plugin_dir_path(__FILE__));
 define('FLUENTFORM_FRAMEWORK_UPGRADE', '4.3.22');


### PR DESCRIPTION
## Summary

- Adds `extension_loaded('mbstring')` check in `fluentform.php` before any constants or framework code loads
- Shows admin notice explaining the issue and how to resolve it
- Logs to `error_log` for non-admin contexts (REST API, WP-CLI, cron)
- Prevents half-initialized state where Pro plugin thinks Free is loaded

## Context

The WPFluent framework 2.11.15 upgrade introduced ~40 unguarded `mb_*` calls in `Support/Str.php`, `Validator/`, and `Pluralizer.php` that run on every request. Servers where PHP-FPM lacks `mbstring` (while CLI has it — a known misconfiguration) get fatal errors like:

```
Call to undefined function mb_strtoupper()
Call to undefined function mb_strpos()
```

The previous framework version didn't use these classes, so the plugin worked without mbstring. This check restores graceful behavior.

## Test plan

- [ ] Verify plugin loads normally on a server with mbstring
- [ ] Simulate missing mbstring: rename/disable the extension in FPM config, confirm site stays up and admin notice appears
- [ ] Confirm Pro plugin shows its own "free plugin required" notice when mbstring is missing (FLUENTFORM constant not defined)
- [ ] Check PHP error log contains the diagnostic message

Ref: https://support.wpmanageninja.com/#/tickets/156046/view
Related issue: N/A