### PR TITLE
Fix: enforce form scope for submissions and print

### DIFF
--- a/app/Http/Controllers/SubmissionController.php
+++ b/app/Http/Controllers/SubmissionController.php
@@ -201,7 +201,7 @@ class SubmissionController extends Controller
             $attributes = $this->request->all();
             
             $sanitizeMap = [
-                'entry_ids' => function($value) {
+                'submission_ids' => function($value) {
                     if (is_array($value)) {
                         return array_map('intval', $value);
                     }
@@ -210,6 +210,15 @@ class SubmissionController extends Controller
                 'form_id' => 'intval',
             ];
             $attributes = fluentform_backend_sanitizer($attributes, $sanitizeMap);
+
+            // Preserve backward compatibility with any legacy callers that still
+            // send entry_ids, while normalizing to the current submission_ids key.
+            if (empty($attributes['submission_ids']) && isset($attributes['entry_ids'])) {
+                $entryIds = $attributes['entry_ids'];
+                $attributes['submission_ids'] = is_array($entryIds)
+                    ? array_map('intval', $entryIds)
+                    : [];
+            }
             
             return $this->sendSuccess(
                 $submissionService->getPrintContent($attributes)

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -186,7 +186,11 @@ class Submission extends Model
     public function paginateEntries($attributes = [])
     {
         $formId = Arr::get($attributes, 'form_id');
+        $allowFormIds = FormManagerService::getUserAllowedFormsScope();
         $query = $this->customQuery($attributes);
+        $query = $query->when(false !== $allowFormIds, function ($q) use ($allowFormIds) {
+            return $q->whereIn('fluentform_submissions.form_id', $allowFormIds ?: [0]);
+        });
         if (Arr::get($attributes, 'advanced_filter')) {
             $query = apply_filters('fluentform/apply_entries_advance_filter', $query, $attributes);
         }

--- a/app/Services/Submission/SubmissionPrint.php
+++ b/app/Services/Submission/SubmissionPrint.php
@@ -18,8 +18,12 @@ class SubmissionPrint
         $orderBy = Helper::sanitizeOrderValue(Arr::get($attr, 'sort_by', 'DESC'));
         $formId = intval(Arr::get($attr, 'form_id'));
         $form = Helper::getForm($formId);
-        $submissions = Submission::whereIn('id', $submissionIds)->orderBy('id', $orderBy)->get();
-        if (count($submissions) === 0 || !$form) {
+        $submissions = Submission::where('form_id', $formId)
+            ->whereIn('id', $submissionIds)
+            ->orderBy('id', $orderBy)
+            ->get();
+
+        if (!$form || count($submissionIds) === 0 || count($submissions) !== count($submissionIds)) {
             // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
             throw new \Exception(__('Invalid Submissions', 'fluentform'));
         }


### PR DESCRIPTION
## What does this PR do and why?

Closes two form-scope access gaps in the entries area.

Restricted managers could still access entries outside their assigned forms through the standard submissions collection when `form_id` was omitted, and the print endpoint could render foreign submissions as long as the request included an allowed `form_id`.

This PR applies allowed-form scoping to the standard submissions pagination path and hard-binds printable submissions to the authorized form before rendering content.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — [app/Models/Submission.php](app/Models/Submission.php): apply `getUserAllowedFormsScope()` to `paginateEntries()` so restricted managers cannot retrieve foreign-form entries from the standard submissions collection.
- [x] PHP — [app/Http/Controllers/SubmissionController.php](app/Http/Controllers/SubmissionController.php): normalize print request IDs to `submission_ids` and preserve backward compatibility for legacy `entry_ids` callers.
- [x] PHP — [app/Services/Submission/SubmissionPrint.php](app/Services/Submission/SubmissionPrint.php): constrain printable submissions by both `form_id` and requested IDs, and fail closed when any requested ID falls outside the authorized form.

## How to test

1. Log in as a restricted manager user assigned only to form `321`.
2. Open the entries admin screen for form `321`.
3. In the browser console, run `await window.FluentFormsGlobal.$rest.get('submissions?search=')`.
4. Verify the returned rows only contain form `321`.
5. In the same session, run `await window.FluentFormsGlobal.$rest.get('submissions/print?form_id=321&submission_ids[]=5147')` where `5147` is a submission from another form.
6. Verify the request no longer renders printable content and fails with `Invalid Submissions`.
7. As an administrator, verify normal entries listing and valid same-form print actions still work.

## Anything the reviewer should know?

- The print endpoint now accepts the current `submission_ids` parameter and still normalizes legacy `entry_ids` callers for backward compatibility.
- Manual verification was performed in the local site with a scoped manager user. After the fix, the unscoped submissions request returned only form `321`, and the cross-form print request failed closed with `422 Invalid Submissions`.