### PR TITLE
Improve: support dynamic autocomplete in conversational forms

### DIFF
--- a/app/Services/FluentConversational/Classes/Converter/Converter.php
+++ b/app/Services/FluentConversational/Classes/Converter/Converter.php
@@ -56,6 +56,10 @@ class Converter
         }
         
         foreach ($fields as $field) {
+            if (!isset($allowedFields[$field['element']])) {
+                continue;
+            }
+
             $field = apply_filters_deprecated('fluentform_rendering_field_data_' . $field['element'],
                 [
                     $field,
@@ -303,6 +307,22 @@ class Converter
                     $question['options'] = self::getAdvancedOptions($field, $form);
                     $question['searchable'] = ArrayHelper::get($field, 'settings.enable_select_2');
                     $question['multiple'] = ArrayHelper::isTrue($field, 'attributes.multiple');
+                } elseif ('autocomplete' === $type) {
+                    $question['type'] = 'FlowFormDynamicFieldType';
+                    $question['placeholder'] = self::getComponent()->replaceEditorSmartCodes(
+                        ArrayHelper::get($field, 'settings.placeholder', ArrayHelper::get($field, 'attributes.placeholder', null)),
+                        $form
+                    );
+                    $question['autocomplete_config'] = [
+                        'formId'         => $form->id,
+                        'fieldName'      => ArrayHelper::get($field, 'attributes.name'),
+                        'minChars'       => (int) ArrayHelper::get($field, 'settings.min_chars', 2),
+                        'maxSuggestions' => (int) ArrayHelper::get($field, 'settings.max_suggestions', 10),
+                        'nonce'          => wp_create_nonce(
+                            'fluentform_dynamic_autocomplete_' . $form->id . '_' . ArrayHelper::get($field, 'attributes.name')
+                        ),
+                        'ajaxUrl'        => admin_url('admin-ajax.php'),
+                    ];
                 } else {
                     continue;
                 }


### PR DESCRIPTION
## What does this PR do and why?

Adds conversational-form conversion support for dynamic fields configured as the autocomplete variant.

Previously, conversational conversion supported dynamic fields for checkbox, radio, select, and multi-select, but skipped the autocomplete type entirely. This update allows the converter to emit the correct conversational question type and passes the field configuration needed by the conversational frontend.

It also adds an early field-type guard in the converter so Pro-only fields such as dynamic field are skipped unless they are present in the allowed conversational field registry.

**Related issue:** https://lounge.authlab.io/projects#/boards/16/tasks/20540

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — `app/Services/FluentConversational/Classes/Converter/Converter.php`: add conversational autocomplete config for `dynamic_field` and respect the existing Pro-only field registry before conversion

## How to test

1. In a site with Fluent Forms Pro active, create or edit a form with a `Dynamic Field` set to `Text Autocomplete`.
2. Enable conversational mode for that form.
3. Open the conversational form on the frontend.
4. Type a matching query into the dynamic field and verify suggestions are returned.
5. Type a non-matching query and verify `No suggestions found` is shown.
6. Verify keyboard behavior: `ArrowUp` / `ArrowDown`, `Tab` / `Shift+Tab`, and `Enter` can be used to navigate and select suggestions.
7. Temporarily change the same field to `Select` and verify the existing conversational dynamic-field flow still works.

## Anything the reviewer should know?

- This PR depends on the matching `WPManageNinja/fluent-conversational-js` PR for the new conversational question component and keyboard behavior.
- The rebuilt conversational assets were intentionally not included in this free-plugin commit.