### PR TITLE
Fix: Preserve duplicate option defaults across editor and frontend

### DIFF
--- a/app/Hooks/filters.php
+++ b/app/Hooks/filters.php
@@ -212,14 +212,14 @@ foreach ($fluentformElements as $fluentformElement) {
         }
 
         if ($response && ($isHtml || defined('FLUENTFORM_RENDERING_ENTRIES')) && in_array($element, ['select', 'input_radio']) && !is_array($response)) {
-            if (!isset($field['options'])) {
-                $field['options'] = [];
-                foreach (\FluentForm\Framework\Helpers\ArrayHelper::get($field, 'raw.settings.advanced_options', []) as $option) {
-                    $field['options'][$option['value']] = $option['label'];
-                }
+            $options = \FluentForm\Framework\Helpers\ArrayHelper::get($field, 'raw.settings.advanced_options', []);
+
+            if (!$options) {
+                $options = isset($field['options']) ? $field['options'] : [];
             }
-            if (isset($field['options'][$response])) {
-                return $field['options'][$response];
+
+            if ($label = \FluentForm\App\Modules\Form\FormDataParser::getOptionLabelByValue($options, $response)) {
+                return $label;
             }
         }
 

--- a/app/Modules/Form/FormDataParser.php
+++ b/app/Modules/Form/FormDataParser.php
@@ -328,12 +328,7 @@ class FormDataParser
                 $values && is_array($values) &&
                 $options = ArrayHelper::get($field, 'raw.settings.advanced_options', [])
             ) {
-                $options = array_column($options, 'label', 'value');
-                foreach ($values as &$value) {
-                    if ($label = ArrayHelper::get($options, $value)) {
-                        $value = $label;
-                    }
-                }
+                $values = static::mapOptionValuesToLabels($values, $options);
             }
             return self::formatValue($values);
         }
@@ -347,22 +342,63 @@ class FormDataParser
         }
 
         if (!isset($field['options'])) {
-            $field['options'] = [];
-            foreach (ArrayHelper::get($field, 'raw.settings.advanced_options', []) as $option) {
-                $field['options'][$option['value']] = $option['label'];
-            }
+            $field['options'] = ArrayHelper::get($field, 'raw.settings.advanced_options', []);
         }
 
+        $optionValueCounts = [];
         $html = '<ul style="white-space: normal;">';
         foreach ($values as $value) {
             $item = $value;
-            if ($itemLabel = ArrayHelper::get($field, 'options.' . $item)) {
+            $optionValue = (string) $value;
+            $optionValueCounts[$optionValue] = ($optionValueCounts[$optionValue] ?? 0) + 1;
+
+            if ($itemLabel = static::getOptionLabelByValue($field['options'], $value, $optionValueCounts[$optionValue])) {
                 $item = $itemLabel;
             }
             $html .= '<li>' . $item . '</li>';
         }
 
         return $html . '</ul>';
+    }
+
+    public static function mapOptionValuesToLabels($values, $options)
+    {
+        $optionValueCounts = [];
+
+        foreach ($values as &$value) {
+            $optionValue = (string) $value;
+            $optionValueCounts[$optionValue] = ($optionValueCounts[$optionValue] ?? 0) + 1;
+
+            if ($label = static::getOptionLabelByValue($options, $value, $optionValueCounts[$optionValue])) {
+                $value = $label;
+            }
+        }
+
+        return $values;
+    }
+
+    public static function getOptionLabelByValue($options, $value, $occurrence = 1)
+    {
+        $value = (string) $value;
+        $matchedOccurrence = 0;
+
+        foreach ($options as $optionKey => $option) {
+            if (!is_array($option)) {
+                if ((string) $optionKey !== $value) {
+                    continue;
+                }
+            } elseif ((string) ArrayHelper::get($option, 'value') !== $value) {
+                continue;
+            }
+
+            $matchedOccurrence++;
+
+            if ($matchedOccurrence === max(1, (int) $occurrence)) {
+                return is_array($option) ? ArrayHelper::get($option, 'label') : $option;
+            }
+        }
+
+        return null;
     }
 
     public static function resetData()

--- a/app/Modules/Payments/Classes/PaymentAction.php
+++ b/app/Modules/Payments/Classes/PaymentAction.php
@@ -52,6 +52,8 @@ class PaymentAction
 
     protected $couponField = [];
 
+    protected $resolvedPaymentOptionCounts = [];
+
     public function __construct($form, $insertData, $data)
     {
         $this->form = $form;
@@ -300,6 +302,7 @@ class PaymentAction
         }
 
         $data = $this->submissionData['response'];
