### PR TITLE
Fix: Add opt-in legacy HMAC fallback for pre-v6.2.0 encrypted tokens

### DIFF
--- a/app/Helpers/Protector.php
+++ b/app/Helpers/Protector.php
@@ -73,10 +73,20 @@ class Protector
 
         $ciphertext_raw = substr($c, $ivlen + $sha2len);
 
+        // Verify with current HMAC (IV + ciphertext)
         $calcmac = hash_hmac('sha256', $iv . $ciphertext_raw, $key, $as_binary = true);
 
         if (!hash_equals($hmac, $calcmac)) {
-            return null;
+            // Fallback: verify with legacy HMAC (ciphertext only) for tokens generated before v6.2.0 IV authentication fix.
+            if (!apply_filters('fluentform/allow_legacy_token_decrypt', false)) {
+                return null;
+            }
+
+            $legacymac = hash_hmac('sha256', $ciphertext_raw, $key, $as_binary = true);
+
+            if (!hash_equals($hmac, $legacymac)) {
+                return null;
+            }
         }
 
         $original_plaintext = openssl_decrypt($ciphertext_raw, $cipher, $key, $options = OPENSSL_RAW_DATA, $iv);


### PR DESCRIPTION
## Summary
- The v6.2.0 IV authentication security fix invalidated all previously generated public PDF download links
- Customers who shared links externally (Google Sheets, emails) cannot regenerate them
- Added a legacy HMAC fallback in `Protector::decrypt()` that is **OFF by default**

## How it works
1. New tokens (v6.2.0+) use secure `hash(IV + ciphertext)` — no change
2. When modern HMAC fails, checks `fluentform/allow_legacy_token_decrypt` filter (default `false`)
3. If opted-in, tries legacy `hash(ciphertext)` verification
4. Tampered tokens still fail both checks

## Opt-in usage
Site admins add this to their theme's `functions.php` or a custom plugin:
```php
add_filter('fluentform/allow_legacy_token_decrypt', '__return_true');
```

## Security notes
- Default OFF — no security impact unless explicitly enabled
- New `encrypt()` always uses secure IV-authenticated HMAC
- Legacy fallback is a conscious tradeoff for sites with existing shared links
- Should be removed in a future major version

## Test plan
- [ ] Generate a PDF download link in v6.1.x, update to v6.2.0+ — link should fail (default behavior preserved)
- [ ] Enable filter — old link should work
- [ ] Generate new link in v6.2.0+ — should work regardless of filter setting
- [ ] Tampered/invalid tokens should fail with or without filter enabled

Related issue: https://support.wpmanageninja.com/#/tickets/156120/view