### PR TITLE
Improve: Smart captcha verification with error classification and Turnstile fixes

### DIFF
--- a/app/Modules/HCaptcha/HCaptcha.php
+++ b/app/Modules/HCaptcha/HCaptcha.php
@@ -7,6 +7,32 @@ use FluentForm\Framework\Helpers\ArrayHelper;
 class HCaptcha
 {
     /**
+     * Error codes that indicate the captcha determined the submission is spam/bot.
+     * These are client-controlled (token) errors — must always block.
+     */
+    private static $spamErrorCodes = [
+        'missing-input-response',
+        'invalid-input-response',
+        'expired-input-response',
+        'already-seen-response',
+    ];
+
+    /**
+     * Error codes that indicate server-side configuration issues.
+     * These are admin-controlled — safe to allow submission through.
+     */
+    private static $configErrorCodes = [
+        'missing-input-secret',
+        'invalid-input-secret',
+        'bad-request',
+        'sitekey-secret-mismatch',
+        'not-using-dummy-passcode',
+        'not-using-dummy-secret',
+        'missing-remoteip',
+        'invalid-remoteip',
+    ];
+
+    /**
      * Verify hCaptcha response.
      *
      * @param string $token  response from the user.
@@ -16,7 +42,21 @@ class HCaptcha
      */
     public static function validate($token, $secret = null)
     {
-        $verifyUrl = 'https://hcaptcha.com/siteverify';
+        $result = static::verify($token, $secret);
+        return 'valid' === $result['status'];
+    }
+
+    /**
+     * Verify hCaptcha response with detailed result.
+     *
+     * @param string $token
+     * @param string|null $secret
+     * @return array{status: string, error_codes: array, message: string}
+     *   status: 'valid' | 'spam' | 'config_error' | 'network_error'
+     */
+    public static function verify($token, $secret = null)
+    {
+        $verifyUrl = 'https://api.hcaptcha.com/siteverify';
 
         $secret = $secret ?: ArrayHelper::get(get_option('_fluentform_hCaptcha_details'), 'secretKey');
 
@@ -28,13 +68,83 @@ class HCaptcha
             ],
         ]);
 
-        $isValid = false;
-
-        if (!is_wp_error($response)) {
-            $result = json_decode(wp_remote_retrieve_body($response));
-            $isValid = $result->success;
+        if (is_wp_error($response)) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['wp_error'],
+                'message'     => $response->get_error_message(),
+            ];
         }
 
-        return $isValid;
+        $statusCode = wp_remote_retrieve_response_code($response);
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['http_' . $statusCode],
+                'message'     => sprintf(
+                    __('hCaptcha service returned HTTP %d.', 'fluentform'),
+                    $statusCode
+                ),
+            ];
+        }
+
+        $result = json_decode(wp_remote_retrieve_body($response));
+
+        if (! $result || ! isset($result->success)) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['invalid_response'],
+                'message'     => __('Invalid response from hCaptcha service.', 'fluentform'),
+            ];
+        }
+
+        if ($result->success) {
+            return [
+                'status'      => 'valid',
+                'error_codes' => [],
+                'message'     => '',
+            ];
+        }
+
+        $errorCodes = isset($result->{'error-codes'}) ? (array) $result->{'error-codes'} : [];
+
+        if (empty($errorCodes)) {
+            return [
+                'status'      => 'spam',
+                'error_codes' => ['unknown'],
+                'message'     => __('hCaptcha verification failed with no error codes returned.', 'fluentform'),
+            ];
+        }
+
+        return [
+            'status'      => static::classifyErrors($errorCodes),
+            'error_codes' => $errorCodes,
+            'message'     => sprintf(
+                __('hCaptcha verification failed. Error codes: %s', 'fluentform'),
+                implode(', ', $errorCodes)
+            ),
+        ];
+    }
+
+    /**
+     * Classify error codes as 'spam' or 'config_error'.
+     * If ANY spam error is present, it's treated as spam.
+     */
+    private static function classifyErrors($errorCodes)
+    {
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$spamErrorCodes, true)) {
+                return 'spam';
+            }
+        }
+
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$configErrorCodes, true)) {
+                return 'config_error';
+            }
+        }
+
+        // Unknown error codes default to spam for safety
+        return 'spam';
     }
 }