+        $this->resolvedPaymentOptionCounts = [];
 
         foreach ($paymentInputs as $paymentInput) {
             $name = ArrayHelper::get($paymentInput, 'attributes.name');
@@ -433,6 +436,7 @@ class PaymentAction
     private function getItemFromVariables($item, $key)
     {
         $elementName = $item['element'];
+        $parentHolder = ArrayHelper::get($item, 'attributes.name');
         $pricingOptions = ArrayHelper::get($item, 'settings.pricing_options');
         $pricingOptions = apply_filters_deprecated(
             'fluentform_payment_field_' . $elementName . '_pricing_options',
@@ -447,21 +451,31 @@ class PaymentAction
         );
         $pricingOptions = apply_filters('fluentform/payment_field_' . $elementName . '_pricing_options', $pricingOptions, $item, $this->form);
 
+        $lookupValue = sanitize_text_field((string) $key);
+        $this->resolvedPaymentOptionCounts[$parentHolder][$lookupValue] = ($this->resolvedPaymentOptionCounts[$parentHolder][$lookupValue] ?? 0) + 1;
+        $targetOccurrence = $this->resolvedPaymentOptionCounts[$parentHolder][$lookupValue];
+
         $selectedOption = [];
+        $matchedOccurrence = 0;
         foreach ($pricingOptions as $priceOption) {
             $label = sanitize_text_field($priceOption['label']);
             $value = sanitize_text_field($priceOption['value']);
-            if ($label == $key || $value == $key) {
-                $selectedOption = $priceOption;
+            if ($label == $lookupValue || $value == $lookupValue) {
+                $matchedOccurrence++;
+
+                if ($matchedOccurrence === $targetOccurrence) {
+                    $selectedOption = $priceOption;
+                    break;
+                }
             }
         }
 
-        if (!$selectedOption || empty($selectedOption['value']) || !is_numeric($selectedOption['value'])) {
+        if (empty($selectedOption['value']) || !is_numeric($selectedOption['value'])) {
             return false;
         }
 
         return [
-            'parent_holder' => ArrayHelper::get($item, 'attributes.name'),
+            'parent_holder' => $parentHolder,
             'item_name'     => $selectedOption['label'],
             'item_price'    => $selectedOption['value']
         ];

--- a/app/Modules/Payments/Components/MultiPaymentComponent.php
+++ b/app/Modules/Payments/Components/MultiPaymentComponent.php
@@ -218,7 +218,9 @@ class MultiPaymentComponent extends BaseFieldManager
         }
 
         $defaultValues = (array)$this->extractValueFromAttributes($data);
-        if ($dynamicValues = $this->extractDynamicValues($data, $form)) {
+        $dynamicValues = $this->extractDynamicValues($data, $form);
+        $hasDynamicValues = !empty($dynamicValues);
+        if ($hasDynamicValues) {
             $defaultValues = $dynamicValues;
         }
 
@@ -241,6 +243,16 @@ class MultiPaymentComponent extends BaseFieldManager
         );
 
         $formattedOptions = apply_filters('fluentform/payment_field_' . $elementName . '_pricing_options', $formattedOptions, $data, $form);
+
+        foreach ($formattedOptions as $index => &$option) {
+            $option['_ff_original_index'] = $index;
+        }
+        unset($option);
+
+        $storedDefaultOptionIds = $hasDynamicValues ? null : $this->getStoredDefaultOptionIds($data, $formattedOptions);
+        $storedDefaultOptionIndexes = $hasDynamicValues ? null : $this->getStoredDefaultOptionIndexes($data, count($formattedOptions));
+        $hasStoredDefaultOptionIds = is_array($storedDefaultOptionIds);
+        $hasStoredDefaultOptionIndexes = is_array($storedDefaultOptionIndexes);
 
         $hasImageOption = ArrayHelper::get($data, 'settings.enable_image_input');
 
@@ -280,13 +292,35 @@ class MultiPaymentComponent extends BaseFieldManager
         }
         $groupId = $this->makeElementId($data, $form);
 
+        $remainingDefaultValues = array_count_values(array_map('strval', $defaultValues));
+
         foreach ($formattedOptions as $index => $option) {
             $quantityLabel = ArrayHelper::get($option,'quantiy_label');
             if ($type == 'select') {
-                if (!$defaultValues && $index == 0) {
+                list($checked, $storedDefaultOptionIds) = $this->consumeStoredDefaultOptionId(
+                    $storedDefaultOptionIds,
+                    ArrayHelper::get($option, '_ff_option_id')
+                );
+
+                if (!$checked && !$hasStoredDefaultOptionIds && $hasStoredDefaultOptionIndexes) {
+                    list($checked, $storedDefaultOptionIndexes) = $this->consumeStoredDefaultOptionIndex(
+                        $storedDefaultOptionIndexes,
+                        ArrayHelper::get($option, '_ff_original_index', $index)
+                    );
+                }
+
+                if (!$checked && !$defaultValues && $index == 0 && !$hasStoredDefaultOptionIds && !$hasStoredDefaultOptionIndexes) {
                     $checked = true;
-                } else {
-                    $checked = in_array($option['value'], $defaultValues);
+                } elseif (!$checked && !$hasStoredDefaultOptionIds && !$hasStoredDefaultOptionIndexes) {
+                    $optionValue = (string) $option['value'];
+                    $checked = !empty($remainingDefaultValues[$optionValue]);
+                }
+
+                if ($checked && !$hasStoredDefaultOptionIds && !$hasStoredDefaultOptionIndexes) {
+                    $optionValue = (string) $option['value'];
+                    if (!empty($remainingDefaultValues[$optionValue])) {
+                        $remainingDefaultValues[$optionValue]--;
+                    }
                 }
                 $optionAtts = $this->buildAttributes([
                     'value' => $option['label'],
@@ -303,11 +337,31 @@ class MultiPaymentComponent extends BaseFieldManager
             $displayType = isset($data['settings']['display_type']) ? ' ff-el-form-check-' . $data['settings']['display_type'] : '';
             $parentClass = "ff-el-form-check{$displayType}";
 
-            if (in_array($option['value'], $defaultValues)) {
-                $data['attributes']['checked'] = true;
+            list($isDefaultOption, $storedDefaultOptionIds) = $this->consumeStoredDefaultOptionId(
+                $storedDefaultOptionIds,
+                ArrayHelper::get($option, '_ff_option_id')
+            );
+
+            if (!$isDefaultOption && !$hasStoredDefaultOptionIds && $hasStoredDefaultOptionIndexes) {
+                list($isDefaultOption, $storedDefaultOptionIndexes) = $this->consumeStoredDefaultOptionIndex(
+                    $storedDefaultOptionIndexes,
+                    ArrayHelper::get($option, '_ff_original_index', $index)
+                );
+            }
+
+            if (!$isDefaultOption && !$hasStoredDefaultOptionIds && !$hasStoredDefaultOptionIndexes) {
+                $optionValue = (string) $option['value'];
+                $isDefaultOption = !empty($remainingDefaultValues[$optionValue]);
+
+                if ($isDefaultOption) {
+                    $remainingDefaultValues[$optionValue]--;
+                }
+            }
+
+            $data['attributes']['checked'] = $isDefaultOption;
+
+            if ($isDefaultOption) {
                 $parentClass .= ' ff_item_selected';
-            } else {
-                $data['attributes']['checked'] = false;
             }
 
             if ($firstTabIndex) {

--- a/app/Services/FluentConversational/Classes/Converter/Converter.php
+++ b/app/Services/FluentConversational/Classes/Converter/Converter.php
@@ -250,6 +250,12 @@ class Converter
                 //				$question['css'] = (new \FluentConversational\Form)->getSubmitBttnStyle($field);
             } elseif ('select' === $field['element']) {
                 $question['options'] = self::getAdvancedOptions($field, $form);
+                $question['selectedOptionIds'] = self::resolveSelectedOptionIds(
+                    $field,
+                    $question['options'],
+                    $saveAndResumeData,
+                    ArrayHelper::get($question, 'name', ArrayHelper::get($question, 'id'))
+                );
                 $question['placeholder'] = self::getComponent()->replaceEditorSmartCodes(ArrayHelper::get($field, 'settings.placeholder', null), $form);
                 $question['searchable'] = ArrayHelper::get($field, 'settings.enable_select_2');
                 $isMultiple = ArrayHelper::get($field, 'attributes.multiple', false);
@@ -295,12 +301,24 @@ class Converter
                 if (in_array($type, ['checkbox', 'radio'])) {
                     $question['type'] = 'FlowFormMultipleChoiceType';
                     $question['options'] = self::getAdvancedOptions($field, $form);
+                    $question['selectedOptionIds'] = self::resolveSelectedOptionIds(
+                        $field,
+                        $question['options'],
+                        $saveAndResumeData,
+                        ArrayHelper::get($question, 'name', ArrayHelper::get($question, 'id'))
+                    );
                     if ('checkbox' == $type) {
                         $question['multiple'] = true;
                     }
                 } elseif (in_array($type, ['select', 'multi_select'])) {
                     $question['type'] = 'FlowFormDropdownType';
                     $question['options'] = self::getAdvancedOptions($field, $form);
+                    $question['selectedOptionIds'] = self::resolveSelectedOptionIds(
+                        $field,
+                        $question['options'],
+                        $saveAndResumeData,
+                        ArrayHelper::get($question, 'name', ArrayHelper::get($question, 'id'))
+                    );
                     $question['searchable'] = ArrayHelper::get($field, 'settings.enable_select_2');
                     $question['multiple'] = ArrayHelper::isTrue($field, 'attributes.multiple');
                 } else {
@@ -309,11 +327,23 @@ class Converter
                 $question['nextStepOnAnswer'] = true;
             } elseif ('input_checkbox' === $field['element']) {
                 $question['options'] = self::getAdvancedOptions($field, $form);
+                $question['selectedOptionIds'] = self::resolveSelectedOptionIds(
+                    $field,
+                    $question['options'],
+                    $saveAndResumeData,
+                    ArrayHelper::get($question, 'name', ArrayHelper::get($question, 'id'))
+                );
                 $question['multiple'] = true;
                 $question = static::hasPictureMode($field, $question);
                 $question = static::maybeAddOtherOption($field, $question);
             } elseif ('input_radio' === $field['element']) {
                 $question['options'] = self::getAdvancedOptions($field, $form);
+                $question['selectedOptionIds'] = self::resolveSelectedOptionIds(
+                    $field,
+                    $question['options'],
+                    $saveAndResumeData,
+                    ArrayHelper::get($question, 'name', ArrayHelper::get($question, 'id'))
+                );
                 $question['nextStepOnAnswer'] = true;
                 $question = static::hasPictureMode($field, $question);
                 $question = static::maybeAddOtherOption($field, $question);
@@ -542,10 +572,21 @@ class Converter
                     }
                     
                     $pricingOptions = ArrayHelper::get($field, 'settings.pricing_options');
-                    foreach ($pricingOptions as &$option) {
+                    $fieldName = ArrayHelper::get($field, 'attributes.name', 'payment_option');
+                    foreach ($pricingOptions as $index => &$option) {
+                        $option['_ff_original_index'] = $index;
+                        if (empty($option['_ff_option_id'])) {
+                            $option['_ff_option_id'] = $fieldName . '_' . $index;
+                        }
                         $option['label'] = self::getComponent()->replaceEditorSmartCodes($option['label'], $form);
                     }
                     $question['options'] = $pricingOptions;
+                    $question['selectedOptionIds'] = self::resolveSelectedOptionIds(
+                        $field,
+                        $question['options'],
+                        $saveAndResumeData,
+                        ArrayHelper::get($question, 'name', ArrayHelper::get($question, 'id'))
+                    );
                 }
                 
                 $question['is_payment_field'] = true;
@@ -1216,8 +1257,14 @@ class Converter
     private static function getAdvancedOptions($field, $form)
     {
         $options = ArrayHelper::get($field, 'settings.advanced_options', []);
-        
-        foreach ($options as &$option) {
+
+        $fieldName = ArrayHelper::get($field, 'attributes.name', 'option');
+
+        foreach ($options as $index => &$option) {
+            $option['_ff_original_index'] = $index;
+            if (empty($option['_ff_option_id'])) {
+                $option['_ff_option_id'] = $fieldName . '_' . $index;
+            }
             $option['label'] = self::getComponent()->replaceEditorSmartCodes($option['label'], $form);
         }
         
@@ -1226,6 +1273,72 @@ class Converter
         }
         
         return $options;
+    }
+
+    private static function resolveSelectedOptionIds($field, $options, $saveAndResumeData, $questionKey)
+    {
+        $savedOptionIds = ArrayHelper::get($saveAndResumeData, 'response.__ff_selected_option_ids');
+
+        if (is_string($savedOptionIds)) {
+            $decodedOptionIds = json_decode($savedOptionIds, true);
+
+            if (json_last_error() === JSON_ERROR_NONE) {
+                $savedOptionIds = $decodedOptionIds;
+            }
+        }
+
+        if (is_array($savedOptionIds) && isset($savedOptionIds[$questionKey]) && is_array($savedOptionIds[$questionKey])) {
+            $savedMatches = array_values(array_filter(array_map('strval', $savedOptionIds[$questionKey]), function ($optionId) use ($options) {
+                foreach ($options as $option) {
+                    if ((string) ArrayHelper::get($option, '_ff_option_id') === $optionId) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }));
+
+            if ($savedMatches) {
+                return $savedMatches;
+            }
+        }
+
+        $storedOptionIds = ArrayHelper::get($field, 'settings.default_value_option_ids');
+        if (is_array($storedOptionIds)) {
+            $storedMatches = array_values(array_filter(array_map('strval', $storedOptionIds), function ($optionId) use ($options) {
+                foreach ($options as $option) {
+                    if ((string) ArrayHelper::get($option, '_ff_option_id') === $optionId) {
+                        return true;
+                    }
+                }
+
+                return false;
+            }));
+
+            if ($storedMatches) {
+                return $storedMatches;
+            }
+        }
+
+        $storedIndexes = ArrayHelper::get($field, 'settings.default_value_option_indexes');
+        if (is_array($storedIndexes)) {
+            $selectedOptionIds = [];
+
+            foreach ($storedIndexes as $storedIndex) {
+                $storedIndex = intval($storedIndex);
+
+                foreach ($options as $option) {
+                    if (intval(ArrayHelper::get($option, '_ff_original_index', -1)) === $storedIndex) {
+                        $selectedOptionIds[] = (string) ArrayHelper::get($option, '_ff_option_id');
+                        break;
+                    }
+                }
+            }
+
+            return $selectedOptionIds;
+        }
+
+        return null;
     }
 
     private static function maybeAddOtherOption($field, $question)

--- a/app/Services/FormBuilder/Components/BaseComponent.php
+++ b/app/Services/FormBuilder/Components/BaseComponent.php
@@ -98,6 +98,79 @@ class BaseComponent
         }
         return $defaultValues;
     }
+
+    protected function getStoredDefaultOptionIndexes($data, $optionCount)
+    {
+        $storedIndexes = ArrayHelper::get($data, 'settings.default_value_option_indexes');
+
+        if (!is_array($storedIndexes)) {
+            return null;
+        }
+
+        $storedIndexes = array_values(array_filter(array_map('intval', $storedIndexes), function ($index) use ($optionCount) {
+            return $index >= 0 && $index < $optionCount;
+        }));
+
+        return $storedIndexes ?: null;
+    }
+
+    protected function getStoredDefaultOptionIds($data, $options)
+    {
+        $storedOptionIds = ArrayHelper::get($data, 'settings.default_value_option_ids');
+
+        if (!is_array($storedOptionIds)) {
+            return null;
+        }
+
+        $validOptionIds = [];
+
+        foreach ($storedOptionIds as $storedOptionId) {
+            $storedOptionId = (string) $storedOptionId;
+
+            foreach ($options as $option) {
+                if ((string) ArrayHelper::get($option, '_ff_option_id') === $storedOptionId) {
+                    $validOptionIds[] = $storedOptionId;
+                    break;
+                }
+            }
+        }
+
+        return $validOptionIds ?: null;
+    }
+
+    protected function consumeStoredDefaultOptionIndex($storedIndexes, $optionIndex)
+    {
+        if (!is_array($storedIndexes)) {
+            return [false, $storedIndexes];
+        }
+
+        $matchedIndex = array_search((int) $optionIndex, $storedIndexes, true);
+
+        if ($matchedIndex === false) {
+            return [false, $storedIndexes];
+        }
+
+        unset($storedIndexes[$matchedIndex]);
+
+        return [true, array_values($storedIndexes)];
+    }
+
+    protected function consumeStoredDefaultOptionId($storedOptionIds, $optionId)
+    {
+        if (!is_array($storedOptionIds)) {
+            return [false, $storedOptionIds];
+        }
+
+        $matchedIndex = array_search((string) $optionId, $storedOptionIds, true);
+
+        if ($matchedIndex === false) {
+            return [false, $storedOptionIds];
+        }
+
+        unset($storedOptionIds[$matchedIndex]);
+
+        return [true, array_values($storedOptionIds)];
+    }
     
     /**
      * Determine if the given element has conditions bound

--- a/app/Services/FormBuilder/Components/Checkable.php
+++ b/app/Services/FormBuilder/Components/Checkable.php
@@ -42,8 +42,10 @@ class Checkable extends BaseComponent
         }
 
         $defaultValues = (array) $this->extractValueFromAttributes($data);
+        $dynamicValues = $this->extractDynamicValues($data, $form);
+        $hasDynamicValues = !empty($dynamicValues);
 
-        if ($dynamicValues = $this->extractDynamicValues($data, $form)) {
+        if ($hasDynamicValues) {
             $defaultValues = $dynamicValues;
         }
 
@@ -63,6 +65,16 @@ class Checkable extends BaseComponent
                 ];
             }
         }
+
+        foreach ($formattedOptions as $index => &$option) {
+            $option['_ff_original_index'] = $index;
+        }
+        unset($option);
+
+        $storedDefaultOptionIds = $hasDynamicValues ? null : $this->getStoredDefaultOptionIds($data, $formattedOptions);
+        $storedDefaultOptionIndexes = $hasDynamicValues ? null : $this->getStoredDefaultOptionIndexes($data, count($formattedOptions));
+        $hasStoredDefaultOptionIds = is_array($storedDefaultOptionIds);
+        $hasStoredDefaultOptionIndexes = is_array($storedDefaultOptionIndexes);
 
         $hasImageOption = ArrayHelper::get($data, 'settings.enable_image_input');
 
@@ -99,11 +111,33 @@ class Checkable extends BaseComponent
 //        $elMarkup .= '<legend  style="  position: absolute;width: 1px;height: 1px;padding: 0;margin: 0;overflow: hidden;clip: rect(0, 0, 0, 0);border: 0;"  role="heading" id="legend_' . $legendId . '" class="ff-sreader-only">' . esc_attr($this->removeShortcode($data['settings']['label'])) . '</legend>';
 
         $otherInputHtml = '';
+        $remainingDefaultValues = array_count_values(array_map('strval', $defaultValues));
         foreach ($formattedOptions as $option) {
             $displayType = isset($data['settings']['display_type']) ? ' ff-el-form-check-' . $data['settings']['display_type'] : '';
             $parentClass = 'ff-el-form-check' . esc_attr($displayType) . '';
 
-            if (in_array($option['value'], $defaultValues)) {
+            list($isDefaultOption, $storedDefaultOptionIds) = $this->consumeStoredDefaultOptionId(
+                $storedDefaultOptionIds,
+                ArrayHelper::get($option, '_ff_option_id')
+            );
+
+            if (!$isDefaultOption && !$hasStoredDefaultOptionIds && $hasStoredDefaultOptionIndexes) {
+                list($isDefaultOption, $storedDefaultOptionIndexes) = $this->consumeStoredDefaultOptionIndex(
+                    $storedDefaultOptionIndexes,
+                    ArrayHelper::get($option, '_ff_original_index')
+                );
+            }
+
+            if (!$isDefaultOption && !$hasStoredDefaultOptionIds && !$hasStoredDefaultOptionIndexes) {
+                $optionValue = (string) $option['value'];
+                $isDefaultOption = !empty($remainingDefaultValues[$optionValue]);
+
+                if ($isDefaultOption) {
+                    $remainingDefaultValues[$optionValue]--;
+                }
+            }
+
+            if ($isDefaultOption) {
                 $data['attributes']['checked'] = true;
                 $parentClass .= ' ff_item_selected';
             } else {

--- a/app/Services/FormBuilder/Components/Select.php
+++ b/app/Services/FormBuilder/Components/Select.php
@@ -62,13 +62,15 @@ class Select extends BaseComponent
         }
 
         $defaultValues = (array) $this->extractValueFromAttributes($data);
+        $dynamicValues = $this->extractDynamicValues($data, $form);
+        $hasDynamicValues = !empty($dynamicValues);
 
-        if ($dynamicValues = $this->extractDynamicValues($data, $form)) {
+        if ($hasDynamicValues) {
             $defaultValues = $dynamicValues;
         }
 
         $atts = $this->buildAttributes($data['attributes']);
-        $options = $this->buildOptions($data, $defaultValues);
+        $options = $this->buildOptions($data, $defaultValues, $hasDynamicValues);
 
         $ariaRequired = 'false';
         if (ArrayHelper::get($data, 'settings.validation_rules.required.value')) {
@@ -103,7 +105,7 @@ class Select extends BaseComponent
      *
      * @return string/html [compiled options]
      */
-    protected function buildOptions($data, $defaultValues)
+    protected function buildOptions($data, $defaultValues, $hasDynamicValues = false)
     {
         if (! $formattedOptions = ArrayHelper::get($data, 'settings.advanced_options')) {
             $options = ArrayHelper::get($data, 'options', []);
@@ -117,6 +119,16 @@ class Select extends BaseComponent
             }
         }
 
+        foreach ($formattedOptions as $index => &$option) {
+            $option['_ff_original_index'] = $index;
+        }
+        unset($option);
+
+        $storedDefaultOptionIds = $hasDynamicValues ? null : $this->getStoredDefaultOptionIds($data, $formattedOptions);
+        $storedDefaultOptionIndexes = $hasDynamicValues ? null : $this->getStoredDefaultOptionIndexes($data, count($formattedOptions));
+        $hasStoredDefaultOptionIds = is_array($storedDefaultOptionIds);
+        $hasStoredDefaultOptionIndexes = is_array($storedDefaultOptionIndexes);
+
         if ('yes' == ArrayHelper::get($data, 'settings.randomize_options')) {
             shuffle($formattedOptions);
         }
@@ -127,12 +139,31 @@ class Select extends BaseComponent
         } elseif (! empty($data['attributes']['placeholder'])) {
             $opts .= '<option value="">' . wp_strip_all_tags($data['attributes']['placeholder']) . '</option>';
         }
+        $remainingDefaultValues = array_count_values(array_map('strval', $defaultValues));
+
         foreach ($formattedOptions as $option) {
-            if (in_array($option['value'], $defaultValues)) {
-                $selected = 'selected';
-            } else {
-                $selected = '';
+            list($isDefaultOption, $storedDefaultOptionIds) = $this->consumeStoredDefaultOptionId(
+                $storedDefaultOptionIds,
+                ArrayHelper::get($option, '_ff_option_id')
+            );
+
+            if (!$isDefaultOption && !$hasStoredDefaultOptionIds && $hasStoredDefaultOptionIndexes) {
+                list($isDefaultOption, $storedDefaultOptionIndexes) = $this->consumeStoredDefaultOptionIndex(
+                    $storedDefaultOptionIndexes,
+                    ArrayHelper::get($option, '_ff_original_index')
+                );
             }
+
+            if (!$isDefaultOption && !$hasStoredDefaultOptionIds && !$hasStoredDefaultOptionIndexes) {
+                $optionValue = (string) ArrayHelper::get($option, 'value');
+                $isDefaultOption = !empty($remainingDefaultValues[$optionValue]);
+
+                if ($isDefaultOption) {
+                    $remainingDefaultValues[$optionValue]--;
+                }
+            }
+
+            $selected = $isDefaultOption ? 'selected' : '';
     
             $atts = [
                 'data-calc_value'        => ArrayHelper::get($option, 'calc_value'),

--- a/resources/assets/admin/components/editor-field-settings/templates/advanced-options.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/advanced-options.vue
@@ -27,8 +27,8 @@
                                :type="optionsType"
                                name="fluentform__default-option"
                                :value="option.value"
-                               :checked="isChecked(option.value)"
-                               @change="updateDefaultOption(option)"
+                               :checked="isChecked(index)"
+                               @change="updateDefaultOption(index)"
                         >
                     </div>
 
@@ -185,6 +185,9 @@
             hasImageSupport() {
                 return this.editItem.element != 'select';
             },
+            selectedOptionIndexSet() {
+                return new Set(this.getSelectedOptionIndexes());
+            },
             valuesVisible:{
                 get() {
                     return this.editItem.settings.values_visible||false;
@@ -199,10 +202,12 @@
                 const { index, list, item } = data;
                 item.id = new Date().getTime();
                 list.splice(index, 0, item);
+                this.syncSelectionMetadata();
             },
             handleMoved(item) {
                 const { index, list } = item;
                 list.splice(index, 1);
+                this.syncSelectionMetadata();
             },
 
             updateValue(currentOption) {
@@ -262,15 +267,13 @@
                 });
 
                 this.editItem.settings.advanced_options = values;
+                this.ensureOptionIds();
+                this.syncSelectionMetadata();
                 this.bulkEditVisible = false
             },
 
-            isChecked(optVal) {
-                if (Array.isArray(this.editItem.attributes.value)) {
-                    return this.editItem.attributes.value.includes(optVal);
-                } else {
-                    return this.editItem.attributes.value == optVal;
-                }
+            isChecked(optionIndex) {
+                return this.selectedOptionIndexSet.has(optionIndex);
             },
 
             increase(index) {
@@ -294,12 +297,15 @@
                 };
 
                 options.splice(index + 1, 0, newOpt);
+                this.ensureOptionIds();
+                this.syncSelectionMetadata();
             },
 
             decrease(index) {
                 let options = this.editItem.settings.advanced_options;
                 if (options.length > 1) {
                     options.splice(index, 1);
+                    this.syncSelectionMetadata();
                 } else {
                     this.$notify.error({
                         message: 'You have to have at least one option.',
@@ -314,35 +320,147 @@
             },
 
             clear() {
-                let attributes = this.editItem.attributes;
-
-                if (attributes.type == 'checkbox' || attributes.multiple) {
-                    attributes.value = [];
-                } else {
-                    attributes.value = '';
-                }
+                this.applySelectedOptionIds([]);
                 this.$refs.defaultOptions.map(el => el.checked = false);
             },
 
-            updateDefaultOption(option) {
-                let attributes = this.editItem.attributes;
-                if (attributes.type == 'checkbox' || attributes.multiple) {
+            updateDefaultOption(optionIndex) {
+                const selectedIds = this.getSelectedOptionIds().slice();
+                const optionId = this.getOptionId(this.editItem.settings.advanced_options[optionIndex]);
+
+                if (this.isMultipleSelection()) {
                     if (event.target.checked) {
-                        attributes.value.push(option.value);
+                        if (!selectedIds.includes(optionId)) {
+                            selectedIds.push(optionId);
+                        }
                     } else {
-                        attributes.value.splice(attributes.value.indexOf(option.value), 1);
+                        const removalIndex = selectedIds.indexOf(optionId);
+
+                        if (removalIndex !== -1) {
+                            selectedIds.splice(removalIndex, 1);
+                        }
                     }
                 } else {
+                    selectedIds.splice(0, selectedIds.length);
+
                     if (event.target.checked) {
-                        attributes.value = option.value;
-                    } else {
-                        attributes.value = '';
+                        selectedIds.push(optionId);
                     }
                 }
+
+                this.applySelectedOptionIds(selectedIds);
             },
 
             createOptionsToRender() {
                 this.optionsToRender = this.editItem.settings.advanced_options;
+            },
+            generateOptionId() {
+                return 'ffo_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+            },
+            ensureOptionIds() {
+                this.editItem.settings.advanced_options.forEach((option, index) => {
+                    if (!option._ff_option_id) {
+                        this.$set(option, '_ff_option_id', this.generateOptionId() + '_' + index);
+                    }
+                });
+            },
+            getOptionId(option) {
+                if (!option._ff_option_id) {
+                    this.$set(option, '_ff_option_id', this.generateOptionId());
+                }
+
+                return String(option._ff_option_id);
+            },
+            getSelectedOptionIndexes() {
+                const optionIds = this.editItem.settings.advanced_options.map(option => this.getOptionId(option));
+
+                return this.getSelectedOptionIds()
+                    .map(optionId => optionIds.indexOf(optionId))
+                    .filter(index => index !== -1);
+            },
+            getSelectedOptionIds() {
+                const storedIds = this.getStoredSelectedOptionIds();
+
+                if (storedIds !== null) {
+                    return storedIds;
+                }
+
+                const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+                if (storedIndexes !== null) {
+                    return storedIndexes.map(index => this.getOptionId(this.editItem.settings.advanced_options[index]));
+                }
+
+                const optionValues = this.editItem.settings.advanced_options.map(option => String(option.value));
+                const remainingValues = [].concat(this.editItem.attributes.value || []).map(String);
+                const selectedIndexes = [];
+
+                remainingValues.forEach(selectedValue => {
+                    const matchedIndex = optionValues.findIndex((value, index) => {
+                        return value === selectedValue && !selectedIndexes.includes(index);
+                    });
+
+                    if (matchedIndex !== -1) {
+                        selectedIndexes.push(matchedIndex);
+                    }
+                });
+
+                return selectedIndexes.map(index => this.getOptionId(this.editItem.settings.advanced_options[index]));
+            },
+            getStoredSelectedOptionIds() {
+                if (!Array.isArray(this.editItem.settings.default_value_option_ids)) {
+                    return null;
+                }
+
+                const validIds = this.editItem.settings.default_value_option_ids
+                    .map(String)
+                    .filter(optionId => this.editItem.settings.advanced_options.some(option => this.getOptionId(option) === optionId));
+
+                return validIds.length ? validIds : null;
+            },
+            getStoredSelectedOptionIndexes() {
+                if (!Array.isArray(this.editItem.settings.default_value_option_indexes)) {
+                    return null;
+                }
+
+                const optionCount = this.editItem.settings.advanced_options.length;
+                const validIndexes = this.editItem.settings.default_value_option_indexes
+                    .map(index => parseInt(index, 10))
+                    .filter(index => !isNaN(index) && index >= 0 && index < optionCount);
+
+                return validIndexes.length ? validIndexes : null;
+            },
+            applySelectedOptionIds(selectedIds) {
+                const normalizedIds = selectedIds
+                    .map(String)
+                    .filter((optionId, index, list) => {
+                        return list.indexOf(optionId) === index && this.editItem.settings.advanced_options.some(option => this.getOptionId(option) === optionId);
+                    });
+                const optionIds = this.editItem.settings.advanced_options.map(option => this.getOptionId(option));
+                const normalizedIndexes = normalizedIds
+                    .map(optionId => optionIds.indexOf(optionId))
+                    .filter(index => index !== -1);
+
+                this.$set(this.editItem.settings, 'default_value_option_ids', normalizedIds);
+                this.$set(this.editItem.settings, 'default_value_option_indexes', normalizedIndexes);
+
+                if (this.isMultipleSelection()) {
+                    this.editItem.attributes.value = normalizedIndexes.map(index => {
+                        return this.editItem.settings.advanced_options[index].value;
+                    });
+                } else {
+                    this.editItem.attributes.value = normalizedIndexes.length
+                        ? this.editItem.settings.advanced_options[normalizedIndexes[0]].value
+                        : '';
+                }
+            },
+            syncSelectionMetadata() {
+                this.applySelectedOptionIds(this.getSelectedOptionIds());
+            },
+            isMultipleSelection() {
+                const attributes = this.editItem.attributes;
+
+                return attributes.type == 'checkbox' || attributes.multiple;
             },
             showProMessage() {
                 this.$notify.error('Images with options is available in the Pro version');
@@ -353,7 +471,9 @@
             this.createOptionsToRender();
             this.editItem.settings.advanced_options.forEach((item,i)=>{
                 item.id = i;
-            })
+            });
+            this.ensureOptionIds();
+            this.syncSelectionMetadata();
         }
     }
 </script>

--- a/resources/assets/admin/components/editor-field-settings/templates/pricing-options.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/pricing-options.vue
@@ -8,7 +8,7 @@
             />
 
             <el-radio-group
-                @change="editItem.attributes.value = ''"
+                @change="resetDefaultSelection()"
                 v-model="editItem.attributes.type"
                 size="small"
             >
@@ -75,8 +75,8 @@
                                 :type="optionsType"
                                 name="fluentform__default-option"
                                 :value="option.value"
-                                :checked="isChecked(option.value)"
-                                @change="updateDefaultOption(option)"
+                                :checked="isChecked(index)"
+                                @change="updateDefaultOption(index)"
                             />
                         </div>
 
@@ -181,6 +181,9 @@
             },
             hasImageSupport() {
                 return this.editItem.element != 'select';
+            },
+            selectedOptionIndexSet() {
+                return new Set(this.getSelectedOptionIndexes());
             }
         },
         methods: {
@@ -188,16 +191,16 @@
                 const {index, list, item} = data;
                 item.id = new Date().getTime();
                 list.splice(index, 0, item);
+                this.syncSelectionMetadata();
             },
             handleMoved(item) {
                 const {index, list} = item;
                 list.splice(index, 1);
+                this.syncSelectionMetadata();
             },
 
-            isChecked(optVal) {
-                if (typeof this.editItem.attributes.value != 'number') {
-                    return this.editItem.attributes.value.includes(optVal);
-                }
+            isChecked(optionIndex) {
+                return this.selectedOptionIndexSet.has(optionIndex);
             },
 
             increase(index) {
@@ -211,12 +214,15 @@
                 };
 
                 options.splice(index + 1, 0, newOpt);
+                this.ensureOptionIds();
+                this.syncSelectionMetadata();
             },
 
             decrease(index) {
                 let options = this.editItem.settings.pricing_options;
                 if (options.length > 1) {
                     options.splice(index, 1);
+                    this.syncSelectionMetadata();
                 } else {
                     this.$notify.error({
                         message: 'You have to have at least one option.',
@@ -226,38 +232,150 @@
             },
 
             clear() {
-                let attributes = this.editItem.attributes;
-                if (attributes.type == 'checkbox' || attributes.multiple) {
-                    attributes.value = [];
-                } else {
-                    attributes.value = '';
-                }
+                this.applySelectedOptionIds([]);
                 this.$refs.defaultOptions.map(el => el.checked = false);
             },
 
-            updateDefaultOption(option) {
-                let attributes = this.editItem.attributes;
-                if (attributes.type == 'checkbox' || attributes.multiple) {
-                    if (typeof attributes.value != 'object') {
-                        attributes.value = [];
-                    }
+            updateDefaultOption(optionIndex) {
+                const selectedIds = this.getSelectedOptionIds().slice();
+                const optionId = this.getOptionId(this.editItem.settings.pricing_options[optionIndex]);
 
+                if (this.isMultipleSelection()) {
                     if (event.target.checked) {
-                        attributes.value.push(option.value);
+                        if (!selectedIds.includes(optionId)) {
+                            selectedIds.push(optionId);
+                        }
                     } else {
-                        attributes.value.splice(attributes.value.indexOf(option.value), 1);
+                        const removalIndex = selectedIds.indexOf(optionId);
+
+                        if (removalIndex !== -1) {
+                            selectedIds.splice(removalIndex, 1);
+                        }
                     }
                 } else {
+                    selectedIds.splice(0, selectedIds.length);
+
                     if (event.target.checked) {
-                        attributes.value = option.value;
-                    } else {
-                        attributes.value = '';
+                        selectedIds.push(optionId);
                     }
                 }
+
+                this.applySelectedOptionIds(selectedIds);
             },
 
             createOptionsToRender() {
                 this.optionsToRender = this.editItem.settings.pricing_options;
+            },
+            generateOptionId() {
+                return 'ffo_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+            },
+            ensureOptionIds() {
+                this.editItem.settings.pricing_options.forEach((option, index) => {
+                    if (!option._ff_option_id) {
+                        this.$set(option, '_ff_option_id', this.generateOptionId() + '_' + index);
+                    }
+                });
+            },
+            getOptionId(option) {
+                if (!option._ff_option_id) {
+                    this.$set(option, '_ff_option_id', this.generateOptionId());
+                }
+
+                return String(option._ff_option_id);
+            },
+            getSelectedOptionIndexes() {
+                const optionIds = this.editItem.settings.pricing_options.map(option => this.getOptionId(option));
+
+                return this.getSelectedOptionIds()
+                    .map(optionId => optionIds.indexOf(optionId))
+                    .filter(index => index !== -1);
+            },
+            getSelectedOptionIds() {
+                const storedIds = this.getStoredSelectedOptionIds();
+
+                if (storedIds !== null) {
+                    return storedIds;
+                }
+
+                const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+                if (storedIndexes !== null) {
+                    return storedIndexes.map(index => this.getOptionId(this.editItem.settings.pricing_options[index]));
+                }
+
+                const optionValues = this.editItem.settings.pricing_options.map(option => String(option.value));
+                const remainingValues = [].concat(this.editItem.attributes.value || []).map(String);
+                const selectedIndexes = [];
+
+                remainingValues.forEach(selectedValue => {
+                    const matchedIndex = optionValues.findIndex((value, index) => {
+                        return value === selectedValue && !selectedIndexes.includes(index);
+                    });
+
+                    if (matchedIndex !== -1) {
+                        selectedIndexes.push(matchedIndex);
+                    }
+                });
+
+                return selectedIndexes.map(index => this.getOptionId(this.editItem.settings.pricing_options[index]));
+            },
+            getStoredSelectedOptionIds() {
+                if (!Array.isArray(this.editItem.settings.default_value_option_ids)) {
+                    return null;
+                }
+
+                const validIds = this.editItem.settings.default_value_option_ids
+                    .map(String)
+                    .filter(optionId => this.editItem.settings.pricing_options.some(option => this.getOptionId(option) === optionId));
+
+                return validIds.length ? validIds : null;
+            },
+            getStoredSelectedOptionIndexes() {
+                if (!Array.isArray(this.editItem.settings.default_value_option_indexes)) {
+                    return null;
+                }
+
+                const optionCount = this.editItem.settings.pricing_options.length;
+                const validIndexes = this.editItem.settings.default_value_option_indexes
+                    .map(index => parseInt(index, 10))
+                    .filter(index => !isNaN(index) && index >= 0 && index < optionCount);
+
+                return validIndexes.length ? validIndexes : null;
+            },
+            applySelectedOptionIds(selectedIds) {
+                const normalizedIds = selectedIds
+                    .map(String)
+                    .filter((optionId, index, list) => {
+                        return list.indexOf(optionId) === index && this.editItem.settings.pricing_options.some(option => this.getOptionId(option) === optionId);
+                    });
+                const optionIds = this.editItem.settings.pricing_options.map(option => this.getOptionId(option));
+                const normalizedIndexes = normalizedIds
+                    .map(optionId => optionIds.indexOf(optionId))
+                    .filter(index => index !== -1);
+
+                this.$set(this.editItem.settings, 'default_value_option_ids', normalizedIds);
+                this.$set(this.editItem.settings, 'default_value_option_indexes', normalizedIndexes);
+
+                if (this.isMultipleSelection()) {
+                    this.editItem.attributes.value = normalizedIndexes.map(index => {
+                        return this.editItem.settings.pricing_options[index].value;
+                    });
+                } else {
+                    this.editItem.attributes.value = normalizedIndexes.length
+                        ? this.editItem.settings.pricing_options[normalizedIndexes[0]].value
+                        : '';
+                }
+            },
+            resetDefaultSelection() {
+                this.applySelectedOptionIds([]);
+            },
+            syncSelectionMetadata() {
+                this.applySelectedOptionIds(this.getSelectedOptionIds());
+            },
+            isMultipleSelection() {
+                const attributes = this.editItem.attributes;
+
+                return attributes.type == 'checkbox' || attributes.multiple;
             },
             showProMessage() {
                 this.$notify.error('Images with options is available in the Pro version');
@@ -266,7 +384,8 @@
         },
         mounted() {
             this.createOptionsToRender();
+            this.ensureOptionIds();
+            this.syncSelectionMetadata();
         }
     };
 </script>
-

--- a/resources/assets/admin/components/editor-field-settings/templates/select-options.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/select-options.vue
@@ -20,8 +20,8 @@
                                :type="optionsType"
                                name="fluentform__default-option"
                                :value="option.value"
-                               :checked="isChecked(option.value)"
-                               @change="updateDefaultOption(option)">
+                               :checked="isChecked(index)"
+                               @change="updateDefaultOption(index)">
                     </div>
 
                     <vddl-handle
@@ -124,6 +124,9 @@
 
             is_rating_field() {
                 return this.editItem.element == 'ratings';
+            },
+            selectedOptionIndexSet() {
+                return new Set(this.getSelectedOptionIndexes());
             }
         },
         watch: {
@@ -177,13 +180,13 @@
                     }
                 });
                 this.optionsToRender = values;
+                this.ensureOptionIds();
+                this.syncSelectionMetadata();
                 this.bulkEditVisible = false
             },
 
-            isChecked(optVal) {
-                if (typeof this.editItem.attributes.value != 'number') {
-                    return this.editItem.attributes.value.includes(optVal);
-                }
+            isChecked(optionIndex) {
+                return this.selectedOptionIndexSet.has(optionIndex);
             },
             increase(index) {
                 let options = this.optionsToRender;
@@ -208,12 +211,15 @@
                 };
 
                 options.splice(index + 1, 0, newOpt);
+                this.ensureOptionIds();
+                this.syncSelectionMetadata();
             },
 
             decrease(index) {
                 let options = this.optionsToRender;
                 if (options.length > 1) {
                     options.splice(index, 1);
+                    this.syncSelectionMetadata();
                 } else {
                     this.$notify.error({
                         message: 'You have to have at least one option.',
@@ -223,42 +229,155 @@
             },
 
             clear() {
-                let attributes = this.editItem.attributes;
-
-                if (attributes.type == 'checkbox' || attributes.multiple) {
-                    attributes.value = [];
-                } else {
-                    attributes.value = '';
-                }
+                this.applySelectedOptionIds([]);
                 this.$refs.defaultOptions.map(el => el.checked = false);
             },
 
-            updateDefaultOption(option) {
-                let attributes = this.editItem.attributes;
+            updateDefaultOption(optionIndex) {
+                const selectedIds = this.getSelectedOptionIds().slice();
+                const optionId = this.getOptionId(this.optionsToRender[optionIndex]);
 
-                if (attributes.type == 'checkbox' || attributes.multiple) {
+                if (this.isMultipleSelection()) {
                     if (event.target.checked) {
-                        attributes.value.push(option.value);
+                        if (!selectedIds.includes(optionId)) {
+                            selectedIds.push(optionId);
+                        }
                     } else {
-                        attributes.value.splice(attributes.value.indexOf(option.value), 1);
+                        const removalIndex = selectedIds.indexOf(optionId);
+
+                        if (removalIndex !== -1) {
+                            selectedIds.splice(removalIndex, 1);
+                        }
                     }
                 } else {
+                    selectedIds.splice(0, selectedIds.length);
+
                     if (event.target.checked) {
-                        attributes.value = option.value;
-                    } else {
-                        attributes.value = '';
+                        selectedIds.push(optionId);
                     }
                 }
+
+                this.applySelectedOptionIds(selectedIds);
             },
 
             createOptionsToRender() {
                 _ff.each(this.editItem.options, (label, value) => {
                     this.optionsToRender.push({value, label, vkey: value});
                 });
+            },
+            generateOptionId() {
+                return 'ffo_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+            },
+            ensureOptionIds() {
+                this.optionsToRender.forEach((option, index) => {
+                    if (!option._ff_option_id) {
+                        this.$set(option, '_ff_option_id', this.generateOptionId() + '_' + index);
+                    }
+                });
+            },
+            getOptionId(option) {
+                if (!option._ff_option_id) {
+                    this.$set(option, '_ff_option_id', this.generateOptionId());
+                }
+
+                return String(option._ff_option_id);
+            },
+            getSelectedOptionIndexes() {
+                const optionIds = this.optionsToRender.map(option => this.getOptionId(option));
+
+                return this.getSelectedOptionIds()
+                    .map(optionId => optionIds.indexOf(optionId))
+                    .filter(index => index !== -1);
+            },
+            getSelectedOptionIds() {
+                const storedIds = this.getStoredSelectedOptionIds();
+
+                if (storedIds !== null) {
+                    return storedIds;
+                }
+
+                const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+                if (storedIndexes !== null) {
+                    return storedIndexes.map(index => this.getOptionId(this.optionsToRender[index]));
+                }
+
+                const optionValues = this.optionsToRender.map(option => String(option.value));
+                const remainingValues = [].concat(this.editItem.attributes.value || []).map(String);
+                const selectedIndexes = [];
+
+                remainingValues.forEach(selectedValue => {
+                    const matchedIndex = optionValues.findIndex((value, index) => {
+                        return value === selectedValue && !selectedIndexes.includes(index);
+                    });
+
+                    if (matchedIndex !== -1) {
+                        selectedIndexes.push(matchedIndex);
+                    }
+                });
+
+                return selectedIndexes.map(index => this.getOptionId(this.optionsToRender[index]));
+            },
+            getStoredSelectedOptionIds() {
+                if (!Array.isArray(this.editItem.settings.default_value_option_ids)) {
+                    return null;
+                }
+
+                const validIds = this.editItem.settings.default_value_option_ids
+                    .map(String)
+                    .filter(optionId => this.optionsToRender.some(option => this.getOptionId(option) === optionId));
+
+                return validIds.length ? validIds : null;
+            },
+            getStoredSelectedOptionIndexes() {
+                if (!Array.isArray(this.editItem.settings.default_value_option_indexes)) {
+                    return null;
+                }
+
+                const optionCount = this.optionsToRender.length;
+                const validIndexes = this.editItem.settings.default_value_option_indexes
+                    .map(index => parseInt(index, 10))
+                    .filter(index => !isNaN(index) && index >= 0 && index < optionCount);
+
+                return validIndexes.length ? validIndexes : null;
+            },
+            applySelectedOptionIds(selectedIds) {
+                const normalizedIds = selectedIds
+                    .map(String)
+                    .filter((optionId, index, list) => {
+                        return list.indexOf(optionId) === index && this.optionsToRender.some(option => this.getOptionId(option) === optionId);
+                    });
+                const optionIds = this.optionsToRender.map(option => this.getOptionId(option));
+                const normalizedIndexes = normalizedIds
+                    .map(optionId => optionIds.indexOf(optionId))
+                    .filter(index => index !== -1);
+
+                this.$set(this.editItem.settings, 'default_value_option_ids', normalizedIds);
+                this.$set(this.editItem.settings, 'default_value_option_indexes', normalizedIndexes);
+
+                if (this.isMultipleSelection()) {
+                    this.editItem.attributes.value = normalizedIndexes.map(index => {
+                        return this.optionsToRender[index].value;
+                    });
+                } else {
+                    this.editItem.attributes.value = normalizedIndexes.length
+                        ? this.optionsToRender[normalizedIndexes[0]].value
+                        : '';
+                }
+            },
+            syncSelectionMetadata() {
+                this.applySelectedOptionIds(this.getSelectedOptionIds());
+            },
+            isMultipleSelection() {
+                const attributes = this.editItem.attributes;
+
+                return attributes.type == 'checkbox' || attributes.multiple;
             }
         },
         mounted() {
             this.createOptionsToRender();
+            this.ensureOptionIds();
+            this.syncSelectionMetadata();
         }
     }
 </script>

--- a/resources/assets/admin/components/templates/inputCheckable.vue
+++ b/resources/assets/admin/components/templates/inputCheckable.vue
@@ -3,21 +3,39 @@
         <div :class="wrapperClass" v-if="!item.settings.enable_image_input">
             <template v-if="inputType == 'radio'">
                 <div v-for="(option,index) in item.settings.advanced_options" :key="index" style="line-height: 25px;">
-                    <input type="radio" :value="option.value" v-model="item.attributes.value"> {{ option.label }}
+                    <input
+                        :name="radioPreviewName"
+                        type="radio"
+                        :value="option.value"
+                        :checked="isOptionSelected(option, index)"
+                    > {{ option.label }}
                 </div>
                 <!-- Other option for radio -->
                 <div v-if="item.settings.enable_other_option === 'yes'" class="ff-el-form-check ff-other-option" style="line-height: 25px;">
-                    <input type="radio" :value="'other_' + item.attributes.name" v-model="item.attributes.value" >
+                    <input
+                        :name="radioPreviewName"
+                        type="radio"
+                        :value="'other_' + item.attributes.name"
+                        :checked="isOtherOptionSelected()"
+                    >
                     {{ item.settings.other_option_label || 'Other' }}
                 </div>
             </template>
             <template v-else>
                 <div v-for="(option,index) in item.settings.advanced_options" :key="index" style="line-height: 25px;">
-                    <input type="checkbox" :value="option.value" v-model="item.attributes.value"> {{ option.label }}
+                    <input
+                        type="checkbox"
+                        :value="option.value"
+                        :checked="isOptionSelected(option, index)"
+                    > {{ option.label }}
                 </div>
                 <!-- Other option for checkbox -->
                 <div v-if="item.settings.enable_other_option === 'yes'" class="ff-el-form-check ff-other-option" style="line-height: 25px;">
-                    <input type="checkbox" :value="'other_' + item.attributes.name" v-model="item.attributes.value" >
+                    <input
+                        type="checkbox"
+                        :value="'other_' + item.attributes.name"
+                        :checked="isOtherOptionSelected()"
+                    >
                     {{ item.settings.other_option_label || 'Other' }}
                 </div>
             </template>
@@ -26,7 +44,12 @@
             <div v-for="(option, i) in item.settings.advanced_options" class="ff_check_photo_item" :key="i">
                 <div class="ff_photo_holder" :style="{ backgroundImage: 'url('+option.image+')' }"></div>
                 <label>
-                    <input :name="item.attributes.name" :value="option.value" v-model="item.attributes.value" :type="inputType">
+                    <input
+                        :name="item.attributes.name"
+                        :value="option.value"
+                        :checked="isOptionSelected(option, i)"
+                        :type="inputType"
+                    >
                     <span v-html="option.label"></span>
                 </label>
             </div>
@@ -47,8 +70,104 @@ export default {
         inputType() {
             return this.item.attributes.type;
         },
+        radioPreviewName() {
+            return (this.item.attributes && this.item.attributes.name ? this.item.attributes.name : 'radio') + '_preview';
+        },
         wrapperClass() {
             return this.item.settings.layout_class+' item_type_'+this.item.attributes.type;
+        },
+        selectionState() {
+            const storedIds = this.getStoredSelectedOptionIds();
+
+            if (storedIds !== null) {
+                return {
+                    storedIds: new Set(storedIds),
+                    storedIndexes: null,
+                    occurrenceSelections: null
+                };
+            }
+
+            const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+            if (storedIndexes !== null) {
+                return {
+                    storedIds: null,
+                    storedIndexes: new Set(storedIndexes),
+                    occurrenceSelections: null
+                };
+            }
+
+            const counts = this.getDefaultValueCounts();
+            const occurrences = {};
+            const occurrenceSelections = new Set();
+
+            this.item.settings.advanced_options.forEach((option, index) => {
+                const optionValue = String(option.value);
+
+                if (!counts[optionValue]) {
+                    return;
+                }
+
+                occurrences[optionValue] = (occurrences[optionValue] || 0) + 1;
+
+                if (occurrences[optionValue] <= counts[optionValue]) {
+                    occurrenceSelections.add(index);
+                }
+            });
+
+            return {
+                storedIds: null,
+                storedIndexes: null,
+                occurrenceSelections
+            };
+        }
+    },
+    methods: {
+        getStoredSelectedOptionIds() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_ids)) {
+                return null;
+            }
+
+            const validIds = this.item.settings.default_value_option_ids
+                .map(String)
+                .filter(optionId => this.item.settings.advanced_options.some(option => String(option._ff_option_id) === optionId));
+
+            return validIds.length ? validIds : null;
+        },
+        getStoredSelectedOptionIndexes() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_indexes)) {
+                return null;
+            }
+
+            return this.item.settings.default_value_option_indexes
+                .map(index => parseInt(index, 10))
+                .filter(index => !isNaN(index) && index >= 0);
+        },
+        getDefaultValueCounts() {
+            return [].concat(this.item.attributes.value || []).reduce((counts, value) => {
+                value = String(value);
+                counts[value] = (counts[value] || 0) + 1;
+
+                return counts;
+            }, {});
+        },
+        isOptionSelected(option, optionIndex) {
+            const { storedIds, storedIndexes, occurrenceSelections } = this.selectionState;
+
+            if (storedIds) {
+                return storedIds.has(String(option._ff_option_id));
+            }
+
+            if (storedIndexes) {
+                return storedIndexes.has(optionIndex);
+            }
+
+            return occurrenceSelections ? occurrenceSelections.has(optionIndex) : false;
+        },
+        isOtherOptionSelected() {
+            const otherValue = 'other_' + this.item.attributes.name;
+
+            return [].concat(this.item.attributes.value || []).map(String).includes(otherValue);
         }
     }
 }

--- a/resources/assets/admin/components/templates/inputCheckbox.vue
+++ b/resources/assets/admin/components/templates/inputCheckbox.vue
@@ -1,7 +1,7 @@
 <template>
     <withLabel :item="item">
-        <div v-for="(label, value, i) in item.options" style="line-height: 25px;" :key="i">
-            <input type="checkbox" :value="value" v-model="item.attributes.value"> {{ label }}
+        <div v-for="(option, i) in renderOptions" style="line-height: 25px;" :key="option._ff_option_id || i">
+            <input type="checkbox" :value="option.value" :checked="isOptionSelected(option, i)"> {{ option.label }}
         </div>
     </withLabel>
 </template>
@@ -14,6 +14,106 @@ export default {
     props: ['item'],
     components: {
         withLabel
+    },
+    computed: {
+        renderOptions() {
+            if (this.item.settings && Array.isArray(this.item.settings.advanced_options) && this.item.settings.advanced_options.length) {
+                return this.item.settings.advanced_options;
+            }
+
+            return Object.keys(this.item.options || {}).map(value => ({
+                value,
+                label: this.item.options[value]
+            }));
+        },
+        selectionState() {
+            const storedIds = this.getStoredSelectedOptionIds();
+
+            if (storedIds !== null) {
+                return {
+                    storedIds: new Set(storedIds),
+                    storedIndexes: null,
+                    occurrenceSelections: null
+                };
+            }
+
+            const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+            if (storedIndexes !== null) {
+                return {
+                    storedIds: null,
+                    storedIndexes: new Set(storedIndexes),
+                    occurrenceSelections: null
+                };
+            }
+
+            const counts = this.getDefaultValueCounts();
+            const occurrences = {};
+            const occurrenceSelections = new Set();
+
+            this.renderOptions.forEach((option, index) => {
+                const optionValue = String(option.value);
+
+                if (!counts[optionValue]) {
+                    return;
+                }
+
+                occurrences[optionValue] = (occurrences[optionValue] || 0) + 1;
+
+                if (occurrences[optionValue] <= counts[optionValue]) {
+                    occurrenceSelections.add(index);
+                }
+            });
+
+            return {
+                storedIds: null,
+                storedIndexes: null,
+                occurrenceSelections
+            };
+        }
+    },
+    methods: {
+        getStoredSelectedOptionIds() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_ids)) {
+                return null;
+            }
+
+            const validIds = this.item.settings.default_value_option_ids
+                .map(String)
+                .filter(optionId => this.renderOptions.some(option => String(option._ff_option_id) === optionId));
+
+            return validIds.length ? validIds : null;
+        },
+        getStoredSelectedOptionIndexes() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_indexes)) {
+                return null;
+            }
+
+            return this.item.settings.default_value_option_indexes
+                .map(index => parseInt(index, 10))
+                .filter(index => !isNaN(index) && index >= 0);
+        },
+        getDefaultValueCounts() {
+            return [].concat(this.item.attributes.value || []).reduce((counts, value) => {
+                value = String(value);
+                counts[value] = (counts[value] || 0) + 1;
+
+                return counts;
+            }, {});
+        },
+        isOptionSelected(option, optionIndex) {
+            const { storedIds, storedIndexes, occurrenceSelections } = this.selectionState;
+
+            if (storedIds) {
+                return storedIds.has(String(option._ff_option_id));
+            }
+
+            if (storedIndexes) {
+                return storedIndexes.has(optionIndex);
+            }
+
+            return occurrenceSelections ? occurrenceSelections.has(optionIndex) : false;
+        }
     }
 }
 </script>

--- a/resources/assets/admin/components/templates/inputMultiPayment.vue
+++ b/resources/assets/admin/components/templates/inputMultiPayment.vue
@@ -5,18 +5,22 @@
         </template>
         <template v-else-if="inputType == 'select'">
             <select class="select el-input__inner">
-                <option v-for="(option, index) in item.settings.pricing_options" :key="index">{{option.label}}</option>
+                <option
+                    v-for="(option, index) in item.settings.pricing_options"
+                    :key="index"
+                    :selected="isOptionSelected(option, index)"
+                >{{option.label}}</option>
             </select>
         </template>
         <template v-else-if="!item.settings.enable_image_input">
-            <el-radio-group v-if="inputType == 'radio'" class="el-radio-horizontal">
-                <el-radio v-for="option in item.settings.pricing_options" :label="option.value" :key="option.value">
-                    {{ option.label }}
-                </el-radio>
-            </el-radio-group>
+            <template v-if="inputType == 'radio'">
+                <div v-for="(option,index) in item.settings.pricing_options" :key="index" style="line-height: 25px;">
+                    <input :name="radioPreviewName" type="radio" :value="option.value" :checked="isOptionSelected(option, index)"> {{ option.label }}
+                </div>
+            </template>
             <template v-else>
                 <div v-for="(option,index) in item.settings.pricing_options" :key="index" style="line-height: 25px;">
-                    <input type="checkbox" :value="option.value"> {{ option.label }}
+                    <input type="checkbox" :value="option.value" :checked="isOptionSelected(option, index)"> {{ option.label }}
                 </div>
             </template>
         </template>
@@ -24,7 +28,7 @@
             <div v-for="(option, i) in item.settings.pricing_options" class="ff_check_photo_item" :key="i">
                 <div v-if="option.image" class="ff_photo_holder" :style="{ backgroundImage: 'url('+option.image+')' }"></div>
                 <label>
-                    <input :name="item.attributes.name" :value="option.value" :type="inputType"> 
+                    <input :name="item.attributes.name" :value="option.value" :type="inputType" :checked="isOptionSelected(option, i)">
                     <span v-html="option.label"></span>
                 </label>
             </div>
@@ -49,6 +53,97 @@ export default {
     computed: {
         inputType() {
             return this.item.attributes.type;
+        },
+        radioPreviewName() {
+            return (this.item.attributes && this.item.attributes.name ? this.item.attributes.name : 'payment_radio') + '_preview';
+        },
+        selectionState() {
+            const storedIds = this.getStoredSelectedOptionIds();
+
+            if (storedIds !== null) {
+                return {
+                    storedIds: new Set(storedIds),
+                    storedIndexes: null,
+                    occurrenceSelections: null
+                };
+            }
+
+            const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+            if (storedIndexes !== null) {
+                return {
+                    storedIds: null,
+                    storedIndexes: new Set(storedIndexes),
+                    occurrenceSelections: null
+                };
+            }
+
+            const counts = this.getDefaultValueCounts();
+            const occurrences = {};
+            const occurrenceSelections = new Set();
+
+            this.item.settings.pricing_options.forEach((option, index) => {
+                const optionValue = String(option.value);
+
+                if (!counts[optionValue]) {
+                    return;
+                }
+
+                occurrences[optionValue] = (occurrences[optionValue] || 0) + 1;
+
+                if (occurrences[optionValue] <= counts[optionValue]) {
+                    occurrenceSelections.add(index);
+                }
+            });
+
+            return {
+                storedIds: null,
+                storedIndexes: null,
+                occurrenceSelections
+            };
+        }
+    },
+    methods: {
+        getStoredSelectedOptionIds() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_ids)) {
+                return null;
+            }
+
+            const validIds = this.item.settings.default_value_option_ids
+                .map(String)
+                .filter(optionId => this.item.settings.pricing_options.some(option => String(option._ff_option_id) === optionId));
+
+            return validIds.length ? validIds : null;
+        },
+        getStoredSelectedOptionIndexes() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_indexes)) {
+                return null;
+            }
+
+            return this.item.settings.default_value_option_indexes
+                .map(index => parseInt(index, 10))
+                .filter(index => !isNaN(index) && index >= 0);
+        },
+        getDefaultValueCounts() {
+            return [].concat(this.item.attributes.value || []).reduce((counts, value) => {
+                value = String(value);
+                counts[value] = (counts[value] || 0) + 1;
+
+                return counts;
+            }, {});
+        },
+        isOptionSelected(option, optionIndex) {
+            const { storedIds, storedIndexes, occurrenceSelections } = this.selectionState;
+
+            if (storedIds) {
+                return storedIds.has(String(option._ff_option_id));
+            }
+
+            if (storedIndexes) {
+                return storedIndexes.has(optionIndex);
+            }
+
+            return occurrenceSelections ? occurrenceSelections.has(optionIndex) : false;
         }
     }
 }

