### PR TITLE
Fix: max/min validation treating numeric-looking text as numbers

### DIFF
--- a/app/Helpers/Traits/GlobalDefaultMessages.php
+++ b/app/Helpers/Traits/GlobalDefaultMessages.php
@@ -17,6 +17,8 @@ trait GlobalDefaultMessages
             static::setGlobalDefaultMessages();
         } else if ($message = Arr::get($globalSettings, 'default_messages.' . $key, '')) {
             static::$globalDefaultMessages[$key] = $message;
+        } else {
+            static::setGlobalDefaultMessages();
         }
         return apply_filters('fluentform/global_default_message', Arr::get(static::$globalDefaultMessages, $key , ''), $key);
     }

--- a/app/Services/Parser/Validations.php
+++ b/app/Services/Parser/Validations.php
@@ -91,6 +91,8 @@ class Validations
                     $this->prepareValidations($fieldName, $ruleName, $rule);
                 }
             }
+
+            $this->ensureStringTypeForSizeRules($fieldName, $rules);
         }
 
 
@@ -222,5 +224,30 @@ class Validations
                      $rule['value'];
 
         return $ruleName.':'.$ruleValue;
+    }
+
+    /**
+     * Ensure fields with max/min rules but no numeric rule
+     * are treated as strings for character-length validation.
+     *
+     * Without this, the WPFluent validator treats numeric-looking
+     * input (e.g. phone "123456") as a number and compares the
+     * numeric value against max/min instead of string length.
+     *
+     * @param string $fieldName
+     * @param array  $rules
+     */
+    protected function ensureStringTypeForSizeRules($fieldName, $rules)
+    {
+        if (!isset($this->rules[$fieldName])) {
+            return;
+        }
+
+        $hasSizeRule = !empty($rules['max']['value']) || !empty($rules['min']['value']);
+        $hasNumericRule = !empty($rules['numeric']['value']);
+
+        if ($hasSizeRule && !$hasNumericRule && !is_array($this->getFieldValue())) {
+            $this->rules[$fieldName] = 'string|' . $this->rules[$fieldName];
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed phone/text field validation where numeric-looking input (e.g. "123456") was compared as a numeric value instead of string length for max/min rules
- Fixed empty validation messages when global settings exist but specific message keys are missing from saved data

## Changes
- `app/Helpers/Traits/GlobalDefaultMessages.php` — Added `else` fallback in `getGlobalDefaultMessage()` to load defaults when a specific message key is missing from saved global settings
- `app/Services/Parser/Validations.php` — Added `ensureStringTypeForSizeRules()` to prepend `string` rule for non-numeric fields with max/min, so the WPFluent validator uses `mb_strlen()` instead of numeric value comparison

## How it was happening
The WPFluent framework validator's `getSize()` method uses `is_numeric()` to decide how to evaluate max/min. Phone number "123456" is numeric-looking, so the validator compared value 123456 > 20 (fails) instead of string length 6 <= 20 (should pass).

## Test plan
- [ ] Enter numeric-looking input (e.g. "123456") in phone field with max validation — should validate by character length, not numeric value
- [ ] Enter text input (e.g. "abcdef") in text field with max validation — should validate by character length
- [ ] Verify numeric fields (input_number) still validate by numeric value
- [ ] Verify checkbox/multi-select fields with max still validate by selection count
- [ ] Verify validation error messages are not empty on fresh installs or after saving global settings

Related issue: https://support.wpmanageninja.com/#/tickets/156127/view