--- a/app/Modules/ReCaptcha/ReCaptcha.php
+++ b/app/Modules/ReCaptcha/ReCaptcha.php
@@ -7,6 +7,26 @@ use FluentForm\Framework\Helpers\ArrayHelper;
 class ReCaptcha
 {
     /**
+     * Error codes that indicate the captcha determined the submission is spam/bot.
+     * These are client-controlled (token) errors — must always block.
+     */
+    private static $spamErrorCodes = [
+        'missing-input-response',
+        'invalid-input-response',
+        'timeout-or-duplicate',
+    ];
+
+    /**
+     * Error codes that indicate server-side configuration issues.
+     * These are admin-controlled — safe to allow submission through.
+     */
+    private static $configErrorCodes = [
+        'missing-input-secret',
+        'invalid-input-secret',
+        'bad-request',
+    ];
+
+    /**
      * Verify reCaptcha response.
      *
      * @param string $token response from the user.
@@ -15,6 +35,21 @@ class ReCaptcha
      * @return bool
      */
     public static function validate($token, $secret = null, $version = 'v2_visible')
+    {
+        $result = static::verify($token, $secret, $version);
+        return 'valid' === $result['status'];
+    }
+
+    /**
+     * Verify reCaptcha response with detailed result.
+     *
+     * @param string $token
+     * @param string|null $secret
+     * @param string $version
+     * @return array{status: string, error_codes: array, message: string}
+     *   status: 'valid' | 'spam' | 'config_error' | 'network_error'
+     */
+    public static function verify($token, $secret = null, $version = 'v2_visible')
     {
         $verifyUrl = 'https://www.google.com/recaptcha/api/siteverify';
 
@@ -28,13 +63,52 @@ class ReCaptcha
             ],
         ]);
 
+        if (is_wp_error($response)) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['wp_error'],
+                'message'     => $response->get_error_message(),
+            ];
+        }
 
-        $isValid = false;
+        $statusCode = wp_remote_retrieve_response_code($response);
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['http_' . $statusCode],
+                'message'     => sprintf(
+                    __('reCAPTCHA service returned HTTP %d.', 'fluentform'),
+                    $statusCode
+                ),
+            ];
+        }
 
-        if (! is_wp_error($response)) {
-            $result = json_decode(wp_remote_retrieve_body($response));
-            if($version == 'v3_invisible' && $result->success) {
-                $score = $result->score;
+        $result = json_decode(wp_remote_retrieve_body($response));
+
+        if (! $result || ! isset($result->success)) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['invalid_response'],
+                'message'     => __('Invalid response from reCAPTCHA service.', 'fluentform'),
+            ];
+        }
+
+        if ($result->success) {
+            if ($version == 'v3_invisible') {
+                $expectedAction = apply_filters('fluentform/recaptcha_v3_action', 'submit');
+                if ($expectedAction && (!isset($result->action) || $result->action !== $expectedAction)) {
+                    return [
+                        'status'      => 'spam',
+                        'error_codes' => ['action_mismatch'],
+                        'message'     => sprintf(
+                            __('reCAPTCHA v3 action mismatch: expected "%s", got "%s".', 'fluentform'),
+                            $expectedAction,
+                            isset($result->action) ? $result->action : 'none'
+                        ),
+                    ];
+                }
+
+                $score = isset($result->score) ? $result->score : 0;
                 $value = 0.5;
                 $value = apply_filters_deprecated(
                     'fluentforms_recaptcha_v3_ref_score',
@@ -46,12 +120,66 @@ class ReCaptcha
                     'Use fluentform/recaptcha_v3_ref_score instead of fluentforms_recaptcha_v3_ref_score.'
                 );
                 $checkScore = apply_filters('fluentform/recaptcha_v3_ref_score', $value);
-                $isValid = $score >= $checkScore;
-            } else {
-                $isValid = $result->success;
+
+                if ($score < $checkScore) {
+                    return [
+                        'status'      => 'spam',
+                        'error_codes' => ['low_score'],
+                        'message'     => sprintf(
+                            __('reCAPTCHA v3 score too low: %s (threshold: %s).', 'fluentform'),
+                            $score,
+                            $checkScore
+                        ),
+                    ];
+                }
+            }
+
+            return [
+                'status'      => 'valid',
+                'error_codes' => [],
+                'message'     => '',
+            ];
+        }
+
+        $errorCodes = isset($result->{'error-codes'}) ? (array) $result->{'error-codes'} : [];
+
+        if (empty($errorCodes)) {
+            return [
+                'status'      => 'spam',
+                'error_codes' => ['unknown'],
+                'message'     => __('reCAPTCHA verification failed with no error codes returned.', 'fluentform'),
+            ];
+        }
+
+        return [
+            'status'      => static::classifyErrors($errorCodes),
+            'error_codes' => $errorCodes,
+            'message'     => sprintf(
+                __('reCAPTCHA verification failed. Error codes: %s', 'fluentform'),
+                implode(', ', $errorCodes)
+            ),
+        ];
+    }
+
+    /**
+     * Classify error codes as 'spam' or 'config_error'.
+     * If ANY spam error is present, it's treated as spam.
+     */
+    private static function classifyErrors($errorCodes)
+    {
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$spamErrorCodes, true)) {
+                return 'spam';
             }
         }
 