--- a/resources/assets/admin/components/templates/inputRadio.vue
+++ b/resources/assets/admin/components/templates/inputRadio.vue
@@ -1,8 +1,8 @@
 <template>
     <withLabel :item="item">
-        <el-radio-group class="el-radio-horizontal" v-model="item.attributes.value">
-            <el-radio v-for="(label, value, i) in item.options" :label="value" :key="i">
-                {{ label }}
+        <el-radio-group class="el-radio-horizontal" :value="selectedOptionIndex">
+            <el-radio v-for="(option, i) in renderOptions" :label="i" :key="option._ff_option_id || i">
+                {{ option.label }}
             </el-radio>
         </el-radio-group>
     </withLabel>
@@ -16,6 +16,54 @@ export default {
     props: ['item'],
     components: {
         withLabel
+    },
+    computed: {
+        renderOptions() {
+            if (this.item.settings && Array.isArray(this.item.settings.advanced_options) && this.item.settings.advanced_options.length) {
+                return this.item.settings.advanced_options;
+            }
+
+            return Object.keys(this.item.options || {}).map(value => ({
+                value,
+                label: this.item.options[value]
+            }));
+        },
+        selectedOptionIndex() {
+            const storedIds = this.getStoredSelectedOptionIds();
+
+            if (storedIds.length) {
+                return this.renderOptions.findIndex(option => storedIds.includes(String(option._ff_option_id)));
+            }
+
+            const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+            if (storedIndexes.length) {
+                return storedIndexes[0];
+            }
+
+            const optionValues = this.renderOptions.map(option => String(option.value));
+            const selectedValue = String(this.item.attributes.value || '');
+
+            return optionValues.findIndex(value => String(value) === selectedValue);
+        }
+    },
+    methods: {
+        getStoredSelectedOptionIds() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_ids)) {
+                return [];
+            }
+
+            return this.item.settings.default_value_option_ids.map(String);
+        },
+        getStoredSelectedOptionIndexes() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_indexes)) {
+                return [];
+            }
+
+            return this.item.settings.default_value_option_indexes
+                .map(index => parseInt(index, 10))
+                .filter(index => !isNaN(index) && index >= 0);
+        }
     }
 }
 </script>

