### PR TITLE
Fix: Authorize payment ajax routes by target form

### DIFF
--- a/app/Modules/Payments/PaymentHandler.php
+++ b/app/Modules/Payments/PaymentHandler.php
@@ -395,16 +395,64 @@ class PaymentHandler
     public function handleAjaxEndpoints()
     {
         // phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce verified by Acl::verify()
-        if (isset($_REQUEST['form_id'])) {
-            Acl::verify('fluentform_forms_manager');
+        $route = isset($_REQUEST['route']) ? sanitize_text_field(wp_unslash($_REQUEST['route'])) : '';
+        $formScopedRoutes = [
+            'get_form_settings',
+            'save_form_settings',
+            'update_transaction',
+            'cancel_subscription'
+        ];
+
+        if (in_array($route, $formScopedRoutes, true)) {
+            Acl::verify('fluentform_forms_manager', $this->resolveRouteFormId($route));
         } else {
             Acl::verify('fluentform_settings_manager');
         }
-
-        $route = isset($_REQUEST['route']) ? sanitize_text_field(wp_unslash($_REQUEST['route'])) : '';
         // phpcs:enable WordPress.Security.NonceVerification.Recommended -- End of AJAX endpoint nonce verification by Acl::verify()
 
         (new AjaxEndpoints())->handleEndpoint($route);
+    }
+
+    private function resolveRouteFormId($route)
+    {
+        switch ($route) {
+            case 'get_form_settings':
+            case 'save_form_settings':
+                return absint(wpFluentForm()->request->get('form_id'));
+            case 'update_transaction':
+                return $this->resolveTransactionFormId();
+            case 'cancel_subscription':
+                return $this->resolveSubscriptionFormId();
+            default:
+                return null;
+        }
+    }
+
+    private function resolveTransactionFormId()
+    {
+        $transactionData = wpFluentForm()->request->get('transaction', []);
+        $transactionId = absint(ArrayHelper::get($transactionData, 'id'));
+
+        if (!$transactionId) {
+            return -1;
+        }
+
+        $transaction = \FluentForm\App\Models\Transaction::select('form_id')->find($transactionId);
+
+        return $transaction ? (int) $transaction->form_id : -1;
+    }
+
+    private function resolveSubscriptionFormId()
+    {
+        $subscriptionId = absint(wpFluentForm()->request->get('subscription_id'));
+
+        if (!$subscriptionId) {
+            return -1;
+        }
+
+        $subscription = \FluentForm\App\Models\Subscription::select('form_id')->find($subscriptionId);
+
+        return $subscription ? (int) $subscription->form_id : -1;
     }
     
     public function maybeHandlePayment($insertData, $data, $form)


### PR DESCRIPTION
## What does this PR do and why?

Makes payment AJAX authorization route-aware so form-scoped actions are checked against the actual target form. This prevents payment settings reads/writes, transaction updates, and subscription cancellation endpoints from falling back to a broader settings permission path.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Create two payment-enabled forms and a user who can manage only one form.
2. For the allowed form, load payment settings, save payment settings, and update a transaction to confirm the requests still succeed.
3. Try the same actions for a disallowed form, including requests that resolve the form through a transaction or subscription id.
4. Confirm unauthorized requests are rejected.

## Anything the reviewer should know?

The form context is resolved from `form_id`, `transaction.id`, or `subscription_id` depending on the route, so the ACL check no longer depends on whether `form_id` happened to be present in the request.