### PR TITLE
Fix: scope legacy settings ajax to the target form

### DIFF
--- a/app/Hooks/Ajax.php
+++ b/app/Hooks/Ajax.php
@@ -93,7 +93,9 @@ $app->addAction('wp_ajax_fluentform-save-form-email-notification', function () u
 // Legacy AJAX handlers removed — these routes are handled by the REST API.
 // Kept: fluentform-form-find-shortcode-locations (still in active use)
 $app->addAdminAjaxAction('fluentform-form-find-shortcode-locations', function () use ($app) {
-    Acl::verify('fluentform_forms_manager');
+    $formId = absint($app->request->get('form_id'));
+
+    Acl::verify('fluentform_forms_manager', $formId);
     (new \FluentForm\App\Modules\Form\Form($app))->findFormLocations();
 });
 

--- a/app/Hooks/Ajax.php
+++ b/app/Hooks/Ajax.php
@@ -57,7 +57,7 @@ $app->addAction('wp_ajax_fluentform-form-update', function () use ($app) {
  * Mod-Security also block this request
  */
 $app->addAction('wp_ajax_fluentform-save-settings-general-formSettings', function () use ($app) {
-    Acl::verify('fluentform_forms_manager');
+    Acl::verify('fluentform_forms_manager', $app->request->get('form_id'));
     try {
         $settingsService = new \FluentForm\App\Services\Settings\SettingsService();
         $settingsService->saveGeneral($app->request->all());
@@ -74,7 +74,7 @@ $app->addAction('wp_ajax_fluentform-save-settings-general-formSettings', functio
  * Mod-Security also block this request
  */
 $app->addAction('wp_ajax_fluentform-save-form-email-notification', function () use ($app) {
-    Acl::verify('fluentform_forms_manager');
+    Acl::verify('fluentform_forms_manager', $app->request->get('form_id'));
     try {
         $settingsService = new \FluentForm\App\Services\Settings\SettingsService();
         [$settingsId, $settings] = $settingsService->store($app->request->all());

--- a/app/Hooks/Ajax.php
+++ b/app/Hooks/Ajax.php
@@ -124,7 +124,7 @@ $resolveSubmissionFormId = function ($submissionId) {
 };
 
 $app->addAction('wp_ajax_fluentform-form-entries-export', function () use ($app) {
-    $formId = absint($app->request->get('form_id'));
+    $formId = Acl::verifyFormId($app->request->get('form_id'));
 
     Acl::verify('fluentform_entries_viewer', $formId);
     (new \FluentForm\App\Modules\Transfer\Transfer())->exportEntries();
@@ -225,7 +225,7 @@ $app->addAction('wp_ajax_fluentform_report_data_migrate', function () {
     if (!wp_verify_nonce(sanitize_text_field(wpFluentForm('request')->get('nonce')), 'fluentform_report_data_migrate')) {
         die('invalid');
     }
-    $formId = intval(wpFluentForm('request')->get('form_id'));
+    $formId = Acl::normalizeFormId(wpFluentForm('request')->get('form_id'));
     if ($formId && Acl::hasPermission('fluentform_entries_viewer', $formId)) {
         \FluentForm\App\Services\Report\ReportHelper::runMigrationBatch($formId);
     }

--- a/app/Hooks/Ajax.php
+++ b/app/Hooks/Ajax.php
@@ -28,9 +28,11 @@ $app->addAction('wp_ajax_fluentform_submit', function () use ($app) {
  * REST API seems not working for some servers with Mod Security Enabled
  */
 $app->addAction('wp_ajax_fluentform-form-update', function () use ($app) {
-    Acl::verify('fluentform_forms_manager', $app->request->get('form_id'));
+    $formId = Acl::verifyFormId($app->request->get('form_id'));
+    Acl::verify('fluentform_forms_manager', $formId);
     try {
         $data = $app->request->all();
+        $data['form_id'] = $formId;
         $isValidJson = (!empty($data['formFields'])) && json_decode($data['formFields'], true);
 
         if(!$isValidJson) {
@@ -57,10 +59,14 @@ $app->addAction('wp_ajax_fluentform-form-update', function () use ($app) {
  * Mod-Security also block this request
  */
 $app->addAction('wp_ajax_fluentform-save-settings-general-formSettings', function () use ($app) {
-    Acl::verify('fluentform_forms_manager', $app->request->get('form_id'));
+    $formId = Acl::verifyFormId($app->request->get('form_id'));
+    Acl::verify('fluentform_forms_manager', $formId);
     try {
         $settingsService = new \FluentForm\App\Services\Settings\SettingsService();
-        $settingsService->saveGeneral($app->request->all());
+        $attributes = $app->request->all();
+        $attributes['form_id'] = $formId;
+
+        $settingsService->saveGeneral($attributes);
         wp_send_json([
             'message' => __('Settings has been saved.', 'fluentform'),
         ]);
@@ -74,10 +80,14 @@ $app->addAction('wp_ajax_fluentform-save-settings-general-formSettings', functio
  * Mod-Security also block this request
  */
 $app->addAction('wp_ajax_fluentform-save-form-email-notification', function () use ($app) {
-    Acl::verify('fluentform_forms_manager', $app->request->get('form_id'));
+    $formId = Acl::verifyFormId($app->request->get('form_id'));
+    Acl::verify('fluentform_forms_manager', $formId);
     try {
         $settingsService = new \FluentForm\App\Services\Settings\SettingsService();
-        [$settingsId, $settings] = $settingsService->store($app->request->all());
+        $attributes = $app->request->all();
+        $attributes['form_id'] = $formId;
+
+        [$settingsId, $settings] = $settingsService->store($attributes);
 
         wp_send_json([
             'message'  => __('Settings has been saved.', 'fluentform'),
@@ -93,9 +103,9 @@ $app->addAction('wp_ajax_fluentform-save-form-email-notification', function () u
 // Legacy AJAX handlers removed — these routes are handled by the REST API.
 // Kept: fluentform-form-find-shortcode-locations (still in active use)
 $app->addAdminAjaxAction('fluentform-form-find-shortcode-locations', function () use ($app) {
-    $formId = absint($app->request->get('form_id'));
-
+    $formId = Acl::verifyFormId($app->request->get('form_id'));
     Acl::verify('fluentform_forms_manager', $formId);
+
     (new \FluentForm\App\Modules\Form\Form($app))->findFormLocations();
 });
 

--- a/app/Hooks/Ajax.php
+++ b/app/Hooks/Ajax.php
@@ -101,20 +101,29 @@ $app->addAdminAjaxAction('fluentform-form-find-shortcode-locations', function ()
 
 
 
+$resolveSubmissionFormId = function ($submissionId) {
+    if (!$submissionId) {
+        return null;
+    }
+
+    $submission = \FluentForm\App\Models\Submission::select('form_id')->find($submissionId);
+
+    return $submission ? $submission->form_id : null;
+};
+
 $app->addAction('wp_ajax_fluentform-form-entries-export', function () use ($app) {
-    Acl::verify('fluentform_entries_viewer');
+    $formId = absint($app->request->get('form_id'));
+
+    Acl::verify('fluentform_entries_viewer', $formId);
     (new \FluentForm\App\Modules\Transfer\Transfer())->exportEntries();
 });
 
-$app->addAction('wp_ajax_fluentform-update-entry-user', function () use ($app) {
-    $submissionId = intval($app->request->get('submission_id'));
-    $formId = null;
-    if ($submissionId) {
-        $submission = \FluentForm\App\Models\Submission::select('form_id')->find($submissionId);
-        $formId = $submission ? $submission->form_id : null;
-    }
+$app->addAction('wp_ajax_fluentform-update-entry-user', function () use ($app, $resolveSubmissionFormId) {
+    $submissionId = absint($app->request->get('submission_id'));
+    $formId = $resolveSubmissionFormId($submissionId);
+
     Acl::verify('fluentform_manage_entries', $formId);
-    $userId = intval($app->request->get('user_id'));
+    $userId = absint($app->request->get('user_id'));
     try {
         $result = (new \FluentForm\App\Services\Submission\SubmissionService())->updateSubmissionUser($userId, $submissionId);
         wp_send_json_success($result);
@@ -143,10 +152,14 @@ $app->addAction('wp_ajax_fluentform-get-users', function () use ($app) {
 
 // Legacy log AJAX handlers removed — these routes are now handled by the REST API.
 
-$app->addAction('wp_ajax_fluentform-change-entry-status', function () use ($app) {
-    Acl::verify('fluentform_manage_entries');
+$app->addAction('wp_ajax_fluentform-change-entry-status', function () use ($app, $resolveSubmissionFormId) {
+    $entryId = absint($app->request->get('entry_id'));
+    $formId = $resolveSubmissionFormId($entryId);
+
+    Acl::verify('fluentform_manage_entries', $formId);
+
     $attributes = [
-        'entry_id' => intval($app->request->get('entry_id')),
+        'entry_id' => $entryId,
         'status'   => sanitize_text_field($app->request->get('status')),
     ];
     $newStatus = (new \FluentForm\App\Services\Submission\SubmissionService())->updateStatus($attributes);

--- a/app/Http/Controllers/FormController.php
+++ b/app/Http/Controllers/FormController.php
@@ -59,15 +59,11 @@ class FormController extends Controller
         }
     }
     
-    public function duplicate(FormService $formService)
+    public function duplicate(FormService $formService, $formId)
     {
         try {
             $attributes = $this->request->all();
-            
-            $sanitizeMap = [
-                'form_id' => 'intval',
-            ];
-            $attributes = fluentform_backend_sanitizer($attributes, $sanitizeMap);
+            $attributes['form_id'] = (int) $formId;
             
             $form = $formService->duplicate($attributes);
             
@@ -83,10 +79,10 @@ class FormController extends Controller
         }
     }
     
-    public function find(FormService $formService)
+    public function find(FormService $formService, $formId)
     {
         try {
-            $id = (int)$this->request->get('form_id');
+            $id = (int) $formId;
             
             $form = $formService->find($id);
             
@@ -98,10 +94,10 @@ class FormController extends Controller
         }
     }
     
-    public function delete(FormService $formService)
+    public function delete(FormService $formService, $formId)
     {
         try {
-            $id = (int)$this->request->get('form_id');
+            $id = (int) $formId;
             
             $formService->delete($id);
             
@@ -115,11 +111,12 @@ class FormController extends Controller
         }
     }
     
-    public function update(FormService $formService)
+    public function update(FormService $formService, $formId)
     {
         try {
             // Sanitization handled in Updater::update() — only title, status, form_id, formFields are extracted
             $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
 
             $formService->update($attributes);
             
@@ -133,10 +130,10 @@ class FormController extends Controller
         }
     }
     
-    public function convert(FormService $formService)
+    public function convert(FormService $formService, $formId)
     {
         try {
-            $formId = (int)$this->request->get('form_id');
+            $formId = (int) $formId;
             $formService->convert($formId);
             
             return $this->sendSuccess([
@@ -199,10 +196,10 @@ class FormController extends Controller
         return $this->sendSuccess($historyService::get($formId));
     }
     
-    public function clearEditHistory(HistoryService $historyService)
+    public function clearEditHistory(HistoryService $historyService, $formId)
     {
         try {
-            $id = (int)$this->request->get('form_id');
+            $id = (int) $formId;
             
             $historyService->delete($id);
             return $this->sendSuccess([

--- a/app/Http/Controllers/FormIntegrationController.php
+++ b/app/Http/Controllers/FormIntegrationController.php
@@ -6,10 +6,10 @@ use FluentForm\App\Services\Integrations\FormIntegrationService;
 
 class FormIntegrationController extends Controller
 {
-    public function index(FormIntegrationService $integrationService)
+    public function index(FormIntegrationService $integrationService, $formId)
     {
         try {
-            $formId = (int) $this->request->get('form_id');
+            $formId = (int) $formId;
             return $this->sendSuccess(
                 $integrationService->get($formId)
             );
@@ -20,10 +20,13 @@ class FormIntegrationController extends Controller
         }
     }
     
-    public function find(FormIntegrationService $integrationService)
+    public function find(FormIntegrationService $integrationService, $formId)
     {
         try {
-            $integration = $integrationService->find($this->request->all());
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
+
+            $integration = $integrationService->find($attributes);
             return $this->sendSuccess($integration);
         } catch (\Exception $e) {
             return $this->sendError([
@@ -32,10 +35,13 @@ class FormIntegrationController extends Controller
         }
     }
     
-    public function update(FormIntegrationService $integrationService)
+    public function update(FormIntegrationService $integrationService, $formId)
     {
         try {
-            $integration = $integrationService->update($this->request->all());
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
+
+            $integration = $integrationService->update($attributes);
             return $this->sendSuccess($integration);
         } catch (\Exception $e) {
             return $this->sendError([
@@ -44,10 +50,10 @@ class FormIntegrationController extends Controller
         }
     }
     
-    public function delete(FormIntegrationService $integrationService)
+    public function delete(FormIntegrationService $integrationService, $formId)
     {
         try {
-            $formId = intval($this->request->get('form_id'));
+            $formId = (int) $formId;
             $id = intval($this->request->get('integration_id'));
             $integrationService->delete($id, $formId);
             return $this->sendSuccess([
@@ -60,10 +66,11 @@ class FormIntegrationController extends Controller
         }
     }
     
-    public function integrationListComponent()
+    public function integrationListComponent($formId)
     {
         try {
             $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
             
             $sanitizeMap = [
                 'integration_name' => 'sanitize_text_field',

--- a/app/Http/Controllers/FormSettingsController.php
+++ b/app/Http/Controllers/FormSettingsController.php
@@ -10,9 +10,12 @@ use FluentForm\App\Services\Submission\SubmissionService;
 
 class FormSettingsController extends Controller
 {
-    public function index(SettingsService $settingsService)
+    public function index(SettingsService $settingsService, $formId)
     {
-        $result = $settingsService->get($this->request->all());
+        $attributes = $this->request->all();
+        $attributes['form_id'] = (int) $formId;
+
+        $result = $settingsService->get($attributes);
 
         return $this->sendSuccess($result);
     }
@@ -24,10 +27,13 @@ class FormSettingsController extends Controller
         return $this->sendSuccess($result);
     }
 
-    public function saveGeneral(SettingsService $settingsService)
+    public function saveGeneral(SettingsService $settingsService, $formId)
     {
         try {
-            $settingsService->saveGeneral($this->request->all());
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
+
+            $settingsService->saveGeneral($attributes);
 
             return $this->sendSuccess([
                 'message' => __('Settings has been saved.', 'fluentform'),
@@ -37,10 +43,13 @@ class FormSettingsController extends Controller
         }
     }
 
-    public function store(SettingsService $settingsService)
+    public function store(SettingsService $settingsService, $formId)
     {
         try {
-            [$settingsId, $settings] = $settingsService->store($this->request->all());
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
+
+            [$settingsId, $settings] = $settingsService->store($attributes);
 
             return $this->sendSuccess([
                 'message'  => __('Settings has been saved.', 'fluentform'),
@@ -52,9 +61,12 @@ class FormSettingsController extends Controller
         }
     }
 
-    public function remove(SettingsService $settingsService)
+    public function remove(SettingsService $settingsService, $formId)
     {
-        $settingsService->remove($this->request->all());
+        $attributes = $this->request->all();
+        $attributes['form_id'] = (int) $formId;
+
+        $settingsService->remove($attributes);
 
         return $this->sendSuccess([]);
     }
@@ -74,7 +86,10 @@ class FormSettingsController extends Controller
     public function storeCustomizer(Customizer $customizer, $id)
     {
         try {
-            $customizer->store($this->request->all());
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $id;
+
+            $customizer->store($attributes);
 
             return $this->sendSuccess([
                 'message' => __('Custom CSS & JS successfully saved.', 'fluentform'),
@@ -89,7 +104,10 @@ class FormSettingsController extends Controller
     public function storeEntryColumns(SubmissionService $submissionService, $id)
     {
         try {
-            $submissionService->storeColumnSettings($this->request->all());
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $id;
+
+            $submissionService->storeColumnSettings($attributes);
 
             return $this->sendSuccess([
                 'message' => __('The column display order has been saved.', 'fluentform'),
@@ -134,10 +152,13 @@ class FormSettingsController extends Controller
         }
     }
 
-    public function savePreset(SettingsService $settingsService)
+    public function savePreset(SettingsService $settingsService, $formId)
     {
         try {
-            return $this->sendSuccess($settingsService->savePreset($this->request->all()));
+            $attributes = $this->request->all();
+            $attributes['form_id'] = (int) $formId;
+
+            return $this->sendSuccess($settingsService->savePreset($attributes));
         } catch (Exception $e) {
             return $this->sendError([
                 'message' => $e->getMessage(),

--- a/app/Http/Controllers/LogController.php
+++ b/app/Http/Controllers/LogController.php
@@ -62,6 +62,14 @@ class LogController extends Controller
             
             $sanitizeMap = [
                 'log_id' => 'intval',
+                'log_ids' => function ($value) {
+                    if (is_array($value)) {
+                        return array_map('intval', $value);
+                    }
+
+                    return [];
+                },
+                'type' => 'sanitize_text_field',
             ];
             $attributes = fluentform_backend_sanitizer($attributes, $sanitizeMap);
             

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -11,13 +11,13 @@ class ReportController extends Controller
     private function sanitizeReportAttributes($formId = null)
     {
         $sanitizeMap = [
-            'form_id'  => 'intval',
             'period'   => 'sanitize_text_field',
             'group_by' => 'sanitize_text_field',
             'status'   => 'sanitize_text_field',
         ];
 
         $attributes = fluentform_backend_sanitizer($this->request->all(), $sanitizeMap);
+        $requestFormId = $this->request->get('form_id');
 
         if (isset($attributes['date_range']) && is_array($attributes['date_range'])) {
             $attributes['date_range'] = array_map('sanitize_text_field', $attributes['date_range']);
@@ -26,7 +26,7 @@ class ReportController extends Controller
         $resolvedFormId = Acl::normalizeFormId($formId);
 
         if (!$resolvedFormId) {
-            $resolvedFormId = Acl::normalizeFormId(isset($attributes['form_id']) ? $attributes['form_id'] : null);
+            $resolvedFormId = Acl::normalizeFormId($requestFormId);
         }
 
         if ($resolvedFormId) {
@@ -93,7 +93,7 @@ class ReportController extends Controller
     public function netRevenue(ReportService $reportService)
     {
         try {
-            $data = apply_filters('fluentform/reports/revenue_analysis', [], $this->request->all());
+            $data = apply_filters('fluentform/reports/revenue_analysis', [], $this->sanitizeReportAttributes());
             return $this->sendSuccess($data);
             
         } catch (Exception $e) {
@@ -110,7 +110,7 @@ class ReportController extends Controller
     public function submissionsAnalysis()
     {
         try {
-            $data = apply_filters('fluentform/reports/submissions_analysis', [], $this->request->all());
+            $data = apply_filters('fluentform/reports/submissions_analysis', [], $this->sanitizeReportAttributes());
             return $this->sendSuccess($data);
         } catch (Exception $e) {
             return $this->sendError([
@@ -160,7 +160,7 @@ class ReportController extends Controller
     public function getCompletionRate()
     {
         try {
-            $data = apply_filters('fluentform/reports/completion_rate', [], $this->request->all());
+            $data = apply_filters('fluentform/reports/completion_rate', [], $this->sanitizeReportAttributes());
             return $this->sendSuccess($data);
         } catch (Exception $e) {
             return $this->sendError([
@@ -193,7 +193,7 @@ class ReportController extends Controller
     public function getHeatmapData()
     {
         try {
-            $data = apply_filters('fluentform/reports/heatmap_data', [], $this->request->all());
+            $data = apply_filters('fluentform/reports/heatmap_data', [], $this->sanitizeReportAttributes());
             return $this->sendSuccess($data);
         } catch (Exception $e) {
             return $this->sendError([
@@ -209,7 +209,7 @@ class ReportController extends Controller
     public function getCountryHeatmap(ReportService $reportService)
     {
         try {
-            $data = apply_filters('fluentform/reports/country_heatmap', [], $this->request->all());
+            $data = apply_filters('fluentform/reports/country_heatmap', [], $this->sanitizeReportAttributes());
             return $this->sendSuccess($data);
         } catch (Exception $e) {
             return $this->sendError([
@@ -259,7 +259,7 @@ class ReportController extends Controller
     public function getSubscriptions()
     {
         try {
-            $data = apply_filters('fluentform/reports/subscriptions', [], $this->request->all());
+            $data = apply_filters('fluentform/reports/subscriptions', [], $this->sanitizeReportAttributes());
             return $this->sendSuccess($data);
         } catch (Exception $e) {
             return $this->sendError([

--- a/app/Http/Controllers/ReportController.php
+++ b/app/Http/Controllers/ReportController.php
@@ -3,11 +3,12 @@
 namespace FluentForm\App\Http\Controllers;
 
 use Exception;
+use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\App\Services\Report\ReportService;
 
 class ReportController extends Controller
 {
-    private function sanitizeReportAttributes()
+    private function sanitizeReportAttributes($formId = null)
     {
         $sanitizeMap = [
             'form_id'  => 'intval',
@@ -22,14 +23,26 @@ class ReportController extends Controller
             $attributes['date_range'] = array_map('sanitize_text_field', $attributes['date_range']);
         }
 
+        $resolvedFormId = Acl::normalizeFormId($formId);
+
+        if (!$resolvedFormId) {
+            $resolvedFormId = Acl::normalizeFormId(isset($attributes['form_id']) ? $attributes['form_id'] : null);
+        }
+
+        if ($resolvedFormId) {
+            $attributes['form_id'] = $resolvedFormId;
+        } else {
+            unset($attributes['form_id']);
+        }
+
         return $attributes;
     }
 
-    public function form(ReportService $reportService)
+    public function form(ReportService $reportService, $formId)
     {
         try {
             return $this->sendSuccess(
-                $reportService->form($this->sanitizeReportAttributes())
+                $reportService->form($this->sanitizeReportAttributes($formId))
             );
         } catch (Exception $e) {
             return $this->sendError([

--- a/app/Http/Controllers/SubmissionLogController.php
+++ b/app/Http/Controllers/SubmissionLogController.php
@@ -28,16 +28,23 @@ class SubmissionLogController extends Controller
         }
     }
 
-    public function remove(Logger $logger)
+    public function remove(Logger $logger, $submissionId)
     {
         try {
             $attributes = $this->request->all();
             
             $sanitizeMap = [
-                'log_id' => 'intval',
-                'submission_id' => 'intval',
+                'log_ids' => function ($value) {
+                    if (is_array($value)) {
+                        return array_map('intval', $value);
+                    }
+
+                    return [];
+                },
+                'type' => 'sanitize_text_field',
             ];
             $attributes = fluentform_backend_sanitizer($attributes, $sanitizeMap);
+            $attributes['entry_id'] = intval($submissionId);
             
             return $this->sendSuccess(
                 $logger->remove($attributes)

--- a/app/Http/Policies/FormPolicy.php
+++ b/app/Http/Policies/FormPolicy.php
@@ -5,6 +5,7 @@ namespace FluentForm\App\Http\Policies;
 use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\Framework\Http\Request\Request;
 use FluentForm\Framework\Foundation\Policy;
+use FluentForm\Framework\Support\Arr;
 
 class FormPolicy extends Policy
 {
@@ -16,46 +17,59 @@ class FormPolicy extends Policy
      */
     public function verifyRequest(Request $request)
     {
-        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_forms_manager', $this->resolveFormId($request));
     }
 
     public function index(Request $request)
     {
-        return Acl::hasPermission('fluentform_dashboard_access', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_dashboard_access', $this->resolveFormId($request));
     }
 
     public function templates(Request $request)
     {
-        return Acl::hasAnyFormPermission($request->get('form_id'));
+        return Acl::hasAnyFormPermission($this->resolveFormId($request));
     }
 
     public function find(Request $request)
     {
-        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_forms_manager', $this->resolveFormId($request));
     }
 
     public function delete(Request $request)
     {
-        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_forms_manager', $this->resolveFormId($request));
     }
 
     public function integrationListComponent(Request $request)
     {
-        return Acl::hasPermission('fluentform_forms_manager', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_forms_manager', $this->resolveFormId($request));
     }
 
     public function updateModuleStatus(Request $request)
     {
-        return Acl::hasPermission('fluentform_settings_manager', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_settings_manager', $this->resolveFormId($request));
     }
 
     public function updateIntegration(Request $request)
     {
-        return Acl::hasPermission('fluentform_settings_manager', $request->get('form_id'));
+        return Acl::hasPermission('fluentform_settings_manager', $this->resolveFormId($request));
     }
 
     public function ping()
     {
         return Acl::hasAnyFormPermission();
+    }
+
+    private function resolveFormId(Request $request)
+    {
+        $route = $request->route();
+        $routeFormId = $route ? Arr::get($route->getParameter(), 'form_id') : null;
+        $routeFormId = Acl::normalizeFormId($routeFormId);
+
+        if ($routeFormId) {
+            return $routeFormId;
+        }
+
+        return Acl::normalizeFormId($request->get('form_id'));
     }
 }

--- a/app/Http/Policies/ReportPolicy.php
+++ b/app/Http/Policies/ReportPolicy.php
@@ -10,26 +10,29 @@ use FluentForm\Framework\Support\Arr;
 
 class ReportPolicy extends Policy
 {
-    private function canAccessDashboardReport(Request $request)
+    private function canAccessReportData(Request $request)
     {
-        if (!Acl::hasPermission('fluentform_dashboard_access')) {
-            return false;
-        }
-
         $formId = $this->resolveFormId($request);
 
         if ($formId) {
             return Acl::hasPermission('fluentform_entries_viewer', $formId);
         }
 
-        return true;
+        return Acl::hasPermission('fluentform_entries_viewer');
+    }
+
+    private function canAccessDashboardReport(Request $request)
+    {
+        if (!Acl::hasPermission('fluentform_dashboard_access')) {
+            return false;
+        }
+
+        return $this->canAccessReportData($request);
     }
 
     private function canAccessRequestedForm(Request $request)
     {
-        $formId = $this->resolveFormId($request);
-
-        return $formId && Acl::hasPermission('fluentform_entries_viewer', $formId);
+        return $this->canAccessReportData($request);
     }
 
     private function canAccessOptionalFormScopedReport(Request $request)
@@ -42,6 +45,10 @@ class ReportPolicy extends Policy
 
         if ($formId) {
             return Acl::hasPermission('fluentform_entries_viewer', $formId);
+        }
+
+        if (!Acl::hasPermission('fluentform_entries_viewer')) {
+            return false;
         }
 
         $userId = get_current_user_id();

--- a/app/Http/Policies/ReportPolicy.php
+++ b/app/Http/Policies/ReportPolicy.php
@@ -5,14 +5,15 @@ namespace FluentForm\App\Http\Policies;
 use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\Framework\Http\Request\Request;
 use FluentForm\Framework\Foundation\Policy;
+use FluentForm\Framework\Support\Arr;
 
 class ReportPolicy extends Policy
 {
     private function canAccessRequestedForm(Request $request)
     {
-        $formId = intval($request->get('form_id'));
+        $formId = $this->resolveFormId($request);
 
-        return Acl::hasPermission('fluentform_entries_viewer', $formId);
+        return $formId && Acl::hasPermission('fluentform_entries_viewer', $formId);
     }
 
     /**
@@ -59,5 +60,18 @@ class ReportPolicy extends Policy
     public function getPaymentTypes(Request $request)
     {
         return $this->canAccessRequestedForm($request);
+    }
+
+    private function resolveFormId(Request $request)
+    {
+        $route = $request->route();
+        $routeFormId = $route ? Arr::get($route->getParameter(), 'form_id') : null;
+        $routeFormId = Acl::normalizeFormId($routeFormId);
+
+        if ($routeFormId) {
+            return $routeFormId;
+        }
+
+        return Acl::normalizeFormId($request->get('form_id'));
     }
 }

--- a/app/Http/Policies/ReportPolicy.php
+++ b/app/Http/Policies/ReportPolicy.php
@@ -5,10 +5,16 @@ namespace FluentForm\App\Http\Policies;
 use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\Framework\Http\Request\Request;
 use FluentForm\Framework\Foundation\Policy;
-use FluentForm\Framework\Support\Arr;
 
 class ReportPolicy extends Policy
 {
+    private function canAccessRequestedForm(Request $request)
+    {
+        $formId = intval($request->get('form_id'));
+
+        return Acl::hasPermission('fluentform_entries_viewer', $formId);
+    }
+
     /**
      * Check permission for any method
      *
@@ -22,11 +28,36 @@ class ReportPolicy extends Policy
 
     public function form(Request $request)
     {
-        return Acl::hasPermission('fluentform_entries_viewer', intval($request->get('form_id')));
+        return $this->canAccessRequestedForm($request);
     }
 
-    public function submissions()
+    public function submissions(Request $request)
     {
-        return Acl::hasPermission('fluentform_entries_viewer');
+        return $this->canAccessRequestedForm($request);
+    }
+
+    public function getOverviewChart(Request $request)
+    {
+        return $this->canAccessRequestedForm($request);
+    }
+
+    public function getRevenueChart(Request $request)
+    {
+        return $this->canAccessRequestedForm($request);
+    }
+
+    public function getFormStats(Request $request)
+    {
+        return $this->canAccessRequestedForm($request);
+    }
+
+    public function getApiLogs(Request $request)
+    {
+        return $this->canAccessRequestedForm($request);
+    }
+
+    public function getPaymentTypes(Request $request)
+    {
+        return $this->canAccessRequestedForm($request);
     }
 }

--- a/app/Http/Policies/ReportPolicy.php
+++ b/app/Http/Policies/ReportPolicy.php
@@ -3,17 +3,50 @@
 namespace FluentForm\App\Http\Policies;
 
 use FluentForm\App\Modules\Acl\Acl;
+use FluentForm\App\Services\Manager\FormManagerService;
 use FluentForm\Framework\Http\Request\Request;
 use FluentForm\Framework\Foundation\Policy;
 use FluentForm\Framework\Support\Arr;
 
 class ReportPolicy extends Policy
 {
+    private function canAccessDashboardReport(Request $request)
+    {
+        if (!Acl::hasPermission('fluentform_dashboard_access')) {
+            return false;
+        }
+
+        $formId = $this->resolveFormId($request);
+
+        if ($formId) {
+            return Acl::hasPermission('fluentform_entries_viewer', $formId);
+        }
+
+        return true;
+    }
+
     private function canAccessRequestedForm(Request $request)
     {
         $formId = $this->resolveFormId($request);
 
         return $formId && Acl::hasPermission('fluentform_entries_viewer', $formId);
+    }
+
+    private function canAccessOptionalFormScopedReport(Request $request)
+    {
+        if (!Acl::hasPermission('fluentform_dashboard_access')) {
+            return false;
+        }
+
+        $formId = $this->resolveFormId($request);
+
+        if ($formId) {
+            return Acl::hasPermission('fluentform_entries_viewer', $formId);
+        }
+
+        $userId = get_current_user_id();
+
+        return !$userId || !FormManagerService::hasSpecificFormsPermission($userId);
     }
 
     /**
@@ -60,6 +93,46 @@ class ReportPolicy extends Policy
     public function getPaymentTypes(Request $request)
     {
         return $this->canAccessRequestedForm($request);
+    }
+
+    public function getCompletionRate(Request $request)
+    {
+        return $this->canAccessOptionalFormScopedReport($request);
+    }
+
+    public function getHeatmapData(Request $request)
+    {
+        return $this->canAccessOptionalFormScopedReport($request);
+    }
+
+    public function getCountryHeatmap(Request $request)
+    {
+        return $this->canAccessOptionalFormScopedReport($request);
+    }
+
+    public function getTopPerformingForms(Request $request)
+    {
+        return $this->canAccessDashboardReport($request);
+    }
+
+    public function getSubscriptions(Request $request)
+    {
+        return $this->canAccessOptionalFormScopedReport($request);
+    }
+
+    public function getFormsDropdown(Request $request)
+    {
+        return $this->canAccessDashboardReport($request);
+    }
+
+    public function netRevenue(Request $request)
+    {
+        return $this->canAccessOptionalFormScopedReport($request);
+    }
+
+    public function submissionsAnalysis(Request $request)
+    {
+        return $this->canAccessOptionalFormScopedReport($request);
     }
 
     private function resolveFormId(Request $request)

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -350,6 +350,7 @@ class Submission extends Model
         $from = date('Y-m-d H:i:s', strtotime('-30 days'));
         $to = date('Y-m-d H:i:s', strtotime('+1 days'));
         $formId = Arr::get($attributes, 'form_id');
+        $allowFormIds = FormManagerService::getUserAllowedForms();
         $status = Arr::get($attributes, 'entry_status');
         $start = Arr::get($attributes, 'date_range.0', '');
         $end = Arr::get($attributes, 'date_range.1', '');
@@ -357,6 +358,9 @@ class Submission extends Model
 
         if ('all' === $dateRange) {
             $firstItem = self::orderBy('created_at', 'ASC')
+                ->when($allowFormIds, function ($q) use ($allowFormIds) {
+                    return $q->whereIn('form_id', $allowFormIds);
+                })
                 ->when($formId, function ($q) use ($formId) {
                     return $q->where('form_id', $formId);
                 })
@@ -393,6 +397,9 @@ class Submission extends Model
             ->whereBetween('created_at', [$from, $to])
             ->groupBy('date')
             ->orderBy('date', 'ASC')
+            ->when($allowFormIds, function ($q) use ($allowFormIds) {
+                return $q->whereIn('form_id', $allowFormIds);
+            })
             ->when($formId, function ($q) use ($formId) {
                 return $q->where('form_id', $formId);
             })

--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -17,23 +17,17 @@ class Acl
             return null;
         }
 
-        if (is_int($formId)) {
-            return $formId > 0 ? $formId : null;
-        }
-
         if (is_string($formId)) {
             $formId = trim($formId);
-
-            if ($formId === '' || !ctype_digit($formId)) {
-                return null;
-            }
-
-            $formId = (int) $formId;
-
-            return $formId > 0 ? $formId : null;
         }
 
-        return null;
+        if (!is_int($formId) && (!is_string($formId) || !ctype_digit($formId))) {
+            return null;
+        }
+
+        $formId = (int) $formId;
+
+        return $formId > 0 ? $formId : null;
     }
 
     public static function verifyFormId(

--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -11,6 +11,51 @@ class Acl
 
     public static $role = '';
 
+    public static function normalizeFormId($formId)
+    {
+        if ($formId === null || $formId === false || $formId === '') {
+            return null;
+        }
+
+        if (is_int($formId)) {
+            return $formId > 0 ? $formId : null;
+        }
+
+        if (is_string($formId)) {
+            $formId = trim($formId);
+
+            if ($formId === '' || !ctype_digit($formId)) {
+                return null;
+            }
+
+            $formId = (int) $formId;
+
+            return $formId > 0 ? $formId : null;
+        }
+
+        return null;
+    }
+
+    public static function verifyFormId(
+        $formId,
+        $message = 'Invalid form id.',
+        $json = true
+    ) {
+        $formId = static::normalizeFormId($formId);
+
+        if ($formId) {
+            return $formId;
+        }
+
+        if ($json) {
+            wp_send_json_error([
+                'message' => $message,
+            ], 422);
+        }
+
+        throw new \InvalidArgumentException(esc_html($message));
+    }
+
     public static function getPermissionSet()
     {
         $data = [

--- a/app/Modules/Payments/Classes/PaymentEntries.php
+++ b/app/Modules/Payments/Classes/PaymentEntries.php
@@ -50,7 +50,9 @@ class PaymentEntries
         
         // Sanitize request data
         $sanitizeMap = [
-            'form_id'          => 'intval',
+            'form_id'          => function ($value) {
+                return Acl::normalizeFormId($value);
+            },
             'per_page'         => 'intval',
             'payment_statuses' => 'sanitize_text_field',
             'payment_types'    => 'sanitize_text_field',

--- a/app/Modules/Payments/Classes/PaymentEntries.php
+++ b/app/Modules/Payments/Classes/PaymentEntries.php
@@ -123,8 +123,6 @@ class PaymentEntries
     
     public function handleBulkAction()
     {
-        Acl::verify('fluentform_forms_manager');
-
         $request = wpFluentForm()->request;
         $attributes = $request->all();
         
@@ -151,12 +149,12 @@ class PaymentEntries
         $statusCode = 400;
         // permanently delete payment entries from transactions
         if ($actionType == 'delete_items') {
-    
-            
             // get submission ids to delete order items
-            $transactionData = Transaction::select(['form_id', 'submission_id'])
+            $transactionData = Transaction::select(['id', 'form_id', 'submission_id'])
                 ->whereIn('id', $entries)
                 ->get();
+
+            $this->authorizeTransactionForms($transactionData);
 
             $submission_ids = [];
 
@@ -225,6 +223,25 @@ class PaymentEntries
         wp_send_json_success([
             'message' => $message
         ], $statusCode);
+    }
+
+    private function authorizeTransactionForms($transactionData)
+    {
+        Acl::verify('fluentform_forms_manager');
+
+        $formIds = [];
+
+        foreach ($transactionData as $transaction) {
+            $formIds[(int) $transaction->form_id] = true;
+        }
+
+        foreach (array_keys($formIds) as $formId) {
+            if (!Acl::hasPermission('fluentform_forms_manager', $formId)) {
+                wp_send_json_error([
+                    'message' => __('You do not have permission to perform this action.', 'fluentform')
+                ], 422);
+            }
+        }
     }
 
     public function getFilters()

--- a/app/Modules/Payments/PaymentHandler.php
+++ b/app/Modules/Payments/PaymentHandler.php
@@ -418,7 +418,7 @@ class PaymentHandler
         switch ($route) {
             case 'get_form_settings':
             case 'save_form_settings':
-                return absint(wpFluentForm()->request->get('form_id'));
+                return Acl::verifyFormId(wpFluentForm()->request->get('form_id'));
             case 'update_transaction':
                 return $this->resolveTransactionFormId();
             case 'cancel_subscription':

--- a/app/Modules/Payments/PaymentHandler.php
+++ b/app/Modules/Payments/PaymentHandler.php
@@ -395,16 +395,64 @@ class PaymentHandler
     public function handleAjaxEndpoints()
     {
         // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce verified by Acl::verify()
-        if (isset($_REQUEST['form_id'])) {
-            Acl::verify('fluentform_forms_manager');
+        $route = isset($_REQUEST['route']) ? sanitize_text_field(wp_unslash($_REQUEST['route'])) : '';
+        $formScopedRoutes = [
+            'get_form_settings',
+            'save_form_settings',
+            'update_transaction',
+            'cancel_subscription'
+        ];
+
+        if (in_array($route, $formScopedRoutes, true)) {
+            Acl::verify('fluentform_forms_manager', $this->resolveRouteFormId($route));
         } else {
             Acl::verify('fluentform_settings_manager');
         }
-
-        $route = isset($_REQUEST['route']) ? sanitize_text_field(wp_unslash($_REQUEST['route'])) : '';
         // phpcs:enable WordPress.Security.NonceVerification.Recommended -- End of AJAX endpoint nonce verification by Acl::verify()
 
         (new AjaxEndpoints())->handleEndpoint($route);
+    }
+
+    private function resolveRouteFormId($route)
+    {
+        switch ($route) {
+            case 'get_form_settings':
+            case 'save_form_settings':
+                return absint(wpFluentForm()->request->get('form_id'));
+            case 'update_transaction':
+                return $this->resolveTransactionFormId();
+            case 'cancel_subscription':
+                return $this->resolveSubscriptionFormId();
+            default:
+                return null;
+        }
+    }
+
+    private function resolveTransactionFormId()
+    {
+        $transactionData = wpFluentForm()->request->get('transaction', []);
+        $transactionId = absint(ArrayHelper::get($transactionData, 'id'));
+
+        if (!$transactionId) {
+            return -1;
+        }
+
+        $transaction = \FluentForm\App\Models\Transaction::select('form_id')->find($transactionId);
+
+        return $transaction ? (int) $transaction->form_id : -1;
+    }
+
+    private function resolveSubscriptionFormId()
+    {
+        $subscriptionId = absint(wpFluentForm()->request->get('subscription_id'));
+
+        if (!$subscriptionId) {
+            return -1;
+        }
+
+        $subscription = \FluentForm\App\Models\Subscription::select('form_id')->find($subscriptionId);
+
+        return $subscription ? (int) $subscription->form_id : -1;
     }
     
     public function maybeHandlePayment($insertData, $data, $form)

--- a/app/Modules/Payments/TransactionShortcodes.php
+++ b/app/Modules/Payments/TransactionShortcodes.php
@@ -5,6 +5,7 @@ namespace FluentForm\App\Modules\Payments   ;
 use FluentForm\App\Helpers\Helper;
 use FluentForm\App\Models\Subscription;
 use FluentForm\App\Models\Transaction;
+use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\Framework\Helpers\ArrayHelper;
 use FluentForm\App\Modules\Payments\Classes\PaymentReceipt;
 use FluentForm\App\Modules\Payments\Orders\OrderData;
@@ -451,16 +452,17 @@ class TransactionShortcodes
         // validate the subscription
         $userid = get_current_user_id();
         $submission = fluentFormApi('submissions')->find($subscription->submission_id);
-        $canManagePayments = current_user_can('fluentform_manage_payments') || current_user_can('fluentform_full_access');
 
         if (!$submission || !$this->canCancelSubscription($subscription)) {
             $this->sendError(__('Sorry, you can not cancel this subscription at this moment', 'fluentform'));
         }
 
+        $canManagePayments = Acl::hasPermission('fluentform_manage_payments', $submission->form_id);
+
         if (!$canManagePayments && (int) $submission->user_id !== (int) $userid) {
             $this->sendError(__('Sorry, you can not cancel this subscription at this moment', 'fluentform'));
         }
-	    
+
         $handler = apply_filters_deprecated(
             'fluentform_payment_manager_class_' . $submission->payment_method,
             [

--- a/app/Modules/Payments/TransactionShortcodes.php
+++ b/app/Modules/Payments/TransactionShortcodes.php
@@ -451,11 +451,16 @@ class TransactionShortcodes
         // validate the subscription
         $userid = get_current_user_id();
         $submission = fluentFormApi('submissions')->find($subscription->submission_id);
+        $canManagePayments = current_user_can('fluentform_manage_payments') || current_user_can('fluentform_full_access');
 
-        if (!$submission || ($submission->user_id != $userid && !$this->canCancelSubscription($subscription))) {
+        if (!$submission || !$this->canCancelSubscription($subscription)) {
             $this->sendError(__('Sorry, you can not cancel this subscription at this moment', 'fluentform'));
         }
-    
+
+        if (!$canManagePayments && (int) $submission->user_id !== (int) $userid) {
+            $this->sendError(__('Sorry, you can not cancel this subscription at this moment', 'fluentform'));
+        }
+	    
         $handler = apply_filters_deprecated(
             'fluentform_payment_manager_class_' . $submission->payment_method,
             [

--- a/app/Services/Logger/Logger.php
+++ b/app/Services/Logger/Logger.php
@@ -294,7 +294,7 @@ class Logger
 
     public function remove($attributes = [])
     {
-        $ids = Arr::get($attributes, 'log_ids');
+        $ids = $this->normalizeLogIds($attributes);
 
         if (!$ids) {
             throw new ValidationException(
@@ -303,14 +303,97 @@ class Logger
             );
         }
 
-        $logType = Arr::get($attributes, 'type', 'logs');
+        $logType = Arr::get($attributes, 'type', Arr::get($attributes, 'log_type', 'logs'));
+        $entryId = intval(Arr::get($attributes, 'entry_id'));
+        $targetLogs = $this->getLogsForDeletion($ids, $logType);
 
-        $model = 'logs' === $logType ? Log::query() : Scheduler::query();
+        if (!$targetLogs->count()) {
+            throw new ValidationException(
+               // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
+                __('No selections found', 'fluentform')
+            );
+        }
 
-        $model->whereIn('id', $ids)->delete();
+        $this->assertDeletePermission($targetLogs, $entryId);
+        $this->getDeleteQuery($logType)
+            ->whereIn('id', $targetLogs->pluck('id')->all())
+            ->delete();
 
         return [
             'message' => __('Selected log(s) successfully deleted', 'fluentform'),
         ];
+    }
+
+    protected function normalizeLogIds($attributes)
+    {
+        $ids = Arr::get($attributes, 'log_ids', []);
+
+        if (!is_array($ids)) {
+            $ids = [];
+        }
+
+        $singleLogId = intval(Arr::get($attributes, 'log_id'));
+        if ($singleLogId) {
+            $ids[] = $singleLogId;
+        }
+
+        $ids = array_map('intval', $ids);
+        $ids = array_filter($ids);
+
+        return array_values(array_unique($ids));
+    }
+
+    protected function getLogsForDeletion($ids, $logType)
+    {
+        if ('logs' === $logType) {
+            return Log::select([
+                'id',
+                'parent_source_id as form_id',
+                'source_id as submission_id',
+            ])->whereIn('id', $ids)->get();
+        }
+
+        return Scheduler::select([
+            'id',
+            'form_id',
+            'origin_id as submission_id',
+        ])->whereIn('id', $ids)->get();
+    }
+
+    protected function getDeleteQuery($logType)
+    {
+        return 'logs' === $logType ? Log::query() : Scheduler::query();
+    }
+
+    protected function assertDeletePermission($targetLogs, $entryId = 0)
+    {
+        if ($entryId) {
+            foreach ($targetLogs as $targetLog) {
+                if (intval($targetLog->submission_id) !== $entryId) {
+                    $this->throwDeletePermissionError();
+                }
+            }
+        }
+
+        $allowedForms = FormManagerService::getUserAllowedForms();
+        if (!$allowedForms) {
+            return;
+        }
+
+        foreach ($targetLogs as $targetLog) {
+            $formId = intval($targetLog->form_id);
+
+            if (!$formId || !in_array($formId, $allowedForms, true)) {
+                $this->throwDeletePermissionError();
+            }
+        }
+    }
+
+    protected function throwDeletePermissionError()
+    {
+        throw new ValidationException(
+           // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
+            __('You do not have permission to delete the selected logs', 'fluentform')
+        );
     }
 }

--- a/app/Services/Manager/FormManagerService.php
+++ b/app/Services/Manager/FormManagerService.php
@@ -6,6 +6,31 @@ namespace FluentForm\App\Services\Manager;
 
 class FormManagerService
 {
+    private static function normalizeFormIds($formIds)
+    {
+        $formIds = is_array($formIds) ? $formIds : [$formIds];
+        $resolvedFormIds = [];
+
+        foreach ($formIds as $formId) {
+            if (is_string($formId)) {
+                $formId = trim($formId);
+            }
+
+            if (!is_int($formId) && (!is_string($formId) || !ctype_digit($formId))) {
+                return [];
+            }
+
+            $formId = (int) $formId;
+
+            if ($formId <= 0) {
+                return [];
+            }
+
+            $resolvedFormIds[] = $formId;
+        }
+
+        return array_values(array_unique($resolvedFormIds));
+    }
 
     public static function maybeAddUserAllowedFormIds($formId)
     {
@@ -62,9 +87,15 @@ class FormManagerService
     public static function hasFormPermission($formId)
     {
         if ($formId && $allowedForm = self::getUserAllowedForms()) {
-            $formId = is_array($formId) ? array_map('intval', $formId) : [intval($formId)];
-            return (bool)array_intersect($formId, $allowedForm);
+            $formIds = self::normalizeFormIds($formId);
+
+            if (!$formIds) {
+                return false;
+            }
+
+            return !array_diff($formIds, $allowedForm);
         }
+
         return true;
     }
 }

--- a/app/Services/Report/ReportHelper.php
+++ b/app/Services/Report/ReportHelper.php
@@ -10,11 +10,25 @@ use FluentForm\App\Models\Log;
 use FluentForm\App\Models\Submission;
 use FluentForm\App\Modules\Form\FormFieldsParser;
 use FluentForm\App\Modules\Payments\PaymentHelper;
+use FluentForm\App\Services\Manager\FormManagerService;
 use FluentForm\App\Services\Submission\SubmissionService;
 use FluentForm\Framework\Helpers\ArrayHelper as Arr;
 
 class ReportHelper
 {
+    private static function scopeQueryToAllowedForms($query, $formId = null, $column = 'form_id')
+    {
+        if ($formId) {
+            return $query->where($column, $formId);
+        }
+
+        if ($allowedFormIds = FormManagerService::getUserAllowedForms()) {
+            return $query->whereIn($column, $allowedFormIds);
+        }
+
+        return $query;
+    }
+
     public static function generateReport($form, $statuses = ['read', 'unread', 'unapproved', 'approved', 'declined', 'unconfirmed', 'confirmed'])
     {
         $formInputs = FormFieldsParser::getEntryInputs($form, ['admin_label', 'element', 'options']);
@@ -444,37 +458,31 @@ class ReportHelper
         $previousEndDate = $previousEndDateTime->format('Y-m-d H:i:s');
 
         // Get submission counts
-        $periodSubmissions = Submission::whereBetween('created_at', [$startDate, $endDate])
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })->count();
-        $previousPeriodSubmissions = Submission::whereBetween('created_at',
-            [$previousStartDate, $previousEndDate])
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })->count();
+        $periodSubmissionsQuery = Submission::whereBetween('created_at', [$startDate, $endDate]);
+        self::scopeQueryToAllowedForms($periodSubmissionsQuery, $formId);
+        $periodSubmissions = $periodSubmissionsQuery->count();
+
+        $previousPeriodSubmissionsQuery = Submission::whereBetween('created_at', [$previousStartDate, $previousEndDate]);
+        self::scopeQueryToAllowedForms($previousPeriodSubmissionsQuery, $formId);
+        $previousPeriodSubmissions = $previousPeriodSubmissionsQuery->count();
 
         // Get submission status counts (grouped)
-        $statusCounts = Submission::whereBetween('created_at', [$startDate, $endDate])
+        $statusCountsQuery = Submission::whereBetween('created_at', [$startDate, $endDate])
             ->selectRaw('status, COUNT(*) as count')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->groupBy('status')
-            ->pluck('count', 'status');
+            ->groupBy('status');
+        self::scopeQueryToAllowedForms($statusCountsQuery, $formId);
+        $statusCounts = $statusCountsQuery->pluck('count', 'status');
 
         $unreadSubmissions = intval(Arr::get($statusCounts, 'unread', 0));
         $readSubmissions = intval(Arr::get($statusCounts, 'read', 0));
         $periodSpamSubmissions = intval(Arr::get($statusCounts, 'spam', 0));
 
 
-        $previousStatusCounts = Submission::whereBetween('created_at', [$previousStartDate, $previousEndDate])
+        $previousStatusCountsQuery = Submission::whereBetween('created_at', [$previousStartDate, $previousEndDate])
             ->selectRaw('status, COUNT(*) as count')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->groupBy('status')
-            ->pluck('count', 'status');
+            ->groupBy('status');
+        self::scopeQueryToAllowedForms($previousStatusCountsQuery, $formId);
+        $previousStatusCounts = $previousStatusCountsQuery->pluck('count', 'status');
 
         $previousSpamSubmissions = intval(Arr::get($previousStatusCounts, 'spam', 0));
 
@@ -508,10 +516,13 @@ class ReportHelper
         $spamType = $spamPercentage > 0 ? 'down' : ($spamPercentage < 0 ? 'up' : 'neutral'); // Refunds going up is bad
 
         // Active forms
-        $periodActiveFormsCount = Form::where('status', 'published')->whereBetween('created_at',
-            [$startDate, $endDate])->count();
-        $previousActiveFormsCount = Form::where('status', 'published')->whereBetween('created_at',
-            [$previousStartDate, $previousEndDate])->count();
+        $periodActiveFormsQuery = Form::where('status', 'published')->whereBetween('created_at', [$startDate, $endDate]);
+        self::scopeQueryToAllowedForms($periodActiveFormsQuery, $formId, 'id');
+        $periodActiveFormsCount = $periodActiveFormsQuery->count();
+
+        $previousActiveFormsQuery = Form::where('status', 'published')->whereBetween('created_at', [$previousStartDate, $previousEndDate]);
+        self::scopeQueryToAllowedForms($previousActiveFormsQuery, $formId, 'id');
+        $previousActiveFormsCount = $previousActiveFormsQuery->count();
         $activeFormsPercentage = 0;
         if ($previousActiveFormsCount > 0) {
             $activeFormsPercentage = round((($periodActiveFormsCount - $previousActiveFormsCount) / $previousActiveFormsCount) * 100,
@@ -599,13 +610,12 @@ class ReportHelper
                 COUNT(*) as count
             ')
                 ->whereBetween('created_at', [$startDate, $endDate])
-                ->when($formId, function ($q) use ($formId) {
-                    return $q->where('form_id', $formId);
-                })
                 ->whereNotIn('status', ['trashed', 'spam'])
                 ->groupBy('day_of_week', 'submission_hour')
                 ->orderBy('day_of_week')
                 ->orderBy('submission_hour');
+
+            self::scopeQueryToAllowedForms($query, $formId);
 
             return $query->get();
         }
@@ -661,9 +671,7 @@ class ReportHelper
                 ->orWhereNotIn('component', $excludedComponents);
         });
 
-        if ($formId) {
-            $logsQuery->where('parent_source_id', $formId);
-        }
+        self::scopeQueryToAllowedForms($logsQuery, $formId, 'parent_source_id');
 
         $results = $logsQuery->selectRaw($dateFormat . ' as log_date')
             ->selectRaw('status')
@@ -679,6 +687,8 @@ class ReportHelper
             $query->whereNull('component')
                 ->orWhereNotIn('component', $excludedComponents);
         });
+
+        self::scopeQueryToAllowedForms($totalsQuery, $formId, 'parent_source_id');
 
         $totalsResults = $totalsQuery->selectRaw('status')
             ->selectRaw('COUNT(*) as count')
@@ -872,19 +882,17 @@ class ReportHelper
         // 1. Get UNIQUE VIEWS by IP address
         $viewsQuery = FormAnalytics::whereBetween('created_at', [$startDate, $endDate])
             ->whereNotNull('ip');
-
-        if ($formId) {
-            $viewsQuery->where('form_id', $formId);
-        }
+        self::scopeQueryToAllowedForms($viewsQuery, $formId);
 
         // Group by date and IP to count unique visitors
         if ($groupingMode === 'day') {
             $viewsQuery->selectRaw('DATE(created_at) as date_group, COUNT(DISTINCT ip) as unique_count');
         } elseif ($groupingMode === '3days') {
             // Get min date for reference
-            $minDateRecord = FormAnalytics::whereBetween('created_at', [$startDate, $endDate])
-                ->selectRaw('MIN(DATE(created_at)) as min_date')
-                ->first();
+            $minDateQuery = FormAnalytics::whereBetween('created_at', [$startDate, $endDate])
+                ->selectRaw('MIN(DATE(created_at)) as min_date');
+            self::scopeQueryToAllowedForms($minDateQuery, $formId);
+            $minDateRecord = $minDateQuery->first();
 
             if ($minDateRecord && $minDateRecord->min_date) {
                 $minDate = $minDateRecord->min_date;
@@ -960,11 +968,7 @@ class ReportHelper
     private static function getAggregatedData($startDate, $endDate, $groupingMode, $view, $formId)
     {
         $baseQuery = Submission::whereBetween('created_at', [$startDate, $endDate]);
-
-        // Filter by form ID if provided
-        if ($formId) {
-            $baseQuery->where('form_id', $formId);
-        }
+        self::scopeQueryToAllowedForms($baseQuery, $formId);
 
         if ($view === 'revenue') {
             // Clone the base query for each payment status
@@ -996,9 +1000,10 @@ class ReportHelper
                 $refundedQuery->selectRaw('DATE(created_at) as date_group')->groupBy('date_group');
             } elseif ($groupingMode === '3days') {
                 // Get minimum date for reference
-                $minDateRecord = Submission::whereBetween('created_at', [$startDate, $endDate])
-                    ->selectRaw('MIN(DATE(created_at)) as min_date')
-                    ->first();
+                $minDateQuery = Submission::whereBetween('created_at', [$startDate, $endDate])
+                    ->selectRaw('MIN(DATE(created_at)) as min_date');
+                self::scopeQueryToAllowedForms($minDateQuery, $formId);
+                $minDateRecord = $minDateQuery->first();
 
                 if ($minDateRecord && $minDateRecord->min_date) {
                     $minDate = $minDateRecord->min_date;
@@ -1071,9 +1076,10 @@ class ReportHelper
                 $query->selectRaw('DATE(created_at) as date_group')
                     ->groupBy('date_group');
             } elseif ($groupingMode === '3days') {
-                $minDateRecord = Submission::whereBetween('created_at', [$startDate, $endDate])
-                    ->selectRaw('MIN(DATE(created_at)) as min_date')
-                    ->first();
+                $minDateQuery = Submission::whereBetween('created_at', [$startDate, $endDate])
+                    ->selectRaw('MIN(DATE(created_at)) as min_date');
+                self::scopeQueryToAllowedForms($minDateQuery, $formId);
+                $minDateRecord = $minDateQuery->first();
 
                 if ($minDateRecord && $minDateRecord->min_date) {
                     $query->selectRaw("MIN(DATE(created_at)) as date_group")
@@ -1235,9 +1241,7 @@ class ReportHelper
             $query->where('transaction_type', 'onetime');
         }
         
-        if ($formId) {
-            $query->where('form_id', $formId);
-        }
+        self::scopeQueryToAllowedForms($query, $formId);
         
         // Get payments grouped by status
         $payments = $query->select('status')
@@ -1394,64 +1398,52 @@ class ReportHelper
     private static function getPaymentStats($startDate, $endDate, $previousStartDate, $previousEndDate, $formId)
     {
         // Get total payments (paid status) for current period
-        $currentPayments = wpFluent()
+        $currentPaymentsQuery = wpFluent()
             ->table('fluentform_transactions')
             ->whereBetween('created_at', [$startDate, $endDate])
-            ->where('status', 'paid')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->sum('payment_total');
+            ->where('status', 'paid');
+        self::scopeQueryToAllowedForms($currentPaymentsQuery, $formId);
+        $currentPayments = $currentPaymentsQuery->sum('payment_total');
 
         // Get total payments for previous period
-        $previousPayments = wpFluent()
+        $previousPaymentsQuery = wpFluent()
             ->table('fluentform_transactions')
             ->whereBetween('created_at', [$previousStartDate, $previousEndDate])
-            ->where('status', 'paid')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->sum('payment_total');
+            ->where('status', 'paid');
+        self::scopeQueryToAllowedForms($previousPaymentsQuery, $formId);
+        $previousPayments = $previousPaymentsQuery->sum('payment_total');
 
         // Get pending payments for current period
-        $currentPending = wpFluent()
+        $currentPendingQuery = wpFluent()
             ->table('fluentform_transactions')
             ->whereBetween('created_at', [$startDate, $endDate])
-            ->where('status', 'pending')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->sum('payment_total');
+            ->where('status', 'pending');
+        self::scopeQueryToAllowedForms($currentPendingQuery, $formId);
+        $currentPending = $currentPendingQuery->sum('payment_total');
 
         // Get pending payments for previous period
-        $previousPending = wpFluent()
+        $previousPendingQuery = wpFluent()
             ->table('fluentform_transactions')
             ->whereBetween('created_at', [$previousStartDate, $previousEndDate])
-            ->where('status', 'pending')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->sum('payment_total');
+            ->where('status', 'pending');
+        self::scopeQueryToAllowedForms($previousPendingQuery, $formId);
+        $previousPending = $previousPendingQuery->sum('payment_total');
 
         // Get total refunds for current period
-        $currentRefunds = wpFluent()
+        $currentRefundsQuery = wpFluent()
             ->table('fluentform_transactions')
             ->whereBetween('created_at', [$startDate, $endDate])
-            ->where('status', 'refunded')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->sum('payment_total');
+            ->where('status', 'refunded');
+        self::scopeQueryToAllowedForms($currentRefundsQuery, $formId);
+        $currentRefunds = $currentRefundsQuery->sum('payment_total');
 
         // Get total refunds for previous period
-        $previousRefunds = wpFluent()
+        $previousRefundsQuery = wpFluent()
             ->table('fluentform_transactions')
             ->whereBetween('created_at', [$previousStartDate, $previousEndDate])
-            ->where('status', 'refunded')
-            ->when($formId, function ($q) use ($formId) {
-                return $q->where('form_id', $formId);
-            })
-            ->sum('payment_total');
+            ->where('status', 'refunded');
+        self::scopeQueryToAllowedForms($previousRefundsQuery, $formId);
+        $previousRefunds = $previousRefundsQuery->sum('payment_total');
 
         // Convert from cents to dollars
         $currentPayments = $currentPayments ? $currentPayments / 100 : 0;

--- a/app/Services/Report/ReportHelper.php
+++ b/app/Services/Report/ReportHelper.php
@@ -738,13 +738,14 @@ class ReportHelper
     /**
      * Get top performing forms by entries, views, or payments
      */
-    public static function getTopPerformingForms($startDate, $endDate, $metric = 'entries')
+    public static function getTopPerformingForms($startDate, $endDate, $metric = 'entries', $formIds = [])
     {
         list($startDate, $endDate) = self::processDateRange($startDate, $endDate);
         global $wpdb;
         $prefix = $wpdb->prefix;
         $formResults = [];
         $disableMessage = '';
+        $formIds = array_values(array_filter(array_map('intval', (array) $formIds)));
 
         switch ($metric) {
             case 'entries':
@@ -755,7 +756,13 @@ class ReportHelper
                             $q->whereBetween('created_at', [$startDate, $endDate]);
                             $q->whereNotIn('status', ['trashed', 'spam']);
                         }
-                    ])
+                    ]);
+
+                if ($formIds) {
+                    $results->whereIn('id', $formIds);
+                }
+
+                $results = $results
                     ->orderBy('submissions_count', 'DESC')
                     ->limit(5)
                     ->get();
@@ -783,7 +790,13 @@ class ReportHelper
                         ->leftJoin('fluentform_transactions', 'fluentform_forms.id', '=',
                             'fluentform_transactions.form_id')
                         ->whereBetween('fluentform_transactions.created_at', [$startDate, $endDate])
-                        ->where('fluentform_transactions.status', 'paid')
+                        ->where('fluentform_transactions.status', 'paid');
+
+                    if ($formIds) {
+                        $results->whereIn('fluentform_forms.id', $formIds);
+                    }
+
+                    $results = $results
                         ->groupBy('fluentform_forms.id')
                         ->orderBy('raw_value', 'DESC')
                         ->limit(5)
@@ -811,7 +824,13 @@ class ReportHelper
                         ])
                         ->leftJoin('fluentform_form_analytics', 'fluentform_forms.id', '=',
                             'fluentform_form_analytics.form_id')
-                        ->whereBetween('fluentform_form_analytics.created_at', [$startDate, $endDate])
+                        ->whereBetween('fluentform_form_analytics.created_at', [$startDate, $endDate]);
+
+                    if ($formIds) {
+                        $results->whereIn('fluentform_forms.id', $formIds);
+                    }
+
+                    $results = $results
                         ->groupBy('fluentform_forms.id')
                         ->orderBy('value', 'DESC')
                         ->limit(5)

--- a/app/Services/Report/ReportService.php
+++ b/app/Services/Report/ReportService.php
@@ -5,6 +5,7 @@ namespace FluentForm\App\Services\Report;
 use Exception;
 use FluentForm\App\Models\Form;
 use FluentForm\App\Models\Submission;
+use FluentForm\App\Services\Manager\FormManagerService;
 use FluentForm\Framework\Helpers\ArrayHelper as Arr;
 use FluentForm\Framework\Support\Sanitizer;
 
@@ -53,8 +54,11 @@ class ReportService
     public function getFormsDropdown()
     {
         $forms = Form::select(['id', 'title', 'has_payment'])
-                     ->orderBy('id', 'DESC')
-                     ->get();
+            ->when(FormManagerService::getUserAllowedForms(), function ($query, $allowFormIds) {
+                return $query->whereIn('id', $allowFormIds);
+            })
+            ->orderBy('id', 'DESC')
+            ->get();
 
         return [
             'forms' => $forms

--- a/app/Services/Report/ReportService.php
+++ b/app/Services/Report/ReportService.php
@@ -5,6 +5,7 @@ namespace FluentForm\App\Services\Report;
 use Exception;
 use FluentForm\App\Models\Form;
 use FluentForm\App\Models\Submission;
+use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\App\Services\Manager\FormManagerService;
 use FluentForm\Framework\Helpers\ArrayHelper as Arr;
 use FluentForm\Framework\Support\Sanitizer;
@@ -194,7 +195,7 @@ class ReportService
 
         $startDate = Arr::get($data, 'start_date');
         $endDate = Arr::get($data, 'end_date');
-        $formId = intval(Arr::get($data, 'form_id'));
+        $formId = Acl::normalizeFormId(Arr::get($data, 'form_id'));
 
         // Set default date range if not provided
         if (!$startDate || !$endDate) {

--- a/app/Services/Report/ReportService.php
+++ b/app/Services/Report/ReportService.php
@@ -152,12 +152,15 @@ class ReportService
         $startDate = $data['start_date'];
         $endDate = $data['end_date'];
         $metric = Arr::get($data, 'metric', 'entries');
+        $allowedFormIds = FormManagerService::getUserAllowedForms();
+        $requestedFormId = Arr::get($data, 'form_id');
+        $scopedFormIds = $requestedFormId ? [$requestedFormId] : $allowedFormIds;
 
         if (!in_array($metric, ['entries', 'payments', 'views'])) {
             $metric = 'entries';
         }
 
-        $result = ReportHelper::getTopPerformingForms($startDate, $endDate, $metric);
+        $result = ReportHelper::getTopPerformingForms($startDate, $endDate, $metric, $scopedFormIds);
         return [
             'top_performing_forms' => Arr::get($result, 'data', []),
             'disable_message'      => Arr::get($result, 'disable_message', '')

--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -145,11 +145,8 @@ class TransferService
             define('FLUENTFORM_EXPORTING_ENTRIES', true);
         }
 
-        $formId = (int)Arr::get($args, 'form_id');
-
-        if ($formId) {
-            Acl::verify('fluentform_entries_viewer', $formId);
-        }
+        $formId = Acl::verifyFormId(Arr::get($args, 'form_id'));
+        Acl::verify('fluentform_entries_viewer', $formId);
 
         $tableName = Arr::get($args, 'table');
         try {

--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -10,6 +10,7 @@ use FluentForm\App\Models\Form;
 use FluentForm\App\Models\FormMeta;
 use FluentForm\App\Models\Submission;
 use FluentForm\App\Models\SubmissionMeta;
+use FluentForm\App\Modules\Acl\Acl;
 use FluentForm\App\Modules\Form\FormDataParser;
 use FluentForm\App\Modules\Form\FormFieldsParser;
 use FluentForm\App\Services\FormBuilder\ShortCodeParser;
@@ -143,7 +144,13 @@ class TransferService
         if (!defined('FLUENTFORM_EXPORTING_ENTRIES')) {
             define('FLUENTFORM_EXPORTING_ENTRIES', true);
         }
+
         $formId = (int)Arr::get($args, 'form_id');
+
+        if ($formId) {
+            Acl::verify('fluentform_entries_viewer', $formId);
+        }
+
         $tableName = Arr::get($args, 'table');
         try {
             $form = Form::findOrFail($formId);


### PR DESCRIPTION
## What does this PR do and why?

Passes the requested `form_id` into the legacy general-settings and email-notification AJAX permission checks. This ensures a user must have access to the specific form being updated instead of only holding a broad forms capability.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Create two forms and a user who can manage only one of them.
2. Save general settings and email notifications for the allowed form and confirm both requests succeed.
3. Repeat the same requests for a disallowed form by changing the `form_id` in the request.
4. Confirm the unauthorized requests are blocked.

## Anything the reviewer should know?

This only affects the remaining legacy AJAX handlers for form settings. It does not change the payload shape or the saved data.