--- a/resources/assets/admin/components/templates/select.vue
+++ b/resources/assets/admin/components/templates/select.vue
@@ -17,9 +17,44 @@ export default {
     props: ['item'],
     computed :{
         defaultVal() {
-            let option = find(this.item.settings.advanced_options, { value: this.item.attributes.value });
+            let option = null;
+            const storedIds = this.getStoredSelectedOptionIds();
+
+            if (storedIds.length) {
+                option = this.item.settings.advanced_options.find(option => {
+                    return storedIds.includes(String(option._ff_option_id));
+                });
+            }
+
+            const storedIndexes = this.getStoredSelectedOptionIndexes();
+
+            if (!option && storedIndexes.length) {
+                option = this.item.settings.advanced_options[storedIndexes[0]];
+            }
+
+            if (!option) {
+                option = find(this.item.settings.advanced_options, { value: this.item.attributes.value });
+            }
 
             return option ? option.label : null;
+        }
+    },
+    methods: {
+        getStoredSelectedOptionIds() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_ids)) {
+                return [];
+            }
+
+            return this.item.settings.default_value_option_ids.map(String);
+        },
+        getStoredSelectedOptionIndexes() {
+            if (!this.item.settings || !Array.isArray(this.item.settings.default_value_option_indexes)) {
+                return [];
+            }
+
+            return this.item.settings.default_value_option_indexes
+                .map(index => parseInt(index, 10))
+                .filter(index => !isNaN(index) && index >= 0);
         }
     },
     components: {


### PR DESCRIPTION
## Summary
- store stable option ids for duplicate-value defaults in the form editor
- preserve those exact defaults across save/reload and frontend rendering
- keep legacy fallback for older forms and duplicate-aware label/payment resolution
- pass stable duplicate selections into conversational conversion

## Testing
- verified form 379 editor save/reload for payment radio, payment checkbox, payment select, radio, and checkbox
- verified https://forms.test/?ff_landing=379 renders the saved duplicate defaults correctly
- verified submission stores the expected payment labels instead of drifting to another same-value option
- verified reorder/delete scenarios no longer remap saved duplicate defaults to the wrong option

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/20665