### PR TITLE
Fix: Move compliance retention to free

### DIFF
--- a/app/Hooks/actions.php
+++ b/app/Hooks/actions.php
@@ -75,6 +75,10 @@ add_action('init', function () {
     new \FluentForm\App\Modules\Form\DefaultStyleApplicator();
 }, 9);
 
+$app->addAction('fluentform/loaded', function () {
+    (new \FluentForm\App\Services\Compliance\ComplianceService())->register();
+});
+
 // From Backend.php
 add_action('admin_init', function () use ($app) {
     (new \FluentForm\App\Modules\Registerer\Menu($app))->reisterScripts();

--- a/app/Models/Form.php
+++ b/app/Models/Form.php
@@ -200,6 +200,8 @@ class Form extends Model
                 'asteriskPlacement'     => 'asterisk-right',
             ],
             'delete_entry_on_submission'         => 'no',
+            'delete_after_x_days'                => 'no',
+            'auto_delete_days'                   => null,
             'conv_form_per_step_save'            => false,
             'conv_form_resume_from_last_step'    => false
         ];

--- a/app/Modules/Form/Form.php
+++ b/app/Modules/Form/Form.php
@@ -228,6 +228,8 @@ class Form
                 'asteriskPlacement'     => 'asterisk-right'
             ],
             'delete_entry_on_submission' => 'no',