-        return $isValid;
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$configErrorCodes, true)) {
+                return 'config_error';
+            }
+        }
+
+        // Unknown error codes default to spam for safety
+        return 'spam';
     }
 }

--- a/app/Modules/Turnstile/Turnstile.php
+++ b/app/Modules/Turnstile/Turnstile.php
@@ -157,6 +157,10 @@ class Turnstile
     {
         $settings = ArrayHelper::get($values, '_fluentform_turnstile_details');
 
+        if (!is_array($settings)) {
+            $settings = [];
+        }
+
         $settings['invisible'] = ArrayHelper::get($settings, 'invisible', 'no');
         $settings['theme'] = ArrayHelper::get($settings, 'theme', 'auto');
         $settings['appearance'] = ArrayHelper::get($settings, 'appearance', 'always');

--- a/app/Modules/Turnstile/Turnstile.php
+++ b/app/Modules/Turnstile/Turnstile.php
@@ -7,6 +7,33 @@ use FluentForm\Framework\Helpers\ArrayHelper;
 class Turnstile
 {
     /**
+     * Error codes that indicate the captcha determined the submission is spam/bot.
+     * These are client-controlled (token) errors — must always block.
+     */
+    private static $spamErrorCodes = [
+        'missing-input-response',
+        'invalid-input-response',
+        'timeout-or-duplicate',
+    ];
+
+    /**
+     * Error codes that indicate server-side configuration issues.
+     * These are admin-controlled — safe to allow submission through.
+     */
+    private static $configErrorCodes = [
+        'missing-input-secret',
+        'invalid-input-secret',
+        'bad-request',
+    ];
+
+    /**
+     * Transient error codes from Cloudflare (service-side issues).
+     */
+    private static $transientErrorCodes = [
+        'internal-error',
+    ];
+
+    /**
      * Verify turnstile response.
      *
      * @param string $token  response from the user.
@@ -15,6 +42,20 @@ class Turnstile
      * @return bool
      */
     public static function validate($token, $secret)
+    {
+        $result = static::verify($token, $secret);
+        return 'valid' === $result['status'];
+    }
+
+    /**
+     * Verify turnstile response with detailed result.
+     *
+     * @param string $token
+     * @param string $secret
+     * @return array{status: string, error_codes: array, message: string}
+     *   status: 'valid' | 'spam' | 'config_error' | 'network_error'
+     */
+    public static function verify($token, $secret)
     {
         $verifyUrl = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
 
@@ -26,14 +67,90 @@ class Turnstile
             ],
         ]);
 
-        $isValid = false;
-
-        if (!is_wp_error($response)) {
-            $result = json_decode(wp_remote_retrieve_body($response));
-            $isValid = $result->success;
+        if (is_wp_error($response)) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['wp_error'],
+                'message'     => $response->get_error_message(),
+            ];
         }
 
-        return $isValid;
+        $statusCode = wp_remote_retrieve_response_code($response);
+        if ($statusCode < 200 || $statusCode >= 300) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['http_' . $statusCode],
+                'message'     => sprintf(
+                    __('Turnstile service returned HTTP %d.', 'fluentform'),
+                    $statusCode
+                ),
+            ];
+        }
+
+        $result = json_decode(wp_remote_retrieve_body($response));
+
+        if (! $result || ! isset($result->success)) {
+            return [
+                'status'      => 'network_error',
+                'error_codes' => ['invalid_response'],
+                'message'     => __('Invalid response from Turnstile service.', 'fluentform'),
+            ];
+        }
+
+        if ($result->success) {
+            return [
+                'status'      => 'valid',
+                'error_codes' => [],
+                'message'     => '',
+            ];
+        }
+
+        $errorCodes = isset($result->{'error-codes'}) ? (array) $result->{'error-codes'} : [];
+
+        if (empty($errorCodes)) {
+            return [
+                'status'      => 'spam',
+                'error_codes' => ['unknown'],
+                'message'     => __('Turnstile verification failed with no error codes returned.', 'fluentform'),
+            ];
+        }
+
+        return [
+            'status'      => static::classifyErrors($errorCodes),
+            'error_codes' => $errorCodes,
+            'message'     => sprintf(
+                __('Turnstile verification failed. Error codes: %s', 'fluentform'),
+                implode(', ', $errorCodes)
+            ),
+        ];
+    }
+
+    /**
+     * Classify error codes as 'spam', 'config_error', or 'network_error'.
+     * If ANY spam error is present, it's treated as spam.
+     */
+    private static function classifyErrors($errorCodes)
+    {
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$spamErrorCodes, true)) {
+                return 'spam';
+            }
+        }
+
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$transientErrorCodes, true)) {
+                return 'network_error';
+            }
+        }
+
+        foreach ($errorCodes as $code) {
+            if (in_array($code, static::$configErrorCodes, true)) {
+                return 'config_error';
+            }
+        }
+
+        // Unknown error codes default to spam for safety
+        return 'spam';
     }
 
     public static function ensureSettings($values)
