### PR TITLE
Fix: Fallback to form instance AJAX URL when global vars are missing

### DIFF
--- a/app/Modules/Component/Component.php
+++ b/app/Modules/Component/Component.php
@@ -724,6 +724,7 @@ class Component
 
         $form_vars = [
             'id'               => $form->id,
+            'ajaxUrl'          => admin_url('admin-ajax.php'),
             'settings'         => $formSettings,
             'form_instance'    => $instanceCssClass,
             'form_id_selector' => 'fluentform_' . $form->id,

--- a/resources/assets/public/form-submission.js
+++ b/resources/assets/public/form-submission.js
@@ -66,6 +66,10 @@ jQuery(document).ready(function () {
                 return fluentFormAppStore[formInstanceSelector];
             }
 
+            if (!fluentFormVars.ajaxUrl) {
+                fluentFormVars.ajaxUrl = form.ajaxUrl || window.ajaxurl;
+            }
+
             var formId = form.form_id_selector;
             var formSelector = '.' + formInstanceSelector;
 


### PR DESCRIPTION
## Summary

This PR prevents AJAX submission from breaking on pages where the global `fluentFormVars` block is missing.

## What Changed

- add `ajaxUrl` to the per-instance form config in `Component.php`
- update `form-submission.js` to fall back to the active form instance `ajaxUrl` when `fluentFormVars.ajaxUrl` is unavailable

## Why

Some pages can render the form instance config but miss the global `fluentFormVars` object. In that state, submission JS can fail when it tries to build the AJAX request URL from the missing global config.

Using the per-instance form config keeps the normal path unchanged while allowing submission to proceed when the global vars block is absent.

## Related Issue

- https://support.wpmanageninja.com/#/tickets/156493/view