+            'delete_after_x_days'        => 'no',
+            'auto_delete_days'           => null,
         ];
 
         if ($formId) {

--- a/app/Modules/Form/Settings/FormSettings.php
+++ b/app/Modules/Form/Settings/FormSettings.php
@@ -140,6 +140,8 @@ class FormSettings
             'errorMessagePlacement'           => 'sanitize_text_field',
             'asteriskPlacement'               => 'sanitize_text_field',
             'delete_entry_on_submission'      => 'sanitize_text_field',
+            'delete_after_x_days'             => 'sanitize_text_field',
+            'auto_delete_days'                => 'intval',
             'id'                              => 'intval',
             'showLabel'                       => 'rest_sanitize_boolean',
             'showCount'                       => 'rest_sanitize_boolean',

--- a/app/Modules/Form/Settings/FormSettings.php
+++ b/app/Modules/Form/Settings/FormSettings.php
@@ -172,7 +172,7 @@ class FormSettings
         $deleteDaysCount = ArrayHelper::get($formSettings, 'auto_delete_days');
         $deleteOnSubmission = ArrayHelper::get($formSettings, 'delete_entry_on_submission');
 
-        if ('yes' != $deleteOnSubmission && $deleteDaysCount && 'yes' == $deleteAfterXDaysStatus) {
+        if ('yes' != $deleteOnSubmission && $deleteDaysCount && in_array($deleteAfterXDaysStatus, ['yes', '1', 1, true], true)) {
             // We have to set meta values
             $form->updateMeta($formId, 'auto_delete_days', intval($deleteDaysCount));
         } else {

--- a/app/Services/Compliance/ComplianceService.php
+++ b/app/Services/Compliance/ComplianceService.php
@@ -2,7 +2,10 @@
 
 namespace FluentForm\App\Services\Compliance;
 
+use FluentForm\App\Models\Form;
+use FluentForm\App\Services\FormBuilder\FormFieldsParser;
 use FluentForm\App\Services\Submission\SubmissionService;
+use FluentForm\Framework\Support\Arr;
 
 class ComplianceService
 {
@@ -19,7 +22,9 @@ class ComplianceService
     public function maybeDeleteOldEntries()
     {
         $autoDeleteFormMetas = wpFluent()->table('fluentform_form_meta')
+            ->select(['id', 'form_id', 'value'])
             ->where('meta_key', 'auto_delete_days')
+            ->orderBy('id', 'DESC')
             ->get();
 
         if (!$autoDeleteFormMetas || !count($autoDeleteFormMetas)) {
@@ -27,8 +32,16 @@ class ComplianceService
         }
 
         $formGroups = [];
+        $processedForms = [];
 
         foreach ($autoDeleteFormMetas as $meta) {
+            $formId = absint($meta->form_id);
+
+            if (!$formId || isset($processedForms[$formId])) {
+                continue;
+            }
+
+            $processedForms[$formId] = true;
             $delayDays = absint($meta->value);
 
             if (!$delayDays) {
@@ -39,7 +52,7 @@ class ComplianceService
                 $formGroups[$delayDays] = [];
             }
 
-            $formGroups[$delayDays][] = absint($meta->form_id);
+            $formGroups[$delayDays][] = $formId;
         }
 
         if (!$formGroups) {
@@ -88,20 +101,54 @@ class ComplianceService
                 }
 
                 foreach ($entriesByForm as $formId => $submissionIds) {
-                    $this->deleteAttachments($submissionService, $submissionIds, $formId);
+                    $attachmentFields = $this->getAttachmentFields($formId);
+                    $this->deleteAttachments($submissionIds, $attachmentFields, $formId);
                     $submissionService->deleteEntries($submissionIds, $formId);
                 }
             }
         }
     }
 
-    private function deleteAttachments(SubmissionService $submissionService, $submissionIds, $formId)
+    private function getAttachmentFields($formId)
+    {
+        static $attachmentFields = [];
+
+        if (isset($attachmentFields[$formId])) {
+            return $attachmentFields[$formId];
+        }
+
+        $form = Form::find($formId);
+
+        if (!$form) {
+            $attachmentFields[$formId] = [];
+            return $attachmentFields[$formId];
+        }
+
+        $fields = FormFieldsParser::getAttachmentInputFields($form, ['element', 'attributes']);
+        $attachmentFields[$formId] = $fields ? Arr::pluck($fields, 'attributes.name') : [];
+
+        return $attachmentFields[$formId];
+    }
+
+    private function deleteAttachments($submissionIds, $attachmentFields, $formId)
     {
         if (apply_filters('fluentform/disable_attachment_delete', false, $formId)) {
             return;
         }
 
-        $deletables = $submissionService->getAttachments($submissionIds, $formId);
+        $deletables = [];
+
+        if ($attachmentFields) {
+            $submissions = wpFluent()->table('fluentform_submissions')
+                ->whereIn('id', (array) $submissionIds)
+                ->get();
+
+            foreach ($submissions as $submission) {
+                $response = json_decode($submission->response, true);
+                $files = Arr::collapse(Arr::only($response, $attachmentFields));
+                $deletables = array_merge($deletables, $files);
+            }
+        }
 
         foreach ($deletables as $file) {
             $file = wp_upload_dir()['basedir'] . FLUENTFORM_UPLOAD_DIR . '/' . basename($file);

--- a/app/Services/Compliance/ComplianceService.php
+++ b/app/Services/Compliance/ComplianceService.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace FluentForm\App\Services\Compliance;
+
+use FluentForm\App\Services\Submission\SubmissionService;
+
+class ComplianceService
+{
+    public function register()
+    {
+        // Pro already registers its own retention handler on the same cron hook.
+        if (defined('FLUENTFORMPRO')) {
+            return;
+        }
+
+        add_action('fluentform_do_email_report_scheduled_tasks', [$this, 'maybeDeleteOldEntries']);
+    }
+
+    public function maybeDeleteOldEntries()
+    {
+        $autoDeleteFormMetas = wpFluent()->table('fluentform_form_meta')
+            ->where('meta_key', 'auto_delete_days')
+            ->get();
+
+        if (!$autoDeleteFormMetas || !count($autoDeleteFormMetas)) {
+            return;
+        }
+
+        $formGroups = [];
+
+        foreach ($autoDeleteFormMetas as $meta) {
+            $delayDays = absint($meta->value);
+
+            if (!$delayDays) {
+                continue;
+            }
+
+            if (!isset($formGroups[$delayDays])) {
+                $formGroups[$delayDays] = [];
+            }
+
+            $formGroups[$delayDays][] = absint($meta->form_id);
+        }
+
+        if (!$formGroups) {
+            return;
+        }
+
+        $submissionService = new SubmissionService();
+
+        foreach ($formGroups as $delayDays => $formIds) {
+            $formIds = array_filter(array_unique($formIds));
+
+            if (!$formIds) {
+                continue;
+            }
+
+            // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Plugin uses local timezone for scheduled retention
+            $date = date('Y-m-d H:i:s', (time() - $delayDays * DAY_IN_SECONDS));
+
+            $oldEntries = wpFluent()->table('fluentform_submissions')
+                ->select(['id', 'form_id'])
+                ->whereIn('form_id', $formIds)
+                ->where('created_at', '<', $date)
+                ->limit(100)
+                ->get();
+
+            if (!$oldEntries || !count($oldEntries)) {
+                continue;
+            }
+
+            $entriesByForm = [];
+
+            foreach ($oldEntries as $entry) {
+                $formId = absint($entry->form_id);
+                $entryId = absint($entry->id);
+
+                if (!$formId || !$entryId) {
+                    continue;
+                }
+
+                if (!isset($entriesByForm[$formId])) {
+                    $entriesByForm[$formId] = [];
+                }
+
+                $entriesByForm[$formId][] = $entryId;
+            }
+
+            foreach ($entriesByForm as $formId => $submissionIds) {
+                $this->deleteAttachments($submissionService, $submissionIds, $formId);
+                $submissionService->deleteEntries($submissionIds, $formId);
+            }
+        }
+    }
+
+    private function deleteAttachments(SubmissionService $submissionService, $submissionIds, $formId)
+    {
+        if (apply_filters('fluentform/disable_attachment_delete', false, $formId)) {
+            return;
+        }
+
+        $deletables = $submissionService->getAttachments($submissionIds, $formId);
+
+        foreach ($deletables as $file) {
+            $file = wp_upload_dir()['basedir'] . FLUENTFORM_UPLOAD_DIR . '/' . basename($file);
+
+            if (is_readable($file) && !is_dir($file)) {
+                wp_delete_file($file);
+            }
+        }
+
+        $tempDir = wp_upload_dir()['basedir'] . FLUENTFORM_UPLOAD_DIR . '/temp/';
+        $files = glob($tempDir . '*');
+        if (!empty($files)) {
+            foreach ($files as $file) {
+                if (basename($file) !== 'index.php') {
+                    wp_delete_file($file);
+                }
+            }
+        }
+    }
+}

--- a/app/Services/Compliance/ComplianceService.php
+++ b/app/Services/Compliance/ComplianceService.php
@@ -73,7 +73,7 @@ class ComplianceService
 
             while (true) {
                 $oldEntries = wpFluent()->table('fluentform_submissions')
-                    ->select(['id', 'form_id'])
+                    ->select(['id', 'form_id', 'response'])
                     ->whereIn('form_id', $formIds)
                     ->where('created_at', '<', $date)
                     ->limit(100)
@@ -97,12 +97,13 @@ class ComplianceService
                         $entriesByForm[$formId] = [];
                     }
 
-                    $entriesByForm[$formId][] = $entryId;
+                    $entriesByForm[$formId][] = $entry;
                 }
 
-                foreach ($entriesByForm as $formId => $submissionIds) {
+                foreach ($entriesByForm as $formId => $submissions) {
                     $attachmentFields = $this->getAttachmentFields($formId);
-                    $this->deleteAttachments($submissionIds, $attachmentFields, $formId);
+                    $submissionIds = Arr::pluck($submissions, 'id');
+                    $this->deleteAttachments($submissions, $attachmentFields, $formId);
                     $submissionService->deleteEntries($submissionIds, $formId);
                 }
             }
@@ -130,7 +131,7 @@ class ComplianceService
         return $attachmentFields[$formId];
     }
 
-    private function deleteAttachments($submissionIds, $attachmentFields, $formId)
+    private function deleteAttachments($submissions, $attachmentFields, $formId)
     {
         if (apply_filters('fluentform/disable_attachment_delete', false, $formId)) {
             return;
@@ -139,10 +140,6 @@ class ComplianceService
         $deletables = [];
 
         if ($attachmentFields) {
-            $submissions = wpFluent()->table('fluentform_submissions')
-                ->whereIn('id', (array) $submissionIds)
-                ->get();
-
             foreach ($submissions as $submission) {
                 $response = json_decode($submission->response, true);
                 $files = Arr::collapse(Arr::only($response, $attachmentFields));

--- a/app/Services/Compliance/ComplianceService.php
+++ b/app/Services/Compliance/ComplianceService.php
@@ -58,37 +58,39 @@ class ComplianceService
             // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date -- Plugin uses local timezone for scheduled retention
             $date = date('Y-m-d H:i:s', (time() - $delayDays * DAY_IN_SECONDS));
 
-            $oldEntries = wpFluent()->table('fluentform_submissions')
-                ->select(['id', 'form_id'])
-                ->whereIn('form_id', $formIds)
-                ->where('created_at', '<', $date)
-                ->limit(100)
-                ->get();
+            while (true) {
+                $oldEntries = wpFluent()->table('fluentform_submissions')
+                    ->select(['id', 'form_id'])
+                    ->whereIn('form_id', $formIds)
+                    ->where('created_at', '<', $date)
+                    ->limit(100)
+                    ->get();
 
-            if (!$oldEntries || !count($oldEntries)) {
-                continue;
-            }
-
-            $entriesByForm = [];
-
-            foreach ($oldEntries as $entry) {
-                $formId = absint($entry->form_id);
-                $entryId = absint($entry->id);
-
-                if (!$formId || !$entryId) {
-                    continue;
+                if (!$oldEntries || !count($oldEntries)) {
+                    break;
                 }
 
-                if (!isset($entriesByForm[$formId])) {
-                    $entriesByForm[$formId] = [];
+                $entriesByForm = [];
+
+                foreach ($oldEntries as $entry) {
+                    $formId = absint($entry->form_id);
+                    $entryId = absint($entry->id);
+
+                    if (!$formId || !$entryId) {
+                        continue;
+                    }
+
+                    if (!isset($entriesByForm[$formId])) {
+                        $entriesByForm[$formId] = [];
+                    }
+
+                    $entriesByForm[$formId][] = $entryId;
                 }
 
-                $entriesByForm[$formId][] = $entryId;
-            }
-
-            foreach ($entriesByForm as $formId => $submissionIds) {
-                $this->deleteAttachments($submissionService, $submissionIds, $formId);
-                $submissionService->deleteEntries($submissionIds, $formId);
+                foreach ($entriesByForm as $formId => $submissionIds) {
+                    $this->deleteAttachments($submissionService, $submissionIds, $formId);
+                    $submissionService->deleteEntries($submissionIds, $formId);
+                }
             }
         }
     }

--- a/app/Services/Migrator/Classes/NinjaFormsMigrator.php
+++ b/app/Services/Migrator/Classes/NinjaFormsMigrator.php
@@ -350,6 +350,7 @@ class NinjaFormsMigrator extends BaseMigrator
                             'delete_after_x_days' => true,
                             'auto_delete_days'    => $actionData['subs_expire_time'],
                         ];
+                        $formMeta['auto_delete_days'] = intval($actionData['subs_expire_time']);
                     }
                 } elseif ($actionData['type'] == 'redirect') {
                     $formMeta['formSettings']['confirmation'] = [

--- a/app/Services/Settings/SettingsService.php
+++ b/app/Services/Settings/SettingsService.php
@@ -152,6 +152,8 @@ class SettingsService
             'errorMessagePlacement'      => 'sanitize_text_field',
             'asteriskPlacement'          => 'sanitize_text_field',
             'delete_entry_on_submission' => 'sanitize_text_field',
+            'delete_after_x_days'        => 'sanitize_text_field',
+            'auto_delete_days'           => 'intval',
             'id'                         => 'intval',
             'showLabel'                  => 'rest_sanitize_boolean',
             'showCount'                  => 'rest_sanitize_boolean',

--- a/app/Services/Settings/SettingsService.php
+++ b/app/Services/Settings/SettingsService.php
@@ -97,7 +97,7 @@ class SettingsService
         $deleteDaysCount = Arr::get($formSettings, 'auto_delete_days');
         $deleteOnSubmission = Arr::get($formSettings, 'delete_entry_on_submission');
 
-        if ('yes' != $deleteOnSubmission && $deleteDaysCount && 'yes' == $deleteAfterXDaysStatus) {
+        if ('yes' != $deleteOnSubmission && $deleteDaysCount && in_array($deleteAfterXDaysStatus, ['yes', '1', 1, true], true)) {
             // We have to set meta values
             FormMeta::persist($formId, 'auto_delete_days', $deleteDaysCount);
         } else {

--- a/resources/assets/admin/components/settings/FormSettings.vue
+++ b/resources/assets/admin/components/settings/FormSettings.vue
@@ -531,6 +531,70 @@
                     </card-body>
                 </card>
 
+                <!-- Compliance Settings -->
+                <card id="compliance-settings">
+                    <card-head>
+                        <card-head-group>
+                            <h5 class="title">{{ $t('Compliance Settings') }}</h5>
+                            <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
+                                <div slot="content">
+                                    <p>
+                                        {{ $t('If you enable this settings then your entry data will be deleted from database. It\'s useful for HIPPA/GDPR Compliance for some forms.') }}
+                                    </p>
+                                </div>
+
+                                <i class="ff-icon ff-icon-info-filled text-primary ml-1"></i>
+                            </el-tooltip>
+                        </card-head-group>
+                    </card-head>
+                    <card-body>
+                        <el-checkbox true-label="yes" false-label="no"
+                                     v-model="formSettings.delete_entry_on_submission">
+                            {{$t('Delete entry data after form submission')}}
+                        </el-checkbox>
+
+                        <p class="mt-3" v-if="formSettings.delete_entry_on_submission == 'yes'">
+                            {{
+                                $t('Your data will be deleted on form submission so no entry data, analytics and visual reporting will be available for this form')
+                            }}
+                        </p>
+
+                        <div v-if="formSettings.delete_entry_on_submission != 'yes'" class="ff_auto_delete_section mt-3">
+                            <el-checkbox
+                                true-label="yes"
+                                false-label="no"
+                                v-model="formSettings.delete_after_x_days"
+                            >
+                                {{ $t('Enable auto delete old entries') }}
+                            </el-checkbox>
+
+                            <div v-if="formSettings.delete_after_x_days == 'yes'" class="el-form--label-top mt-3">
+                                <div class="el-form-item ff-form-item">
+                                    <label class="el-form-item__label">
+                                        {{ $t('Specify how many days old entries will be deleted for this form') }}
+                                    </label>
+                                    <div class="el-form-item__content">
+                                        <el-input-number :min="1" v-model="formSettings.auto_delete_days"/>
+                                    </div>
+                                    <p
+                                        class="mt-2 text-danger"
+                                        v-if="formSettings.auto_delete_days"
+                                        v-html="
+                                            $t(
+                                                'Entries older than %s%s days%s will be deleted automatically.',
+                                                '<b>',
+                                                formSettings.auto_delete_days,
+                                                '</b>'
+                                            )
+                                        "
+                                    >
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </card-body>
+                </card>
+
                 <!-- Advanced form validation -->
                 <card id="advanced-form-validation">
                     <card-head>
@@ -569,72 +633,6 @@
                     <card-body>
                         <survey-result v-if="hasPro" :data="formSettings.appendSurveyResult" :hasPro="hasPro"/>
                         <update-to-pro-content v-else :update-message="$t('Survey Result is available in the pro version')" />
-                    </card-body>
-                </card>
-
-                <!-- Compliance Settings -->
-                <card id="compliance-settings">
-                    <card-head>
-                        <card-head-group>
-                            <h5 class="title">{{ $t('Compliance Settings') }}</h5>
-                            <el-tooltip class="item" placement="bottom-start" popper-class="ff_tooltip_wrap">
-                                <div slot="content">
-                                    <p>
-                                        {{ $t('If you enable this settings then your entry data will be deleted from database. It\'s useful for HIPPA/GDPR Compliance for some forms.') }}
-                                    </p>
-                                </div>
-
-                                <i class="ff-icon ff-icon-info-filled text-primary ml-1"></i>
-                            </el-tooltip>
-                        </card-head-group>
-                    </card-head>
-                    <card-body>
-                        <el-checkbox v-if="hasPro" true-label="yes" false-label="no"
-                            v-model="formSettings.delete_entry_on_submission">
-                            {{$t('Delete entry data after form submission')}}
-                        </el-checkbox>
-
-                        <p class="mt-3" v-if="formSettings.delete_entry_on_submission == 'yes'">
-                            {{
-                                $t('Your data will be deleted on form submission so no entry data, analytics and visual reporting will be available for this form')
-                            }}
-                        </p>
-
-                        <div v-if="formSettings.delete_entry_on_submission != 'yes'" class="ff_auto_delete_section mt-3">
-                            <el-checkbox
-                                v-if="hasPro"
-                                true-label="yes"
-                                false-label="no"
-                                v-model="formSettings.delete_after_x_days"
-                            >
-                                {{ $t('Enable auto delete old entries') }}
-                            </el-checkbox>
-
-                            <div v-if="formSettings.delete_after_x_days == 'yes'" class="el-form--label-top mt-3">
-                                <div class="el-form-item ff-form-item">
-                                    <label class="el-form-item__label">
-                                        {{ $t('Specify how many days old entries will be deleted for this form') }}
-                                    </label>
-                                    <div class="el-form-item__content">
-                                        <el-input-number :min="1" v-model="formSettings.auto_delete_days"/>
-                                    </div>
-                                    <p
-                                        class="mt-2 text-danger"
-                                        v-if="formSettings.auto_delete_days"
-                                        v-html="
-                                            $t(
-                                                'Entries older than %s%s days%s will be deleted automatically.',
-                                                '<b>',
-                                                formSettings.auto_delete_days,
-                                                '</b>'
-                                            )
-                                        "
-                                    >
-                                    </p>
-                                </div>
-                            </div>
-                        </div>
-                        <update-to-pro-content  v-if="!hasPro" :update-message="$t('Compliance Settings is available in the pro version')" />
                     </card-body>
                 </card>
 
@@ -940,7 +938,10 @@
                         helpMessagePlacement: 'with_label',
                         errorMessagePlacement: 'inline',
                         cssClassName: ''
-                    }
+                    },
+                    delete_entry_on_submission: 'no',
+                    delete_after_x_days: 'no',
+                    auto_delete_days: null
                 }
             },
             fetchSettings() {
@@ -949,7 +950,8 @@
                 FluentFormsGlobal.$rest.get(url)
                     .then(response => {
                         if (response.generalSettings) {
-                            let settings = response.generalSettings;
+                            this.setDefaultSettings();
+                            let settings = _ff.merge({}, this.formSettings, response.generalSettings);
                             if (!settings.confirmation)
                                 settings.confirmation = {};
                             if (!settings.restrictions)


### PR DESCRIPTION
## What does this PR do and why?

Moves form-level compliance retention into the free plugin by exposing the compliance settings UI, persisting the retention values in free, and adding a free-side scheduled cleanup handler. The implementation keeps compatibility with Pro by avoiding duplicate retention registration when Pro is active.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — app/Services/Compliance/ComplianceService.php: adds scheduled cleanup for auto_delete_days and attachment cleanup for the free retention flow
- [x] PHP — app/Hooks/actions.php, app/Models/Form.php, app/Modules/Form/Form.php, app/Modules/Form/Settings/FormSettings.php, app/Services/Settings/SettingsService.php: wires the feature into free and aligns legacy/default settings paths
- [x] Vue — resources/assets/admin/components/settings/FormSettings.vue: enables compliance retention controls in free and initializes the related state keys

## How to test

1. In the free plugin, open a form settings page and enable Compliance Settings with auto delete old entries.
2. Save settings and confirm the values persist after reload.
3. Create entries older than the configured delay and run the scheduled retention hook.
4. Verify old entries and uploaded files for those entries are removed in free-only mode.
5. Activate Pro and verify the same form still uses Pro handling without duplicate cleanup behavior.

## Anything the reviewer should know?

- npm run production passed during verification.
- The free repo commit does not include vendor autoload artifacts or unrelated build output.