@@ -43,6 +160,7 @@ class Turnstile
         $settings['invisible'] = ArrayHelper::get($settings, 'invisible', 'no');
         $settings['theme'] = ArrayHelper::get($settings, 'theme', 'auto');
         $settings['appearance'] = ArrayHelper::get($settings, 'appearance', 'always');
+        $settings['size'] = ArrayHelper::get($settings, 'size', 'normal');
         unset($settings['token']);
 
         $values['_fluentform_turnstile_details'] = $settings;

--- a/app/Modules/Turnstile/Turnstile.php
+++ b/app/Modules/Turnstile/Turnstile.php
@@ -161,7 +161,14 @@ class Turnstile
             $settings = [];
         }
 
-        $settings['invisible'] = ArrayHelper::get($settings, 'invisible', 'no');
+        // Migrate legacy invisible flag to appearance, persist once
+        if (isset($settings['invisible'])) {
+            if ('yes' === $settings['invisible']) {
+                $settings['appearance'] = 'interaction-only';
+            }
+            unset($settings['invisible']);
+            update_option('_fluentform_turnstile_details', $settings, 'no');
+        }
         $settings['theme'] = ArrayHelper::get($settings, 'theme', 'auto');
         $settings['appearance'] = ArrayHelper::get($settings, 'appearance', 'always');
         $settings['size'] = ArrayHelper::get($settings, 'size', 'normal');

--- a/app/Services/Form/FormValidationService.php
+++ b/app/Services/Form/FormValidationService.php
@@ -21,6 +21,7 @@ class FormValidationService
     protected $app;
     protected $form;
     protected $formData;
