### PR TITLE
Fix: All entries search bypassing ACL and filters

### DIFF
--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -96,7 +96,7 @@ class Submission extends Model
         return $this->hasMany(OrderItem::class, 'submission_id', 'id');
     }
 
-    public function customQuery($attributes = [])
+    public function customQuery($attributes = [], $searchExtender = null)
     {
         $entryType = Arr::get($attributes, 'entry_type');
         $dateRange = Arr::get($attributes, 'date_range');
@@ -145,14 +145,17 @@ class Submission extends Model
                 return $q->where('fluentform_submissions.created_at', '>=', $startDate)
                     ->where('fluentform_submissions.created_at', '<=', $endDate);
             })
-            ->when($search, function ($q) use ($search) {
+            ->when($search, function ($q) use ($search, $searchExtender) {
                 global $wpdb;
                 $escaped = $wpdb->esc_like($search);
-                return $q->where(function ($q) use ($escaped) {
-                    return $q->where('fluentform_submissions.id', 'LIKE', "%{$escaped}%")
+                return $q->where(function ($q) use ($escaped, $searchExtender) {
+                    $q->where('fluentform_submissions.id', 'LIKE', "%{$escaped}%")
                         ->orWhere('response', 'LIKE', "%{$escaped}%")
                         ->orWhere('fluentform_submissions.status', 'LIKE', "%{$escaped}%")
                         ->orWhere('fluentform_submissions.created_at', 'LIKE', "%{$escaped}%");
+                    if ($searchExtender) {
+                        $searchExtender($q, $escaped);
+                    }
                 });
             })
             ->when($wheres, function ($q) use ($wheres) {
@@ -297,8 +300,12 @@ class Submission extends Model
     }
 
     public function allSubmissions($attributes = []) {
-        $customQuery = $this->customQuery($attributes);
-        $search = Arr::get($attributes, 'search');
+        $searchExtender = function ($q, $escaped) {
+            $q->orWhereHas('form', function ($q) use ($escaped) {
+                $q->where('title', 'LIKE', "%{$escaped}%");
+            });
+        };
+        $customQuery = $this->customQuery($attributes, $searchExtender);
         $allowFormIds = FormManagerService::getUserAllowedForms();
 
         $result = $customQuery
@@ -310,13 +317,6 @@ class Submission extends Model
             ->select(['id', 'form_id', 'status', 'created_at', 'browser', 'currency', 'total_paid'])
             ->when($allowFormIds, function ($q) use ($allowFormIds){
                 return $q->whereIn('form_id', $allowFormIds);
-            })
-            ->when($search, function ($q) use ($search){
-                global $wpdb;
-                $escaped = $wpdb->esc_like($search);
-                return $q->orWhereHas('form', function ($q) use ($escaped) {
-                    return $q->orWhere('title', 'LIKE', "%{$escaped}%");
-                });
             })
             ->paginate()
             ->toArray();


### PR DESCRIPTION
## Summary
- Fixed entries search on the All Entries page where `orWhereHas` at the top level of the query bypassed form ACL restrictions and all other filters (status, date range, entry type)
- Form title search now works correctly within the grouped search clause
- Added `$searchExtender` callback parameter to `customQuery()` for extensible search

## Why this happened

The original `allSubmissions()` code used `orWhereHas('form', ...)` directly in the query chain:

```php
->when($search, function ($q) use ($search){
    return $q->orWhereHas('form', function ($q) use ($escaped) {
        return $q->orWhere('title', 'LIKE', "%{$escaped}%");
    });
})
```

This produced SQL like:
```sql
WHERE (status != 'trashed')
AND form_id IN (1,2,3)        -- ACL
AND (id LIKE ... OR response LIKE ...)  -- customQuery search
OR EXISTS (... title LIKE ...)  -- BYPASSES EVERYTHING ABOVE
```

The top-level `OR` meant any form title match bypassed the ACL `whereIn`, status filter, and date range filter entirely.

## How it was fixed

Added a `$searchExtender` callback parameter to `customQuery()` that injects additional search conditions **inside** the existing grouped `where(function)` closure:

```php
// customQuery() now accepts an optional search extender
public function customQuery($attributes = [], $searchExtender = null)

// allSubmissions() passes form title search as the extender
$searchExtender = function ($q, $escaped) {
    $q->orWhereHas('form', function ($q) use ($escaped) {
        $q->where('title', 'LIKE', "%{$escaped}%");
    });
};
$customQuery = $this->customQuery($attributes, $searchExtender);
```

This produces correct SQL:
```sql
WHERE (status != 'trashed')
AND form_id IN (1,2,3)        -- ACL preserved
AND (                          -- all ORs safely grouped
    id LIKE '%search%'
    OR response LIKE '%search%'
    OR status LIKE '%search%'
    OR created_at LIKE '%search%'
    OR EXISTS (... title LIKE '%search%')
)
```

## Breaking changes
None. The `$searchExtender` parameter defaults to `null`. All existing callers of `customQuery()` (`paginateEntries`, `findAdjacentSubmission`, `TransferService`) pass only 1 argument and are unaffected.

## Test plan
- [ ] Search by submission content on All Entries page — should return matching entries
- [ ] Search by form title on All Entries page — should return entries from matching forms
- [ ] Search should respect date range filter (default: last month)
- [ ] Search should respect form ACL — restricted users should only see entries from allowed forms
- [ ] Per-form entries page search should work unchanged (doesn't use extender)
- [ ] Entry export search should work unchanged

Related issue: https://support.wpmanageninja.com/#/tickets/156112/view