### PR TITLE
Fix: respect user locale in form editor

### DIFF
--- a/app/Modules/Component/Component.php
+++ b/app/Modules/Component/Component.php
@@ -338,7 +338,7 @@ class Component
             ];
             $disabled['phone'] = [
                 'disabled'    => true,
-                'title'       => 'Phone Field',
+                'title'       => __('Phone Field', 'fluentform'),
                 'description' => __('Phone Field is not available with the free version. Please upgrade to pro to get all the advanced features.', 'fluentform'),
                 'image'       => fluentformMix('img/pro-fields/phone-field.png'),
                 'video'       => '',

--- a/app/Services/FormBuilder/DefaultElements.php
+++ b/app/Services/FormBuilder/DefaultElements.php
@@ -195,7 +195,7 @@ $fluentformDefaultElements = [
                 ],
             ],
             'editor_options' => [
-                'title'      => 'Name Fields',
+                'title'      => __('Name Fields', 'fluentform'),
                 'element'    => 'name-fields',
                 'icon_class' => 'ff-edit-name',
                 'template'   => 'nameFields',
@@ -736,7 +736,7 @@ $fluentformDefaultElements = [
                         'UK' => 'United Kingdom',
                     ],
                     'editor_options' => [
-                        'title'      => 'Country List',
+                        'title'      => __('Country List', 'fluentform'),
                         'element'    => 'country-list',
                         'icon_class' => 'icon-text-width',
                         'template'   => 'selectCountry',

--- a/resources/assets/admin/Request.js
+++ b/resources/assets/admin/Request.js
@@ -2,14 +2,18 @@ export default function (method, route, data = {}) {
     const url = `${window.fluent_forms_global_var.rest.url}/${route}`;
     const originalMethod = method;
 
-    const headers = { "X-WP-Nonce": window.fluent_forms_global_var.rest.nonce };
+    const headers = {
+        "X-WP-Nonce": window.fluent_forms_global_var.rest.nonce,
+        "Accept": "application/json"
+    };
+
+    data._locale = 'user';
+    data.query_timestamp = Date.now();
 
     if (["PUT", "PATCH", "DELETE"].indexOf(method.toUpperCase()) !== -1) {
         headers["X-HTTP-Method-Override"] = method;
         method = "POST";
     }
-
-    data.query_timestamp = Date.now();
 
     return new Promise((resolve, reject) => {
         window.jQuery


### PR DESCRIPTION
## What does this PR do and why?

Fixes a Fluent Forms editor localization issue where field titles could follow the site language instead of the logged-in user’s profile language.

The root cause was in the shared admin REST request layer. WordPress only resolves JSON request locale to the user language when the request is clearly a JSON request and asks for the user locale. This change makes Fluent Forms admin REST calls send _locale=user and Accept: application/json, so editor resource responses follow the current user locale.

This PR also wraps a few remaining hardcoded editor field titles in translation functions so they can be localized correctly.

**Related issue:** https://lounge.authlab.io/projects#/boards/16/tasks/20245

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] JS - resources/assets/admin/Request.js: add _locale=user and Accept: application/json to shared admin REST requests
- [x] PHP - app/Services/FormBuilder/DefaultElements.php: localize Name Fields and Country List
- [x] PHP - app/Modules/Component/Component.php: localize Phone Field

## How to test

1. Set WordPress site language to a non-English locale, such as de_DE.
2. Set the admin user profile language to English (United States).
3. Open Fluent Forms form editor for any form.
4. Verify the editor sidebar field titles show in English for that user.
5. Confirm examples like Name Fields, Country List, and Phone Field are shown in the user language.
6. Verify the editor still loads normally and existing admin REST interactions work.

## Anything the reviewer should know?

- Pro does not need a matching code change for this fix.
- I verified the split-locale scenario locally with Playwright: site locale = de_DE, user locale = en_US.
- The unrelated local assets/js/fluent_gutenblock.js change was not included in this PR.