+    protected $captchaWarnings = [];
 
     public function __construct()
     {
@@ -45,6 +46,8 @@ class FormValidationService
      */
     public function validateSubmission(&$fields, &$formData)
     {
+        $this->captchaWarnings = [];
+
         do_action('fluentform/before_form_validation', $fields, $formData);
 
         $this->preventMaliciousAttacks();
@@ -569,14 +572,29 @@ class FormValidationService
         
         if (!$disableReCaptcha && (FormFieldsParser::hasElement($this->form, 'recaptcha') || $autoInclude)) {
             $keys = get_option('_fluentform_reCaptcha_details');
+
+            if (!is_array($keys) || empty($keys['secretKey'])) {
+                $this->captchaWarnings[] = [
+                    'type'        => 'reCAPTCHA',
+                    'status'      => 'config_error',
+                    'error_codes' => ['missing_settings'],
+                    'message'     => __('reCAPTCHA secret key not configured.', 'fluentform'),
+                ];
+                return;
+            }
+
             $token = Arr::get($this->formData, 'g-recaptcha-response');
             $version = 'v2_visible';
             if (!empty($keys['api_version'])) {
                 $version = $keys['api_version'];
             }
-            $isValid = ReCaptcha::validate($token, $keys['secretKey'], $version);
-            
-            if (!$isValid) {
+            $result = ReCaptcha::verify($token, $keys['secretKey'], $version);
+
+            if ('valid' === $result['status']) {
+                return;
+            }
+
+            if ('spam' === $result['status']) {
                 // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
                 throw new ValidationException('', 422, null, [
                     'errors' => [
@@ -586,6 +604,14 @@ class FormValidationService
                     ],
                 ]);
             }
+
+            // config_error or network_error — allow submission, log warning
+            $this->captchaWarnings[] = [
+                'type'        => 'reCAPTCHA',
+                'status'      => $result['status'],
+                'error_codes' => $result['error_codes'],
+                'message'     => $result['message'],
+            ];
         }
     }
 
@@ -615,10 +641,25 @@ class FormValidationService
         FormFieldsParser::resetData();
         if (!$disableHCaptcha && (FormFieldsParser::hasElement($this->form, 'hcaptcha') || $autoInclude)) {
             $keys = get_option('_fluentform_hCaptcha_details');
+
+            if (!is_array($keys) || empty($keys['secretKey'])) {
+                $this->captchaWarnings[] = [
+                    'type'        => 'hCaptcha',
+                    'status'      => 'config_error',
+                    'error_codes' => ['missing_settings'],
+                    'message'     => __('hCaptcha secret key not configured.', 'fluentform'),
+                ];
+                return;
+            }
+
             $token = Arr::get($this->formData, 'h-captcha-response');
-            $isValid = HCaptcha::validate($token, $keys['secretKey']);
-            
-            if (!$isValid) {
+            $result = HCaptcha::verify($token, $keys['secretKey']);
+
+            if ('valid' === $result['status']) {
+                return;
+            }
+
+            if ('spam' === $result['status']) {
                 throw new ValidationException('', 422, null, [
                     'errors' => [
                         'h-captcha-response' => [
@@ -627,6 +668,14 @@ class FormValidationService
                     ],
                 ]);
             }
+
+            // config_error or network_error — allow submission, log warning
+            $this->captchaWarnings[] = [
+                'type'        => 'hCaptcha',
+                'status'      => $result['status'],
+                'error_codes' => $result['error_codes'],
+                'message'     => $result['message'],
+            ];
         }
     }
 
@@ -656,11 +705,25 @@ class FormValidationService
         
         if (!$disableTurnsTile && (FormFieldsParser::hasElement($this->form, 'turnstile') || $autoInclude)) {
             $keys = get_option('_fluentform_turnstile_details');
+
+            if (!is_array($keys) || empty($keys['secretKey'])) {
+                $this->captchaWarnings[] = [
+                    'type'        => 'Turnstile',
+                    'status'      => 'config_error',
+                    'error_codes' => ['missing_settings'],
+                    'message'     => __('Turnstile secret key not configured.', 'fluentform'),
+                ];
+                return;
+            }
+
             $token = Arr::get($this->formData, 'cf-turnstile-response');
-            
-            $isValid = Turnstile::validate($token, $keys['secretKey']);
-            
-            if (!$isValid) {
+            $result = Turnstile::verify($token, $keys['secretKey']);
+
+            if ('valid' === $result['status']) {
+                return;
+            }
+
+            if ('spam' === $result['status']) {
                 throw new ValidationException('', 422, null, [
                     'errors' => [
                         'cf-turnstile-response' => [
@@ -669,6 +732,14 @@ class FormValidationService
                     ],
                 ]);
             }
+
+            // config_error or network_error — allow submission, log warning
+            $this->captchaWarnings[] = [
+                'type'        => 'Turnstile',
+                'status'      => $result['status'],
+                'error_codes' => $result['error_codes'],
+                'message'     => $result['message'],
+            ];
         }
     }
 
@@ -911,5 +982,17 @@ class FormValidationService
         }
 
         return true; // Skip validation for non-selected captcha types
+    }
+
+    /**
+     * Get captcha warnings collected during validation.
+     * These are non-blocking issues (config errors, network failures)
+     * that should be logged after submission insertion.
+     *
+     * @return array
+     */
+    public function getCaptchaWarnings()
+    {
+        return $this->captchaWarnings;
     }
 }

--- a/app/Services/Form/SubmissionHandlerService.php
+++ b/app/Services/Form/SubmissionHandlerService.php
@@ -49,6 +49,8 @@ class SubmissionHandlerService
         }
         $insertId = $this->insertSubmission($insertData, $formDataRaw, $formId);
 
+        $this->logCaptchaWarnings($insertId);
+
         return $this->processSubmissionData($insertId, $this->formData, $this->form);
     }
 
@@ -596,6 +598,46 @@ class SubmissionHandlerService
         Helper::setSubmissionMeta($insertId, '_entry_uid_hash', $uidHash, $formId);
 
         return $insertId;
+    }
+
+    private function logCaptchaWarnings($insertId)
+    {
+        try {
+            $warnings = $this->validationService->getCaptchaWarnings();
+
+            if (empty($warnings)) {
+                return;
+            }
+
+            foreach ($warnings as $warning) {
+                $statusLabel = 'config_error' === $warning['status']
+                    ? __('Configuration Error', 'fluentform')
+                    : __('Network Error', 'fluentform');
+
+                do_action('fluentform/log_data', [
+                    'parent_source_id' => $this->form->id,
+                    'source_type'      => 'submission_item',
+                    'source_id'        => $insertId,
+                    'component'        => $warning['type'],
+                    'status'           => 'error',
+                    'title'            => sprintf(
+                        __('%s verification skipped (%s)', 'fluentform'),
+                        $warning['type'],
+                        $statusLabel
+                    ),
+                    'description'      => sprintf(
+                        __('Submission was allowed through because %s verification failed due to a %s, not spam detection. Error codes: %s. Please check your %s configuration in Fluent Forms global settings.', 'fluentform'),
+                        $warning['type'],
+                        strtolower($statusLabel),
+                        implode(', ', $warning['error_codes']),
+                        $warning['type']
+                    ),
+                ]);
+            }
+        } catch (\Throwable $e) {
+            // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            error_log('FluentForm: Failed to log captcha warning for submission ' . $insertId . ': ' . $e->getMessage());
+        }
     }
 
     private function processSpamSubmission($insertId, $type)

