### PR TITLE
Fix: avoid long entry export URLs

### DIFF
--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -531,7 +531,12 @@
                         <el-button @click="closeInputSelection" type="info" class="el-button--soft">
                             {{ $t('Cancel') }}
                         </el-button>
-                        <el-button type="primary" icon="el-icon-download" @click="exportEntries()">
+                        <el-button
+                            type="primary"
+                            icon="el-icon-download"
+                            :loading="exportingEntries"
+                            @click="exportEntries()"
+                        >
                             {{ $t('Export') }}
                         </el-button>
                     </span>
@@ -1148,6 +1153,8 @@
                 this.submitExportRequest(data);
             },
             submitExportRequest(data) {
+                this.exportingEntries = true;
+
                 const iframeName = `ff-export-${Date.now()}`;
                 const $iframe = jQuery('<iframe>', {
                     name: iframeName,
@@ -1168,6 +1175,7 @@
                         cleanupTimer = null;
                     }
 
+                    this.exportingEntries = false;
                     $form.remove();
                     $iframe.remove();
                 };
@@ -1176,6 +1184,17 @@
                     if (!hasLoadedInitialFrame) {
                         hasLoadedInitialFrame = true;
                         return;
+                    }
+
+                    try {
+                        const iframeDocument = $iframe[0].contentDocument || $iframe[0].contentWindow.document;
+                        const responseText = jQuery(iframeDocument.body).text().trim();
+
+                        if (responseText) {
+                            this.$fail(this.$t('Export failed. Please try again.'));
+                        }
+                    } catch (e) {
+                        // Ignore iframe document access errors and fall back to cleanup.
                     }
 
                     cleanup();
@@ -1200,7 +1219,10 @@
                 jQuery('body').append($iframe, $form);
                 $form.trigger('submit');
 
-                cleanupTimer = window.setTimeout(cleanup, 300000);
+                cleanupTimer = window.setTimeout(() => {
+                    this.$fail(this.$t('Export timed out. Please try again.'));
+                    cleanup();
+                }, 30000);
             },
             dateFormat(date, format) {
                 if (!format) {

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -1159,6 +1159,27 @@
                     target: iframeName,
                     style: 'display:none;'
                 });
+                let hasLoadedInitialFrame = false;
+                let cleanupTimer = null;
+
+                const cleanup = () => {
+                    if (cleanupTimer) {
+                        window.clearTimeout(cleanupTimer);
+                        cleanupTimer = null;
+                    }
+
+                    $form.remove();
+                    $iframe.remove();
+                };
+
+                $iframe.on('load', () => {
+                    if (!hasLoadedInitialFrame) {
+                        hasLoadedInitialFrame = true;
+                        return;
+                    }
+
+                    cleanup();
+                });
 
                 jQuery.param(data)
                     .split('&')
@@ -1179,10 +1200,7 @@
                 jQuery('body').append($iframe, $form);
                 $form.trigger('submit');
 
-                window.setTimeout(() => {
-                    $form.remove();
-                    $iframe.remove();
-                }, 60000);
+                cleanupTimer = window.setTimeout(cleanup, 300000);
             },
             dateFormat(date, format) {
                 if (!format) {

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -14,7 +14,7 @@
                     </btn-group-item>
                     <btn-group-item as="div">
                         <el-dropdown @command="selectFieldsToExport" trigger="click">
-                            <el-button>
+                            <el-button :disabled="exportingEntries">
                                 {{ $t('Export') }}
                                 <i class="el-icon-arrow-down el-icon--right"></i>
                             </el-button>
@@ -1101,6 +1101,10 @@
                 this.input_selection_visibility  = false;
             },
             selectFieldsToExport(format = 'csv'){
+                if (this.exportingEntries) {
+                    return;
+                }
+
                 this.selectExportFormat = format;
 
                 if (format == 'json'){
@@ -1111,6 +1115,9 @@
                 }
             },
             exportEntries() {
+                if (this.exportingEntries) {
+                    return;
+                }
 
                 this.input_selection_visibility  = false;
 

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -1145,7 +1145,44 @@
 				if (this.advanced_filter_active) {
 					data.advanced_filter = this.advanced_filter;
 				}
-	            location.href = ajaxurl + '?' + jQuery.param(data);
+                this.submitExportRequest(data);
+            },
+            submitExportRequest(data) {
+                const iframeName = `ff-export-${Date.now()}`;
+                const $iframe = jQuery('<iframe>', {
+                    name: iframeName,
+                    style: 'display:none;'
+                });
+                const $form = jQuery('<form>', {
+                    method: 'POST',
+                    action: ajaxurl,
+                    target: iframeName,
+                    style: 'display:none;'
+                });
+
+                jQuery.param(data)
+                    .split('&')
+                    .forEach(item => {
+                        const [rawName, rawValue = ''] = item.split('=');
+                        const name = decodeURIComponent(rawName.replace(/\+/g, ' '));
+                        const value = decodeURIComponent(rawValue.replace(/\+/g, ' '));
+
+                        $form.append(
+                            jQuery('<input>', {
+                                type: 'hidden',
+                                name,
+                                value
+                            })
+                        );
+                    });
+
+                jQuery('body').append($iframe, $form);
+                $form.trigger('submit');
+
+                window.setTimeout(() => {
+                    $form.remove();
+                    $iframe.remove();
+                }, 60000);
             },
             dateFormat(date, format) {
                 if (!format) {
@@ -1286,4 +1323,3 @@
 	    }
     };
 </script>
-


### PR DESCRIPTION
## What does this PR do and why?

Fixes entry export failures when a form has a large number of selected export fields. The entries screen was building the download request as a long GET URL, which could exceed request URI limits and fail before the export started.

This changes the entries export flow to submit the same payload as a hidden form POST to admin-ajax.php, keeping the existing backend export handler unchanged while removing the URL-length constraint.

**Related issue:** https://lounge.authlab.io/projects#/boards/16/tasks/20460

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] Vue — resources/assets/admin/views/Entries.vue: submit entry export requests through a hidden POST form instead of location.href with a query string

## How to test

1. Open the entries screen for a form with many exportable fields.
2. Run a normal CSV export and confirm the download succeeds.
3. Repeat with a very large fields_to_export payload.
4. Confirm the request goes to admin-ajax.php as POST and the export still downloads successfully.

## Anything the reviewer should know?

- The export payload shape and backend handler are unchanged; only the transport changed from query string GET to form-encoded POST.
- Verified locally with Playwright for both normal export flow and an oversized field-selection payload.