--- a/app/Services/FormBuilder/Components/Turnstile.php
+++ b/app/Services/FormBuilder/Components/Turnstile.php
@@ -53,7 +53,7 @@ class Turnstile extends BaseComponent
 
             wp_enqueue_script(
                 'turnstile',
-                'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit', // phpcs:ignore PluginCheck.CodeAnalysis.EnqueuedResourceOffloading.OffloadedContent -- Cloudflare Turnstile requires loading from their CDN for CAPTCHA functionality
+                $apiUrl, // phpcs:ignore PluginCheck.CodeAnalysis.EnqueuedResourceOffloading.OffloadedContent -- Cloudflare Turnstile requires loading from their CDN for CAPTCHA functionality
                 [],
                 FLUENTFORM_VERSION,
                 true
@@ -69,7 +69,10 @@ class Turnstile extends BaseComponent
             $appearance = 'interaction-only';
         }
 
+        $size = esc_attr(ArrayHelper::get($turnstile, 'size', 'normal'));
+
         $turnstileBlock = "<div
+		data-size='" . $size . "'
 		data-sitekey='" . esc_attr($siteKey) . "'
 		data-theme='" . esc_attr(ArrayHelper::get($turnstile, 'theme', 'auto')) . "'
 		id='fluentform-turnstile-{$form->id}-{$form->instance_index}'

--- a/app/Services/FormBuilder/Components/Turnstile.php
+++ b/app/Services/FormBuilder/Components/Turnstile.php
@@ -32,6 +32,16 @@ class Turnstile extends BaseComponent
         $data = apply_filters('fluentform/rendering_field_data_' . $elementName, $data, $form);
 
         $turnstile = get_option('_fluentform_turnstile_details');
+
+        // One-time migration: convert legacy invisible flag to appearance
+        if (is_array($turnstile) && isset($turnstile['invisible'])) {
+            if ('yes' === $turnstile['invisible']) {
+                $turnstile['appearance'] = 'interaction-only';
+            }
+            unset($turnstile['invisible']);
+            update_option('_fluentform_turnstile_details', $turnstile, 'no');
+        }
+
         $siteKey = ArrayHelper::get($turnstile, 'siteKey');
 
         if (! $siteKey) {
@@ -64,10 +74,6 @@ class Turnstile extends BaseComponent
         }
 
         $appearance = esc_attr(ArrayHelper::get($turnstile, 'appearance', 'always'));
-
-        if ('yes' == ArrayHelper::get($turnstile, 'invisible')) {
-            $appearance = 'interaction-only';
-        }
 
         $size = esc_attr(ArrayHelper::get($turnstile, 'size', 'normal'));
 

--- a/app/Services/GlobalSettings/GlobalSettingsHelper.php
+++ b/app/Services/GlobalSettings/GlobalSettingsHelper.php
@@ -221,6 +221,7 @@ class GlobalSettingsHelper
             'secretKey'  => $secretKey,
             'invisible'  => 'no',
             'appearance' => Arr::get($data, 'appearance', 'always'),
+            'size'       => sanitize_text_field(Arr::get($data, 'size', 'normal')),
             'theme'      => Arr::get($data, 'theme', 'auto')
         ];
 

--- a/app/Services/GlobalSettings/GlobalSettingsHelper.php
+++ b/app/Services/GlobalSettings/GlobalSettingsHelper.php
@@ -215,14 +215,15 @@ class GlobalSettingsHelper
         $token = Arr::get($data, 'token');
         $secretKey = sanitize_text_field(Arr::get($data, 'secretKey'));
 
+        $siteKey = sanitize_text_field(Arr::get($data, 'siteKey'));
+
         // Prepare captcha data.
         $captchaData = [
-            'siteKey'    => Arr::get($data, 'siteKey'),
+            'siteKey'    => $siteKey,
             'secretKey'  => $secretKey,
-            'invisible'  => 'no',
-            'appearance' => Arr::get($data, 'appearance', 'always'),
+            'appearance' => sanitize_text_field(Arr::get($data, 'appearance', 'always')),
             'size'       => sanitize_text_field(Arr::get($data, 'size', 'normal')),
-            'theme'      => Arr::get($data, 'theme', 'auto')
+            'theme'      => sanitize_text_field(Arr::get($data, 'theme', 'auto'))
         ];
 
         // If token is not empty meaning user verified their captcha.
@@ -256,12 +257,22 @@ class GlobalSettingsHelper
             $status = get_option('_fluentform_turnstile_keys_status');
 
             if ($status) {
-                // Only update presentation fields, preserve verified keys
                 $existing = get_option('_fluentform_turnstile_details');
                 if (is_array($existing)) {
-                    $existing['appearance'] = Arr::get($data, 'appearance', 'always');
+                    $keysChanged = $siteKey !== Arr::get($existing, 'siteKey')
+                        || $secretKey !== Arr::get($existing, 'secretKey');
+
+                    if ($keysChanged) {
+                        return([
+                            'message' => __('Please verify your Turnstile to save the new keys.', 'fluentform'),
+                            'status'  => false,
+                        ]);
+                    }
+
+                    // Keys unchanged — only update presentation fields
+                    $existing['appearance'] = sanitize_text_field(Arr::get($data, 'appearance', 'always'));
                     $existing['size'] = sanitize_text_field(Arr::get($data, 'size', 'normal'));
-                    $existing['theme'] = Arr::get($data, 'theme', 'auto');
+                    $existing['theme'] = sanitize_text_field(Arr::get($data, 'theme', 'auto'));
                     update_option('_fluentform_turnstile_details', $existing, 'no');
                 }
                 $message = __('Your Turnstile settings is saved.', 'fluentform');

--- a/app/Services/GlobalSettings/GlobalSettingsHelper.php
+++ b/app/Services/GlobalSettings/GlobalSettingsHelper.php
@@ -252,11 +252,18 @@ class GlobalSettingsHelper
             // The token is empty, so the user didn't verify their captcha.
             $message = __('Please validate your Turnstile first and then hit save.', 'fluentform');
 
-            // Get the already stored reCaptcha status.
+            // Get the already stored Turnstile status.
             $status = get_option('_fluentform_turnstile_keys_status');
 
             if ($status) {
-                update_option('_fluentform_turnstile_details', $captchaData, 'no');
+                // Only update presentation fields, preserve verified keys
+                $existing = get_option('_fluentform_turnstile_details');
+                if (is_array($existing)) {
+                    $existing['appearance'] = Arr::get($data, 'appearance', 'always');
+                    $existing['size'] = sanitize_text_field(Arr::get($data, 'size', 'normal'));
+                    $existing['theme'] = Arr::get($data, 'theme', 'auto');
+                    update_option('_fluentform_turnstile_details', $existing, 'no');
+                }
                 $message = __('Your Turnstile settings is saved.', 'fluentform');
 
                 return([

--- a/resources/assets/admin/settings/turnstile.vue
+++ b/resources/assets/admin/settings/turnstile.vue
@@ -165,7 +165,6 @@ export default {
             turnstile: {
                 siteKey: "",
                 secretKey: "",
-                invisible: "no",
                 appearance: 'always',
                 size: 'normal',
                 theme: 'auto'
@@ -281,9 +280,6 @@ export default {
                 .then(response => {
                     const turnstile = response._fluentform_turnstile_details;
                     this.turnstile = turnstile;
-                    if (this.turnstile?.invisible == 'yes') {
-                        this.turnstile.appearance = 'interaction-only';
-                    }
                     this.turnstile_status = response._fluentform_turnstile_keys_status;
                 });
         }

--- a/resources/assets/admin/settings/turnstile.vue
+++ b/resources/assets/admin/settings/turnstile.vue
@@ -73,6 +73,25 @@
 
                     <el-form-item class="ff-form-item">
                         <template slot="label">
+                            {{ $t('Widget Size') }}
+                            <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
+                                <div slot="content">
+                                    <p>
+                                        {{ $t('Select the size of the Turnstile widget') }}
+                                    </p>
+                                </div>
+
+                                <i class="ff-icon ff-icon-info-filled text-primary"></i>
+                            </el-tooltip>
+                        </template>
+
+                        <el-radio class="mr-3" v-model="turnstile.size" label="normal">{{$t('Normal')}}</el-radio>
+                        <el-radio class="mr-3" v-model="turnstile.size" label="flexible">{{$t('Flexible')}}</el-radio>
+                        <el-radio class="mr-3" v-model="turnstile.size" label="compact">{{$t('Compact')}}</el-radio>
+                    </el-form-item>
+
+                    <el-form-item class="ff-form-item">
+                        <template slot="label">
                             {{ $t('Theme') }}
                             <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
                                 <div slot="content">
@@ -93,7 +112,6 @@
                     <!--Validate Keys-->
                     <el-form-item :label="$t('Validate Keys')" v-if="siteKeyChanged">
                         <div
-                            class="cf-turnstile"
                             id="turnstile"
                             :data-sitekey="turnstile.siteKey"
                         ></div>
@@ -149,6 +167,7 @@ export default {
                 secretKey: "",
                 invisible: "no",
                 appearance: 'always',
+                size: 'normal',
                 theme: 'auto'
             },
             turnstile_status: false,
@@ -179,6 +198,7 @@ export default {
                 let widgetID = turnstile.render(id, {
                     sitekey: siteKey,
                     theme: this.turnstile.theme,
+                    size: this.turnstile.size || 'normal',
                     callback: (token) => {
                         this.turnstile.token = token;
                     }
@@ -274,7 +294,7 @@ export default {
     created() {
         let turnstileScript = document.createElement('script');
 
-        turnstileScript.setAttribute('src', 'https://challenges.cloudflare.com/turnstile/v0/api.js');
+        turnstileScript.setAttribute('src', 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit');
 
         document.body.appendChild(turnstileScript);
     },

--- a/resources/assets/public/form-submission.js
+++ b/resources/assets/public/form-submission.js
@@ -1043,6 +1043,9 @@ jQuery(document).ready(function () {
                         // Special case for Turnstile
                         if (type === 'cf-turnstile') {
                             container = '#' + id;
+                            options['size'] = $el.data('size') || 'normal';
+                            options['theme'] = $el.data('theme') || 'auto';
+                            options['appearance'] = $el.data('appearance') || 'always';
                         }
 
                         // Render the captcha


### PR DESCRIPTION
## Summary

- Overhaul captcha server-side verification (reCAPTCHA, hCaptcha, Turnstile) to classify API error codes as spam vs configuration/network errors
- Spam errors block submission (current behavior preserved). Config/network errors allow submission through with an admin log entry via `fluentform/log_data`
- Fix multiple bugs found during docs audit: hCaptcha siteverify URL, reCAPTCHA v3 action verification, Turnstile locale filter, theme/appearance pass-through, admin double-render
- Add configurable Turnstile widget size setting (normal/flexible/compact) to fix `size: "invisible"` error

## Changes

### Smart Error Classification
Each captcha module (`ReCaptcha.php`, `HCaptcha.php`, `Turnstile.php`) now has a `verify()` method returning `{status, error_codes, message}`. Error codes from each service's API are classified per official docs:
- **Spam** (block): `invalid-input-response`, `missing-input-response`, `timeout-or-duplicate`, `expired-input-response`, `already-seen-response`, low reCAPTCHA v3 score
- **Config** (allow + log): `invalid-input-secret`, `missing-input-secret`, `bad-request`, `sitekey-secret-mismatch`, `not-using-dummy-passcode`, `not-using-dummy-secret`
- **Network** (allow + log): `internal-error`, HTTP 4xx/5xx, WP_Error, malformed response

The existing `validate()` boolean API is preserved as a wrapper for backward compatibility.

### Bug Fixes
- **hCaptcha**: siteverify URL corrected from `hcaptcha.com` to `api.hcaptcha.com`
- **reCAPTCHA v3**: action field now verified to prevent cross-action token replay attacks
- **Turnstile**: locale filter was built but ignored (hardcoded URL in `wp_enqueue_script`)
- **Turnstile**: `theme` and `appearance` now passed to `turnstile.render()` (were ignored with `render=explicit`)
- **Turnstile admin**: removed `cf-turnstile` class + added `render=explicit` to prevent double-render
- **Turnstile**: added configurable size setting to fix `size: "invisible"` Cloudflare error

### Hardening
- Guard `$keys` null check before accessing `secretKey` in all 3 validate methods
- HTTP status code check (4xx/5xx → network_error) before parsing response body
- Empty error-codes handled explicitly with `unknown` code
- `logCaptchaWarnings()` wrapped in `try/catch \Throwable` to protect submission flow
- `captchaWarnings` reset at start of each validation cycle
- Strict `in_array()` with `true` third argument throughout
- Turnstile size field sanitized with `sanitize_text_field()` on save

## Test Plan

- [x] Turnstile: successful submission with valid token
- [x] Turnstile: spam blocked (no token → `missing-input-response`)
- [x] Turnstile: config error pass-through (invalid secret → HTTP 400 → allowed + log)
- [x] reCAPTCHA v3: successful submission with valid token
- [x] reCAPTCHA v3: spam blocked (invalid secret → Google returns `invalid-input-response`)
- [x] reCAPTCHA v3: config error pass-through (empty secret → `missing_settings` → allowed + log)
- [x] hCaptcha: successful submission with test keys
- [x] hCaptcha: spam blocked (no token)
- [x] hCaptcha: config error pass-through (invalid secret → `not-using-dummy-secret` → allowed + log)
- [x] Verify log entries created in `fluentform_logs` table for all pass-through cases
- [x] Verify backward compatibility: `validate()` still returns boolean
- [x] PHP 7.4 syntax compliance
- [x] No build artifacts in commit

Related issue: N/A