### PR TITLE
Framework Chore: Restore fluentform dev tooling 

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -23,3 +23,5 @@ composer.lock
 assets/report.html
 .claude/
 builds/*
+dev
+wpf

--- a/boot/globals.php
+++ b/boot/globals.php
@@ -13,11 +13,14 @@ use FluentForm\App\Services\FormBuilder\EditorShortCode;
  * so the $app is not available here, only declare functions here.
  */
 
-//if ('dev' == $app->config->get('app.env')) {
-//    $globalsDevFile = __DIR__ . '/globals_dev.php';
-//
-//    is_readable($globalsDevFile) && include $globalsDevFile;
-//}
+if (isset($app) && 'dev' === $app->config->get('app.env')) {
+    foreach ([__DIR__ . '/../dev/globals.php', __DIR__ . '/globals_dev.php'] as $globalsDevFile) {
+        if (is_readable($globalsDevFile)) {
+            include_once $globalsDevFile;
+            break;
+        }
+    }
+}
 
 if (!function_exists('dd')) {
     // function dd()

--- a/boot/globals.php
+++ b/boot/globals.php
@@ -13,14 +13,11 @@ use FluentForm\App\Services\FormBuilder\EditorShortCode;
  * so the $app is not available here, only declare functions here.
  */
 
-if (isset($app) && 'dev' === $app->config->get('app.env')) {
-    foreach ([__DIR__ . '/../dev/globals.php', __DIR__ . '/globals_dev.php'] as $globalsDevFile) {
-        if (is_readable($globalsDevFile)) {
-            include_once $globalsDevFile;
-            break;
-        }
-    }
-}
+//if ('dev' == $app->config->get('app.env')) {
+//    $globalsDevFile = __DIR__ . '/globals_dev.php';
+//
+//    is_readable($globalsDevFile) && include $globalsDevFile;
+//}
 
 if (!function_exists('dd')) {
     // function dd()

--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/test.log

--- a/dev/ComposerScript.php
+++ b/dev/ComposerScript.php
@@ -1,0 +1,296 @@
+<?php
+
+namespace FluentForm\Dev;
+
+use Composer\Script\Event;
+use InvalidArgumentException;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+
+class ComposerScript
+{
+    private static $composerUpdateReport = __DIR__.'/composer-update-report.json';
+
+    private static $packagePostInstallOrUpdate = [];
+
+    public static function postInstall(Event $event)
+    {
+        static::runComposerScript($event);
+    }
+
+    public static function postUpdate(Event $event)
+    {
+        static::runComposerScript($event);
+    }
+
+    public static function run(Event $event)
+    {
+        static::runComposerScript($event);
+        shell_exec('composer dump-autoload');
+    }
+
+    protected static function runComposerScript(Event $event)
+    {
+        echo "Please wait, this may take a while." . PHP_EOL;
+        
+        $vendorDir = $event->getComposer()->getConfig()->get('vendor-dir');
+        
+        $composerJson = json_decode(
+            file_get_contents($vendorDir . '/../composer.json'), true
+        );
+
+        $namespace = $composerJson['extra']['wpfluent']['namespace']['current'];
+
+        if (!$namespace) {
+            throw new InvalidArgumentException(
+                'Namespace not set in composer.json file.'
+            );
+        }
+
+        $itr = new RecursiveIteratorIterator(new RecursiveDirectoryIterator(
+            $vendorDir.'/wpfluent/framework/src/', RecursiveDirectoryIterator::SKIP_DOTS
+        ), RecursiveIteratorIterator::SELF_FIRST);
+
+        foreach ($itr as $file) {
+            if ($file->isDir()) { 
+                continue;
+            }
+
+            $fileName = $file->getPathname();
+
+            $content = file_get_contents($fileName);
+            $content = str_replace(
+                ['WPFluent\\', 'WPFluentPackage\\'],
+                [$namespace . '\\Framework\\', $namespace . '\\'],
+                $content
+            );
+
+            file_put_contents($fileName, $content);
+        }
+
+        static::updateVendorComposerFiles($vendorDir, $namespace, $event);
+
+        // Execute package's scripts
+        foreach (static::$packagePostInstallOrUpdate as $value) {
+            list($vnd, $pkg, $evt) = $value;
+            $packageDir = "{$vnd}/{$pkg['name']}/";
+            if (file_exists($file = $packageDir . 'composer.json')) {
+                $comp = json_decode(file_get_contents($file), true);
+                if (isset($comp['extra'])) {
+                    $extra = $comp['extra'];
+                    if (isset($extra['wpfluent'])) {
+                        $wpfluent = $extra['wpfluent'];
+                        if (isset($extra['scripts'])) {
+                            $scripts = $extra['scripts'];
+                            foreach ($scripts as $script) {
+                                exec($script);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Update composer files and installed.json for global functions
+        $composerReportData = (array) json_decode(
+            file_get_contents(static::$composerUpdateReport), true
+        );
+
+        $installedJson = json_decode(file_get_contents(
+            $installedJsonFile = $vendorDir . '/composer/installed.json'
+        ), true);
+
+        foreach ($composerReportData as $composerFile => $file) {
+            $newName = static::renameFile($file['path'], $namespace);
+            $composerFileData = json_decode(file_get_contents($composerFile), true);
+            if (isset($composerFileData['autoload']['files'])) {
+                $files = $composerFileData['autoload']['files'];
+                foreach ($files as $key => $fileName) {
+                    if ($file['name'] === $fileName) {
+                        $ds = DIRECTORY_SEPARATOR;
+                        $arr = explode($ds, $file['name']);
+                        
+                        if (count($arr) > 1) {
+                            array_pop($arr);
+                            $pathParts = implode($ds, $arr);
+                            $pathParts = rtrim($pathParts, $ds).$ds;
+                            $files[$key] =  $pathParts.pathinfo($newName)['basename'];
+                        } else {
+                            $files[$key] = pathinfo($newName)['basename'];
+                        }
+
+                        foreach ($installedJson['packages'] as $key => &$packageData) {
+                            if ($packageData['name'] === $file['package']) {
+                                $packageData['autoload']['files'] = $files;
+                            }
+                        }
+                    }
+                }
+                $composerFileData['autoload']['files'] = $files;
+            }
+            
+            file_put_contents($composerFile, json_encode(
+                $composerFileData, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES
+            ));
+
+            file_put_contents($installedJsonFile, json_encode(
+                $installedJson, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES
+            ));
+        }
+    }
+
+    protected static function updateVendorComposerFiles($vendorDir, $namespace, $event)
+    {
+        if (!file_exists(static::$composerUpdateReport)) {
+            touch(static::$composerUpdateReport);
+        } else {
+            file_put_contents(static::$composerUpdateReport, '');
+        }
+
+        $composerInstalledJson = json_decode(file_get_contents(
+            $installedJsonFile = $vendorDir . '/composer/installed.json'
+        ), true);
+
+        foreach ($composerInstalledJson['packages'] as &$package) {
+            try {
+                if ($package['name'] == 'wpfluent/framework') {
+                    $package['autoload']['psr-4'] = [
+                        $namespace . "\\Framework\\" => "src/WPFluent"
+                    ];
+                } else {
+                    $packageDir = $vendorDir . "/{$package['name']}/src/";
+
+                    if (!str_contains($package['name'], 'wpfluent')) {
+                        
+                        static::updatePackageNamespace(
+                            str_replace('src/', '', $packageDir), $namespace, $event
+                        );
+
+                        if (!isset($package['autoload']['psr-4'])) continue;
+                        
+                        foreach ($package['autoload']['psr-4'] as $key => $value) {
+                            $package['autoload']['psr-4'][$namespace.'\\'.$key] = $value;
+                        }
+
+                        $packageComposerJson = json_decode(file_get_contents(
+                            $vendorDir .'/' . $package['name'] . '/composer.json'
+                        ), true);
+                        
+                        foreach (
+                            $packageComposerJson['autoload']['psr-4'] as $k => $v
+                        ) {
+                            $package['autoload']['psr-4'][$namespace.'\\'.$k] = $v;
+                        }
+
+                        file_put_contents(
+                            $vendorDir .'/' . $package['name'] . '/composer.json',
+                            json_encode(
+                                $packageComposerJson,
+                                JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES
+                            )
+                        );
+                    } else {
+                        $iterator = new RecursiveIteratorIterator(
+                            new RecursiveDirectoryIterator(
+                                $packageDir, RecursiveDirectoryIterator::SKIP_DOTS
+                            ),
+                            RecursiveIteratorIterator::SELF_FIRST
+                        );
+
+                        foreach ($iterator as $item) {
+
+                            if ($item->isDir()) {
+                                continue;
+                            }
+
+                            $fileName = $item->getPathname();
+                            $content = file_get_contents($fileName);
+                            $content = str_replace(
+                                [
+                                    'WPFluent\\',
+                                    'WPFluentPackage\\',
+                                    'WpfluentPackage\\'
+                                ],
+                                [
+                                    $namespace . '\\Framework\\',
+                                    $namespace . '\\',
+                                    $namespace . '\\'
+                                ],
+                                $content
+                            );
+
+                            file_put_contents($fileName, $content);
+                        }
+
+                        $psr4 = array_keys($package['autoload']['psr-4']);
+                        
+                        $replaced = str_replace(
+                            ['WPFluentPackage', 'WpfluentPackage'],
+                            [$namespace, $namespace],
+                            $psr4[0]
+                        );
+                        
+                        $package['autoload']['psr-4'] = [
+                            $replaced => "src/"
+                        ];
+
+                        $packageComposerJson = json_decode(file_get_contents(
+                            $vendorDir .'/' . $package['name'] . '/composer.json'
+                        ), true);
+                        
+                        $packageComposerJson['autoload']['psr-4'] = [
+                            $replaced => "src/"
+                        ];
+
+                        file_put_contents(
+                            $vendorDir .'/' . $package['name'] . '/composer.json',
+                            json_encode($packageComposerJson, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)
+                        );
+
+                        static::$packagePostInstallOrUpdate[] = [
+                            $vendorDir, $package, $event
+                        ];
+                    }
+                }
+            } catch (\Exception $e) {
+                echo $e->getMessage() . PHP_EOL;
+                continue;
+            }
+        }
+
+        file_put_contents(
+            $installedJsonFile,
+            json_encode(
+                $composerInstalledJson,
+                JSON_UNESCAPED_SLASHES|JSON_PRETTY_PRINT
+            )
+        );
+    }
+
+    protected static function updatePackageNamespace($inDir, $namespace, $event)
+    {
+        $composerUpdateReport = static::$composerUpdateReport;
+        if (file_exists($inDir)) {
+            (require __DIR__.'/cli/namespace_fixer.php')($inDir, $namespace);
+        }
+    }
+
+    protected static function renameFile($path, $namespace)
+    {
+        $nameParts = explode('/', $path);
+
+        $name = array_pop($nameParts);
+        
+        if (str_starts_with($name, $namespace)) {
+            return $path;
+        }
+
+        $dirPath = implode('/', $nameParts);
+
+        $newName = $dirPath . '/' . $namespace . '-' . md5($path) . '-' . $name;
+        
+        if (rename($path, $newName)) {
+            return $newName;
+        }
+    }
+}

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,31 @@
+# ./wpf
+
+This is a cli toolkit for helping the development process with many handy features. To know more about this tool, just run `./wpf` from your plugin's root directory and check the available commands that you may use to ease your development process.
+
+# But, at first!
+
+- Run `chmod 700 ./wpf` to grant the permission and then `./wpf init` to install the dependencies.
+
+If you've done everything right then, you may run `./wpf` to check the list of available commands.
+
+# Test Setup:
+
+- Run `chmod 700 ./test/setup.sh` to grant the necessary permission to run.
+- Run `./test/setup.sh dbname dbuser dbpass dbhost` to setup the test suite.
+
+The `dbname` will be used to create the database for testing, so provide your `mysql` username and password in the place of `dbuser` and `dbpass` and use `localhost` for the `dbhost`. Once you complete setting up the test environment, find ther `./stubs/Models/Model.php` and rename the `WPFluent` using the correct namespace of your project from `\WPFluent\App\Models\Model`. If
+you did everything correctly then you should be able to write and run tests.
+
+- To check, run `./wpf test` from the root of your plugin directory.
+
+**Note** You may run the `./setup.sh` multiple times if you need to.
+
+# If anything goes wrong:
+
+- `cd /var/folders/hl/9mtnq0xx42n17zs18wwpfwv80000gn/T`
+- `rm -rf wordpress`
+- `rm -rf wordpress-tests-lib`
+- run the `setup.sh` again.
+- run `phpunit` again.
+
+**Note:** The path is dynamic so it could be a little bit different. In that case adjust the path from the error message displayed on the console which will mention the location using something similar to this kind of path.

--- a/dev/README.md
+++ b/dev/README.md
@@ -18,6 +18,11 @@ you did everything correctly then you should be able to write and run tests.
 
 - To check, run `./wpf test` from the root of your plugin directory.
 
+# QA Tooling:
+
+- Run `cd dev && composer run phpcs` to scan plugin PHP compatibility.
+- Run `cd dev && composer run phpstan` to run the WordPress-aware static analysis baseline.
+
 **Note** You may run the `./setup.sh` multiple times if you need to.
 
 # If anything goes wrong:

--- a/dev/cli/build.php
+++ b/dev/cli/build.php
@@ -1,0 +1,29 @@
+<?php require __DIR__.'/functions.php';
+
+return function($pluginDir) {
+	$tempDir = $pluginDir.'/buildtemp';
+	$zipFile = $pluginDir . '/' . basename($pluginDir) . '.zip';
+	$excludeList = [
+	    '.git',
+	    '.gitignore',
+	    '.gitmodules',
+	    'README.md',
+	    'composer.json',
+	    'composer.lock',
+	    'package.json',
+	    'package-lock.json',
+	    'dev',
+	    'buildtemp',
+	    'node_modules',
+	    'webpack.mix.js',
+	    'wp-tests-config.php',
+	    'wpf',
+	    'wpflog',
+	];
+
+	if (!is_dir($tempDir)) mkdir($tempDir);
+	recursiveCopy($pluginDir, $tempDir, $excludeList);
+	createZipArchive($tempDir, $zipFile);
+	deleteDirectory($tempDir);
+	echo "The zip file has been create at: {$zipFile}".PHP_EOL;
+};

--- a/dev/cli/classes.php
+++ b/dev/cli/classes.php
@@ -1,0 +1,20 @@
+<?php
+
+$classList = getClassesFromDirectory(
+    __DIR__.'/../../vendor/wpfluent/framework/src/WPFluent'
+);
+
+$classesArray = [];
+
+foreach ($classList as $class) {
+    $pieces = explode('\\', $class);
+    $classesArray[$class] = end($pieces);
+}
+
+$classesArray = array_flip($classesArray);
+
+uksort($classesArray, function($a, $b) {
+    return strcmp($a, $b);
+});
+
+return array_flip($classesArray);

--- a/dev/cli/commands/init.php
+++ b/dev/cli/commands/init.php
@@ -1,0 +1,143 @@
+<?php
+
+return function($args, $loader) {
+	$wpRootDir = realpath(__DIR__ . '/../../../../../../');
+	$wpConfigPath = $wpRootDir . '/wp-config.php';
+
+	$getWpConfigValue = function ($name, $default = null) use ($wpConfigPath) {
+		if (!file_exists($wpConfigPath)) {
+			return $default;
+		}
+
+		$content = file_get_contents($wpConfigPath);
+
+		$patterns = [
+			"/define\s*\(\s*'" . preg_quote($name, '/') . "'\s*,\s*'([^']*)'\s*\)/",
+			'/define\s*\(\s*"' . preg_quote($name, '/') . '"\s*,\s*"([^"]*)"\s*\)/',
+		];
+
+		foreach ($patterns as $pattern) {
+			if (preg_match($pattern, $content, $matches)) {
+				return $matches[1];
+			}
+		}
+
+		return $default;
+	};
+
+	$getWpConfig = function () use ($getWpConfigValue, $wpRootDir) {
+		return [
+			'db_name' => $getWpConfigValue('DB_NAME'),
+			'db_user' => $getWpConfigValue('DB_USER'),
+			'db_password' => $getWpConfigValue('DB_PASSWORD', ''),
+			'db_host' => $getWpConfigValue('DB_HOST', 'localhost'),
+			'wp_root' => $wpRootDir,
+		];
+	};
+
+	if (!file_exists($loader)) {	
+		echo 'Please wait...'.PHP_EOL;
+		chdir(__DIR__.'/../../../dev');
+		exec('composer update', $output);
+		foreach ($output as $line) {
+		    echo $line . PHP_EOL;
+		}
+	}
+
+	if (($args && reset($args) === 'init') || !file_exists($loader)) {
+		if (file_exists($f = __DIR__ . '/../../../dev/test/setup.sh')) {
+		    @chmod($f, 0700);
+			$wpConfig = $getWpConfig();
+
+			if (!$wpConfig['db_user'] || !$wpConfig['db_name']) {
+				throw new RuntimeException('Could not read database settings from wp-config.php.');
+			}
+
+			if (isset($args[1]) && $args[1] === '--config') {
+				if (file_exists($filePath = $wpConfig['wp_root'] . '/wp-tests-config.php')) {
+					$file = fopen($filePath, 'r');
+					while (!feof($file)) {
+					    $line = fgets($file);
+					    if (strpos($line, 'DB_NAME') !== false) {
+					        preg_match(
+					        	"/define\s*\(\s*'DB_NAME'\s*,\s*'([^']+)'\s*\)/", $line, $matches
+					        );
+
+					        if (isset($matches[1])) {
+					            $dbn = $matches[1];
+					        }
+					    }
+					}
+					fclose($file);
+				}
+			} else {
+				$dbn = str_replace('-', '_', basename($wpConfig['wp_root']).'_testdb');
+			}
+
+			// Delete wordpress & wordpress-tests-lib diectories
+			$tmpDir = getenv('TMPDIR');
+			$wordpressDir = escapeshellarg($tmpDir . 'wordpress');
+			$testsLibDir = escapeshellarg($tmpDir . 'wordpress-tests-lib');
+			$command = "rm -rf $wordpressDir $testsLibDir";
+			exec($command, $output, $returnVar);
+
+			echo "Installing test suit, it may take a while...\n\n";
+			exec(
+				implode(' ', [
+					escapeshellarg($f),
+					escapeshellarg($dbn),
+					escapeshellarg($wpConfig['db_user']),
+					escapeshellarg($wpConfig['db_password']),
+					escapeshellarg($wpConfig['db_host']),
+				]),
+				$out
+			); foreach ($out as $o) echo $o.PHP_EOL;
+
+			$testConf = $tmpDir . '/wordpress-tests-lib/wp-tests-config.php';
+			$newTestConf = $wpRootDir . '/wp-tests-config.php';
+			
+			@chmod($wpRootDir, 0700);
+			@unlink($newTestConf);
+			@symlink($testConf, $newTestConf);
+			$newLine = "defined('WP_DEBUG_LOG') || define('WP_DEBUG_LOG', true);";
+			$currentContent = file_get_contents($newTestConf);
+			$newContent = $currentContent . "\n" . $newLine;
+			file_put_contents($newTestConf, $newContent);
+
+			// Create debug.log file
+			if (!file_exists(
+				$testLog = $tmpDir.'/wordpress/wp-content/debug.log'
+			)) { @touch($testLog); }
+
+			$devDir = __DIR__.'/../..';
+			@chmod($devDir, 0700);
+			@unlink($devDir.'/test.log');
+			@symlink($testLog, $devDir.'/test.log');
+		}
+
+		if (!file_exists($loader)) {
+			
+			echo 'Please wait...'.PHP_EOL;
+			chdir(__DIR__.'/../../../dev');
+			exec('composer update');
+
+			$content = file_get_contents(
+				$file = __DIR__.'/../../../dev/test/inc/RefreshDatabase.php'
+			);
+			
+			$composer = json_decode(
+				file_get_contents(__DIR__.'/../../../composer.json'), true
+			);
+
+			$ns = $composer['extra']['wpfluent']['namespace']['current'];
+			file_put_contents($file, str_replace('WPFluent\\', $ns . '\\', $content));
+			
+			exec(__FILE__, $output);
+			foreach ($output as $line) {
+			    echo $line . PHP_EOL;
+			}
+		}
+
+		return true;
+	}
+};

--- a/dev/cli/commands/make/controller.php
+++ b/dev/cli/commands/make/controller.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * ./wpf make:controller <path/name>
+ * Creates a controller class inside the app/Http/Controllers folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Http/Controllers/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Http\Controllers\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    use $namespace\Framework\Request\Request;
+
+    class {$name} extends Controller
+    {
+        public function index(Request \$request)
+        {
+            // Your code goes here...
+        }
+
+        public function create(Request \$request)
+        {
+            // Your code goes here...
+        }
+
+        public function update(Request \$request, \$id)
+        {
+            // Your code goes here...
+        }
+
+        public function delete(Request \$request, \$id)
+        {
+            // Your code goes here...
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+    	@mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+    	$mainPath = substr(
+    		$file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+    	);
+    	$output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Controller '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/controller.php
+++ b/dev/cli/commands/make/controller.php
@@ -4,14 +4,15 @@
  * Creates a controller class inside the app/Http/Controllers folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Http/Controllers/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Http/Controllers/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Http\Controllers\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Http\Controllers', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/factory.php
+++ b/dev/cli/commands/make/factory.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ./wpf make:factory    <path/name>
+ * Creates a factory class for generating data.
+ */
+(function($pluginDir, $args) {
+    $file = $pluginDir . '/dev/factories/' . $args[1] . '.php';
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = rtrim('Dev\Factories\\'.ltrim($sub, '\\'), '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace $fqn;
+
+    use Dev\Factories\Core\Factory;
+
+    class $name extends Factory
+    {
+        // Required to use Factory::create method
+        // protected static \$model = ModelName::class;
+
+       /**
+        * @see https://fakerphp.github.io/formatters/
+        */
+        public function defination()
+        {
+            return [
+                'name' => \$this->fake->name(2),
+                'email' => \$this->fake->email(),
+                'phone' => \$this->fake->phoneNumber(),
+            ];
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Factory '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/factory.php
+++ b/dev/cli/commands/make/factory.php
@@ -4,8 +4,9 @@
  * Creates a factory class for generating data.
  */
 (function($pluginDir, $args) {
-    $file = $pluginDir . '/dev/factories/' . $args[1] . '.php';
-    $pieces = explode('/', $args[1]);
+    $target = wpf_generator_target($args[1]);
+    $file = $pluginDir . '/dev/factories/' . $target . '.php';
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
     $fqn = rtrim('Dev\Factories\\'.ltrim($sub, '\\'), '\\');

--- a/dev/cli/commands/make/handler.php
+++ b/dev/cli/commands/make/handler.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * ./wpf make:handler    <path/name>
+ * * Creates a handler class inside the app/Hooks/Handlers folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Hooks/Handlers/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Hooks\Handlers\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    use $namespace\Framework\Foundation\Application;
+
+    class {$name}
+    {
+        protected \$app = null;
+
+        public function __construct(Application \$app)
+        {
+            \$this->app = \$app;
+        }
+        
+        public function handle()
+        {
+            // ...
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+    	@mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+    	$mainPath = substr(
+    		$file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+    	);
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Handler '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/handler.php
+++ b/dev/cli/commands/make/handler.php
@@ -4,14 +4,15 @@
  * * Creates a handler class inside the app/Hooks/Handlers folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Hooks/Handlers/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Hooks/Handlers/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Hooks\Handlers\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Hooks\Handlers', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/middleware.php
+++ b/dev/cli/commands/make/middleware.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * ./wpf make:middleware <path/name>
+ * Creates a middleware class inside the app/Http/Middleware folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Http/Middleware/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Http\Middleware\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    class $name
+    {
+        /**
+         * Handle the request
+         *
+         * Note: For a before middleware the \$r will contain the request instance and
+         * for the after middleware, the Response will available in the \$r variable.
+         * 
+         * @param  \$namespace\Framework\Request\Request|\$namespace\Framework\Response\Response \$r
+         * @param  Closure \$next
+         * @param  array \$params
+         * @return mixed
+         */
+        public function handle(\$r, \Closure \$next, ...\$params)
+        {
+            if (isset(\$params[0]) && \$params[0] === 'something_matches') {
+                return \$next(\$r);
+            }
+
+            // return false or nothing for null, the Rest API will handle the response as
+            // rest_forbidden (status:403) or call \$r->abort to send a custom
+            // response. This call will simply return a WP_REST_Response.
+            return \$r->abort(/*int code, string message*/);
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Middleware '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/middleware.php
+++ b/dev/cli/commands/make/middleware.php
@@ -4,14 +4,15 @@
  * Creates a middleware class inside the app/Http/Middleware folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Http/Middleware/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Http/Middleware/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Http\Middleware\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Http\Middleware', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/model.php
+++ b/dev/cli/commands/make/model.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * ./wpf make:model      <path/name>
+ * Creates a ORM model class inside the app/Models folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Models/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Models\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    use $namespace\App\Models\Model;
+
+    class $name extends Model
+    {
+        // If the table name is not given explicitly then the plural form of
+        // your model name in lower case will be used for the table name.
+
+        // protected \$table = 'database_table_name_without_prefix';
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Model '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/model.php
+++ b/dev/cli/commands/make/model.php
@@ -4,14 +4,15 @@
  * Creates a ORM model class inside the app/Models folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Models/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Models/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Models\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Models', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/policy.php
+++ b/dev/cli/commands/make/policy.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * ./wpf make:policy     <path/name>
+ * Creates a policy class inside the app/Http/Policies folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Http/Policies/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Http\Policies\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    use $namespace\Framework\Request\Request;
+    use $namespace\Framework\Foundation\Policy;
+
+    class $name extends Policy
+    {
+        /**
+         * Check user permission for any method
+         * @param  $namespace\Framework\Request\Request \$request
+         * @return Boolean
+         */
+        public function verifyRequest(Request \$request)
+        {
+            return current_user_can('manage_options');
+        }
+
+        /**
+         * Check user permission for create method
+         * @param  $namespace\Framework\Request\Request \$request
+         * @return Boolean
+         */
+        public function create(Request \$request)
+        {
+            return current_user_can('manage_options');
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Policy '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/policy.php
+++ b/dev/cli/commands/make/policy.php
@@ -4,14 +4,15 @@
  * Creates a policy class inside the app/Http/Policies folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Http/Policies/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Http/Policies/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Http\Policies\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Http\Policies', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/post.php
+++ b/dev/cli/commands/make/post.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * ./wpf make:post       <path/name>
+ * Creates a custom post class to register CPT inside the app/CPT folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/CPT/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\CPT\\'.ltrim($sub, '\\');
+
+    $postTypeName = strtolower($name);
+    $appConfig = require $pluginDir . '/config/app.php';
+    $textDomain = $appConfig['text_domain'];
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    class $name
+    {
+        public function registerPostType()
+        {
+            \$slug = '$postTypeName';
+
+            \$labels = [
+                'name'          => __('$name', '$textDomain'),
+                'singular_name' => __('$name', '$textDomain'),
+            ];
+
+            register_post_type(\$slug, [
+                'labels'                => \$labels,
+                'public'                => true,
+                'show_in_rest'          => true,
+                'show_ui'               => false,
+                'show_in_nav_menus'     => false,
+                'description'           => 'Custom post type used in Foo plugin.',
+            ]);
+
+            \$this->registerTaxonomies(\$slug);
+        }
+
+        protected function registerTaxonomies(\$slug)
+        {
+            // ...
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Post '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/post.php
+++ b/dev/cli/commands/make/post.php
@@ -4,14 +4,15 @@
  * Creates a custom post class to register CPT inside the app/CPT folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/CPT/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/CPT/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\CPT\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\CPT', $sub);
 
     $postTypeName = strtolower($name);
     $appConfig = require $pluginDir . '/config/app.php';

--- a/dev/cli/commands/make/request.php
+++ b/dev/cli/commands/make/request.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * ./wpf make:request    <path/name>
+ * Creates a request class inside the app/Http/Requests folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Http/Requests/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Http\Requests\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    use $namespace\Framework\Validator\Rule;
+    use $namespace\Framework\Foundation\RequestGuard;
+
+    class $name extends RequestGuard
+    {
+        /**
+         * Register your custom rules
+         */
+        public function __construct()
+        {
+            // Rule::add(CustomRule::class);
+        }
+
+        /**
+         * Authorize the request
+         * 
+         * @return bool
+         */
+        public function authorize()
+        {
+            return true;
+        }
+
+        /**
+         * @return Array
+         */
+        public function rules()
+        {
+            return [];
+        }
+
+        /**
+         * @return Array
+         */
+        public function messages()
+        {
+            return [];
+        }
+
+        /**
+         * @return Array
+         */
+        public function beforeValidation()
+        {
+            \$data = \$this->all();
+            
+            // Modify the \$data
+
+            return \$data;
+        }
+
+        /**
+         * @return Array
+         */
+        public function afterValidation(\$validator)
+        {
+            \$data = \$this->all();
+            
+            // Modify the \$data
+
+            return \$data;
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Request '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/request.php
+++ b/dev/cli/commands/make/request.php
@@ -4,14 +4,15 @@
  * Creates a request class inside the app/Http/Requests folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Http/Requests/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Http/Requests/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Http\Requests\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Http\Requests', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/rule.php
+++ b/dev/cli/commands/make/rule.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ./wpf make:rule       <path/name>
+ * Creates a custom validation rule class inside the app/Http/Rules folder.
+ */
+(function($pluginDir, $args) {
+    $composerFile = $pluginDir . '/composer.json';
+    $file = $pluginDir . '/app/Http/Rules/' . $args[1] . '.php';
+    $composer = json_decode(file_get_contents($composerFile), true);
+    $namespace = $composer['extra']['wpfluent']['namespace']['current'];
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = $namespace.'\App\Http\Rules\\'.ltrim($sub, '\\');
+
+    $content = <<<TEXT
+    <?php
+
+    namespace {$fqn};
+
+    class $name
+    {
+        public function __invoke(\$attr, \$value, \$rules, \$data, ...\$params)
+        {
+            // \$params = ['param1', 'param2'] (Passed from method call)
+            // i.e: Rule::isValidPassword('param1', 'param2')
+
+            if (!true) {
+                return "The {\$attr} field must contain special characters.";
+            }
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Rule '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/rule.php
+++ b/dev/cli/commands/make/rule.php
@@ -4,14 +4,15 @@
  * Creates a custom validation rule class inside the app/Http/Rules folder.
  */
 (function($pluginDir, $args) {
+    $target = wpf_generator_target($args[1]);
     $composerFile = $pluginDir . '/composer.json';
-    $file = $pluginDir . '/app/Http/Rules/' . $args[1] . '.php';
+    $file = $pluginDir . '/app/Http/Rules/' . $target . '.php';
     $composer = json_decode(file_get_contents($composerFile), true);
     $namespace = $composer['extra']['wpfluent']['namespace']['current'];
-    $pieces = explode('/', $args[1]);
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
-    $fqn = $namespace.'\App\Http\Rules\\'.ltrim($sub, '\\');
+    $fqn = wpf_namespace_join($namespace . '\App\Http\Rules', $sub);
 
     $content = <<<TEXT
     <?php

--- a/dev/cli/commands/make/test.php
+++ b/dev/cli/commands/make/test.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * ./wpf make:test       <path/name>
+ * Creates a test class for writing unit tests.
+ */
+(function($pluginDir, $args) {
+    $file = $pluginDir . '/dev/test/tests/' . $args[1] . '.php';
+    $pieces = explode('/', $args[1]);
+    $name = array_pop($pieces);
+    $sub = implode('\\', $pieces);
+    $fqn = 'Dev\Test\Tests\\'.ltrim($sub, '\\');
+    $fqn = trim($fqn, '\\');
+    
+    $content = <<<TEXT
+    <?php
+
+    namespace $fqn;
+
+    use Dev\Test\Inc\TestCase;
+
+    class $name extends TestCase
+    {
+        public function test()
+        {
+            \$this->assertTrue(true);
+        }
+    }
+
+    TEXT;
+
+    $dirPath = substr($file, 0, strrpos($file, '/')) . '/';
+
+    if (!is_dir($dirPath)) {
+        @mkdir($dirPath, 0777, true);
+    }
+
+    if (file_put_contents($file, $content)) {
+        $mainPath = substr(
+            $file, strpos($file, ltrim(substr($pluginDir, strrpos($pluginDir, '/')), '/'))
+        );
+        $output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        $output->writeln('<info>Test '.$mainPath.' created successfully.</info>');
+    }
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/make/test.php
+++ b/dev/cli/commands/make/test.php
@@ -4,8 +4,9 @@
  * Creates a test class for writing unit tests.
  */
 (function($pluginDir, $args) {
-    $file = $pluginDir . '/dev/test/tests/' . $args[1] . '.php';
-    $pieces = explode('/', $args[1]);
+    $target = wpf_generator_target($args[1]);
+    $file = $pluginDir . '/dev/test/tests/' . $target . '.php';
+    $pieces = explode('/', $target);
     $name = array_pop($pieces);
     $sub = implode('\\', $pieces);
     $fqn = 'Dev\Test\Tests\\'.ltrim($sub, '\\');

--- a/dev/cli/commands/migration/index.php
+++ b/dev/cli/commands/migration/index.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * ./wpf migrate         -----------
+ * Migrates the database (Create/Delete/Modify Tables/Columns).
+ */
+(function($pluginDir, $args) {
+	$command = reset($args);
+	if ($command === 'migrate') {
+		$composer = json_decode(file_get_contents($pluginDir.'/composer.json'), true);
+		$ns = $composer['extra']['wpfluent']['namespace']['current'];
+		$dbMigratorClass = $ns.'\\Database\\DBMigrator';
+		if ($result = $dbMigratorClass::run()) {
+			$output = new \Symfony\Component\Console\Output\ConsoleOutput;
+        	$output->writeln('<info>The migration ran successfully.</info>');
+        	foreach ($result as $key => $value) {
+        		$output->writeln('<comment>'.$value.'.</comment>');
+        	}
+		}
+	} elseif ($command === 'migrate:refresh') {
+		return (require __DIR__.'/refresh.php')($pluginDir, $args);
+	}
+})(realpath(__DIR__.'/../../../..'), $args);

--- a/dev/cli/commands/migration/refresh.php
+++ b/dev/cli/commands/migration/refresh.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * ./wpf migrate:refresh <path/name>
+ * Refreshes all the tables by deleting the tables and re-running the migrations.
+ */
+return function($pluginDir, $args) {
+	$composer = json_decode(file_get_contents($pluginDir.'/composer.json'), true);
+	$ns = $composer['extra']['wpfluent']['namespace']['current'];
+	$dbMigratorClass = $ns.'\\Database\\DBMigrator';
+	if ($result = $dbMigratorClass::getMigrations()) {
+		$db = $GLOBALS['wpdb'];
+		$output = new \Symfony\Component\Console\Output\ConsoleOutput;
+		foreach (array_keys($result) as $table) {
+			if ($db->query("drop table if exists {$db->prefix}{$table}")) {
+				$output->writeln(
+					'<comment>Dropped table '.$db->prefix.$table.'.</comment>'
+				);
+			}
+		}
+
+		if ($result = $dbMigratorClass::run()) {
+			foreach ($result as $key => $value) {
+        		$output->writeln('<comment>'.$value.'.</comment>');
+        	}
+        	$output->writeln('<info>The migration ran successfully.</info>');
+		} else {
+			$output->writeln('<info>There was nothing to migrate.</info>');
+		}
+
+		if (isset($args[1]) && $args[1] === '--seed') {
+    		require $pluginDir.'/dev/seeds/index.php';
+    		$output->writeln('<info>The database has been seeded successfully.</info>');
+		}
+	}
+};

--- a/dev/cli/doc_viewer.php
+++ b/dev/cli/doc_viewer.php
@@ -1,0 +1,44 @@
+<?php
+
+($func = function ($classes = []) use (&$func) {
+
+	$classMap = array_map(function($key) {
+		return strtolower($key);
+	}, $classes = $classes ?: require __DIR__.'/classes.php');
+
+	$helper = new \Symfony\Component\Console\Helper\SymfonyQuestionHelper;
+
+    $class = $helper->ask(
+    	new \Symfony\Component\Console\Input\ArgvInput,
+    	new \Symfony\Component\Console\Output\ConsoleOutput,
+    	new \Symfony\Component\Console\Question\ChoiceQuestion(
+	        'Please select a class to view methods', $classMap
+	    )
+    );
+
+	if (isset($class)) {
+		$methods = get_methods($class);
+		$method = $helper->ask(
+	    	new \Symfony\Component\Console\Input\ArgvInput,
+	    	new \Symfony\Component\Console\Output\ConsoleOutput,
+	    	new \Symfony\Component\Console\Question\ChoiceQuestion(
+		        'Please select a method', array_keys($methods)
+		    )
+	    );
+
+	    if ($method) {
+
+	    	$output = new \Symfony\Component\Console\Output\ConsoleOutput;
+
+	    	$output->writeln('<info></info>');
+	    	$output->writeln('<info>'. $methods[$method] . '</info>');
+	    	$output->writeln('<info></info>');
+
+			if (strtolower(trim(readline("Press enter to continue:"))) !== 'q') {
+				$func();
+			}
+		}
+	}
+})(
+	require __DIR__.'/classes.php',
+);

--- a/dev/cli/functions.php
+++ b/dev/cli/functions.php
@@ -1,0 +1,189 @@
+<?php
+
+require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../../vendor/autoload.php';
+
+if (!function_exists('get_methods')) {
+	function get_methods($class) {
+		$methods = [];
+	
+		$object = new \ReflectionClass($class);
+
+		foreach ($object->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+			
+			$name = $method->getName();
+			
+			if (!str_starts_with($name, '_')) {
+				
+				$params = array_map(function($p) {
+					return '$'.$p->name;
+				}, $method->getParameters());
+				
+				$doc = $method->getDocComment();
+
+				$reflectionMethod = new \ReflectionMethod($class, $name);
+				$fnDec = 'public function';
+				if ($reflectionMethod->isStatic()) {
+					$fnDec = 'public static function';
+				}
+
+				$header = "$fnDec $name(". implode(', ', $params) .")";
+
+				$methods[$name] = implode(
+					PHP_EOL, array_merge(parse_docblock($doc), [$header])
+				);
+			}
+		}
+
+		return $methods;
+	}
+}
+
+if (!function_exists('parse_docblock')) {
+	function parse_docblock($sourceCode) {
+	    $pattern = '/\/\*\*(.*?)\*\//s';
+
+	    if (!preg_match($pattern, $sourceCode, $matches)) {
+	    	return [];
+	    }
+	    
+	    $cleanedDocBlock = array_map(function($line) {
+	        return trim(ltrim($line, ' *'));
+	    }, explode("\n", $matches[1]));
+
+	    return array_filter($cleanedDocBlock);
+	}
+}
+
+if (!function_exists('getClassesFromDirectory')) {
+    function getClassesFromDirectory($directory) {
+        $classes = [];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(
+            	$directory, \RecursiveDirectoryIterator::SKIP_DOTS
+            ),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'php') {
+                
+                $filePath = $file->getRealPath();
+                
+                $content = file_get_contents($filePath);
+
+                $isClass = false;
+                foreach (token_get_all($content) as $token) {
+                	if (is_array($token) && isset($token[0])) {
+                		if ($token[0] === T_CLASS) {
+                			$isClass = true;
+                			break;
+                		}
+                		continue;
+                	}
+                }
+                
+                if (!$isClass) continue;
+
+                preg_match(
+                    '/\bnamespace\s+([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff\\\\]*)\s*;/',
+                    $content,
+                    $namespaceMatches
+                );
+
+                preg_match_all(
+                    '/\bclass\s+([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)/', $content, $classMatches
+                );
+
+
+                if (!empty($namespaceMatches)) {
+                    $namespace = trim($namespaceMatches[1]);
+
+                    foreach ($classMatches[1] as $className) {
+                    	$className = ucfirst($className);
+                        $fqn = empty($namespace) ? $className : $namespace . '\\' . $className;
+                        if (class_exists($fqn)) {
+                            $reflection = new \ReflectionClass($fqn);
+                            if (!$reflection->isSubclassOf(\Exception::class)) {
+                                if (
+                                	$reflection->isUserDefined() &&
+                                	$reflection->isInstantiable()
+                                ) {
+                                    $classes[] = $fqn;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return array_unique($classes);
+    }
+}
+
+if (!function_exists('recursiveCopy')) {
+	function recursiveCopy($source, $dest, $excludeList) {
+	    if (!is_dir($dest)) {
+	        mkdir($dest);
+	    }
+
+	    $files = scandir($source);
+	    foreach ($files as $file) {
+	        if ($file != "." && $file != ".." && !in_array($file, $excludeList)) {
+	            $sourcePath = "{$source}/{$file}";
+	            $destPath = "{$dest}/{$file}";
+
+	            if (is_dir($sourcePath)) {
+	                recursiveCopy($sourcePath, $destPath, $excludeList);
+	            } else {
+	                copy($sourcePath, $destPath);
+	            }
+	        }
+	    }
+	}
+}
+
+if (!function_exists('createZipArchive')) {
+	function createZipArchive($source, $destination) {
+	    $zip = new \ZipArchive();
+	    if ($zip->open($destination, \ZipArchive::CREATE) !== TRUE) {
+	        exit("Cannot create a zip archive");
+	    }
+
+	    $files = new \RecursiveIteratorIterator(
+	        new \RecursiveDirectoryIterator($source),
+	        \RecursiveIteratorIterator::LEAVES_ONLY
+	    );
+
+	    foreach ($files as $name => $file) {
+	        if (!$file->isDir()) {
+	            $filePath = $file->getRealPath();
+	            $relativePath = substr($filePath, strlen($source) + 1);
+
+	            $zip->addFile($filePath, $relativePath);
+	        }
+	    }
+
+	    $zip->close();
+	}
+}
+
+if (!function_exists('deleteDirectory')) {
+	function deleteDirectory($dir) {
+	    if (is_dir($dir)) {
+	        $objects = scandir($dir);
+	        foreach ($objects as $object) {
+	            if ($object != "." && $object != "..") {
+	                if (is_dir($dir . "/" . $object)) {
+	                    deleteDirectory($dir . "/" . $object);
+	                } else {
+	                    unlink($dir . "/" . $object);
+	                }
+	            }
+	        }
+	        rmdir($dir);
+	    }
+	}
+}

--- a/dev/cli/functions.php
+++ b/dev/cli/functions.php
@@ -187,3 +187,18 @@ if (!function_exists('deleteDirectory')) {
 	    }
 	}
 }
+
+if (!function_exists('wpf_generator_target')) {
+	function wpf_generator_target($target) {
+		return preg_replace('/\.php$/i', '', trim($target));
+	}
+}
+
+if (!function_exists('wpf_namespace_join')) {
+	function wpf_namespace_join($base, $suffix = '') {
+		$base = trim($base, '\\');
+		$suffix = trim($suffix, '\\');
+
+		return $suffix === '' ? $base : $base . '\\' . $suffix;
+	}
+}

--- a/dev/cli/functions.php
+++ b/dev/cli/functions.php
@@ -1,7 +1,29 @@
 <?php
 
-require __DIR__.'/../vendor/autoload.php';
-require __DIR__.'/../../vendor/autoload.php';
+$devAutoload = __DIR__.'/../vendor/autoload.php';
+$rootAutoload = __DIR__.'/../../vendor/autoload.php';
+$rootAutoloadReal = __DIR__.'/../../vendor/composer/autoload_real.php';
+$rootPlatformCheck = __DIR__.'/../../vendor/composer/platform_check.php';
+
+if (!is_readable($devAutoload)) {
+	fwrite(STDERR, 'Dev Composer autoload is missing. Run ./wpf init first.'.PHP_EOL);
+	exit(1);
+}
+
+if (
+	!is_readable($rootAutoload) ||
+	(
+		is_readable($rootAutoloadReal) &&
+		strpos(file_get_contents($rootAutoloadReal), 'platform_check.php') !== false &&
+		!is_readable($rootPlatformCheck)
+	)
+) {
+	fwrite(STDERR, 'Root Composer autoload is missing or incomplete. Run composer install in the plugin root first.'.PHP_EOL);
+	exit(1);
+}
+
+require $devAutoload;
+require $rootAutoload;
 
 if (!function_exists('get_methods')) {
 	function get_methods($class) {

--- a/dev/cli/index.php
+++ b/dev/cli/index.php
@@ -1,0 +1,26 @@
+<?php
+
+return function($args) {
+	if (($arg = reset($args)) === 'doc') {
+		return require __DIR__.'/doc_viewer.php';
+	} elseif (substr($arg, 0, 4) === 'make') {
+		$files = glob(__DIR__.'/commands/make/*.php');
+		$command = ltrim(substr($arg, 4), ':');
+
+		if (in_array($file = __DIR__."/commands/make/{$command}.php", $files)) {
+			return require $file;
+		}
+		return;
+	} elseif (substr($arg, 0, 4) === 'migr') {
+		return require __DIR__.'/commands/migration/index.php';
+	} elseif (substr($arg, 0, 4) === 'seed') {
+		require __DIR__.'/../seeds/index.php';
+		return (new \Symfony\Component\Console\Output\ConsoleOutput)->writeln(
+			'<info>The database has been seeded successfully.</info>'
+		);
+	}
+
+	(new \Symfony\Component\Console\Output\ConsoleOutput)->writeln(
+		'<info>Unknown command '. (isset($command) ? "make:{$command}" : $arg) . '.' .'</info>'
+	);
+};

--- a/dev/cli/list_commands.php
+++ b/dev/cli/list_commands.php
@@ -1,0 +1,48 @@
+<?php
+
+(function() {
+	$commands = array_map(function($c) {
+		$doc = parse_docblock(file_get_contents($c));
+		$name = substr($c = basename($c), 0, strpos($c, '.'));
+		return ['command' => reset($doc), 'description' => end($doc)];
+	}, glob(__DIR__.'/commands/*/*.php'));
+
+	$commands[] = [
+		'command' => './wpf build             -----------',
+		'description' => 'Builds the plugin zip file.'
+	];
+
+	$commands[] = [
+		'command' => './wpf fix             -----------',
+		'description' => 'To make each composer package unique, it adds the current namespace as prefix where applicable.'
+	];
+	
+	$commands[] = [
+		'command' => './wpf seed            -----------',
+		'description' => 'Runs the db database seeders to seed the database tables.'
+	];
+
+	$commands[] = [
+		'command' => './wpf test            [--options]',
+		'description' => 'Runs the tests. It\'s possible to use all the options of phpunit.'
+	];
+
+	$commands[] = [
+		'command' => './wpf doc             -----------',
+		'description' => 'Opens an interactive shell to search/view method signature and docblock.'
+	];
+
+	array_unshift($commands, [
+		'command' => './wpf about           -----------',
+		'description' => 'Displays information about the application.'
+	]);
+
+	array_unshift($commands, [
+		'command' => './wpf                 -----------',
+		'description' => 'Shows the table of all available commands.'
+	]);
+
+	(new \Symfony\Component\Console\Helper\Table(
+		new \Symfony\Component\Console\Output\ConsoleOutput
+	))->setHeaders(['Command', 'Description'])->setRows($commands)->render();
+})();

--- a/dev/cli/logmon.php
+++ b/dev/cli/logmon.php
@@ -1,0 +1,32 @@
+<?php
+
+$logFile = __DIR__."/../test.log";
+file_put_contents($logFile, '');
+$fileHandle = fopen($logFile, "r");
+
+while (true) {
+
+    if ($fileHandle) {
+        
+        clearstatcache();
+        
+        if (($fileSize = filesize($logFile)) === 0) {
+            fclose($fileHandle);
+            $fileHandle = fopen($logFile, "r");
+            fseek($fileHandle, 0, SEEK_END);
+            sleep(1);
+            continue;
+        }
+        
+        if (fread($fileHandle, $fileSize)) {
+            $title = "Error";
+            $msg = 'Please check the dev/test.Log file.';
+            $command = 'osascript -e \'display notification "'.$msg.'" with title "'.$title.'" sound name "funk"\'';
+            shell_exec($command);
+        }
+    }
+    
+    sleep(1);
+}
+
+fclose($fileHandle);

--- a/dev/cli/namespace_fixer.php
+++ b/dev/cli/namespace_fixer.php
@@ -1,0 +1,251 @@
+<?php ini_set("memory_limit", -1);
+
+require __DIR__.'/../vendor/autoload.php';
+require __DIR__.'/../../../../../wp-load.php';
+
+if (!function_exists('dd')) {
+    function dd(/*args*/) {
+        ob_start();
+        foreach (func_get_args() as $arg) {
+            echo "<pre>";
+            print_r($arg);
+            echo "</pre>";
+        }
+        $ret = ob_get_clean();
+
+        if (str_contains(strtolower(php_sapi_name()), 'cli')) {
+            echo PHP_EOL.PHP_EOL . strip_tags($ret) . PHP_EOL.PHP_EOL;
+        } else {
+            echo strip_tags($ret);
+        }
+        die;
+    }
+}
+
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitorAbstract;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\NodeVisitor\NameResolver;
+
+return function($inDir, $namespace) use ($composerUpdateReport) {
+    $printer = new PrettyPrinter\Standard;
+    $traverser = new PhpParser\NodeTraverser;
+    $parser = (new ParserFactory())->createForNewestSupportedVersion();
+
+    $traverser->addVisitor(new class($namespace) extends NodeVisitorAbstract {
+        private $ns = '';
+        private $funcs = [];
+        private $internals = [];
+        
+        public function __construct($namespace) {
+            $this->ns = $namespace;
+            $this->funcs = $this->getListOfExcludableFunctions();
+            $this->internals = $this->getAllBuiltinEntitiesOfPhp();
+        }
+
+        public function enterNode(Node $node) {
+            // Add namespace prefix to namespace and use cases
+            if ($node instanceof Node\Name) {
+                if ($this->isInternal($name = $node->toString())) {
+                    return $node;
+                }
+
+                if (!str_contains($name, $this->ns)) {
+                    if (strpos($name, '\\') !== false) {
+                        $name = trim(str_replace($this->ns, '', $name), '\\');
+                        if ($node instanceof Namespace_ || $node->isQualified()) {
+                            $name = trim(rtrim($this->ns, '\\') . '\\' . $name, '\\');
+                        } else {
+                            $name = '\\'.trim(
+                                rtrim($this->ns, '\\') . '\\' . $node->toString(), '\\'
+                            );
+                        }
+                        return new Node\Name($name);
+                    }
+                }
+                return $node;
+            }
+
+            // Add namespace prefix to function calls
+            if ($node instanceof FuncCall && method_exists($node->name, 'toString')) {
+                if ($node->getAttribute('startLine') !== null) {
+                    $name = $node->name->toString();
+                    if (!$this->isInternal($name) && $this->isExcludableFn($name)) {
+                        if (!str_contains($name, $this->ns)) {
+                            $name = trim(str_replace($this->ns, '', $name), '\\');
+                            $ns = '\\'.trim(rtrim($this->ns, '\\') . '\\' . $name, '\\');
+                            $node->name = new Node\Name(str_replace('\\\\', '\\', $ns));
+                        }
+                    }
+                }
+                return $node;
+            }
+        }
+
+        private function isInternal($name) {
+            $nameParts = explode('\\', $name);
+            $name = array_pop($nameParts);
+            return in_array($name, $this->internals);
+        }
+
+        private function isExcludableFn($name){
+            return !in_array($name, $this->funcs);
+        }
+        
+        private function getAllBuiltinEntitiesOfPhp() {
+            $classes = array_filter(get_declared_classes(), function($c) {
+                return (new ReflectionClass($c))->isInternal();
+            });
+            $interfaces = array_filter(get_declared_interfaces(), function($i) {
+                return (new ReflectionClass($i))->isInternal();
+            });
+            $functions = get_defined_functions()['internal'];
+            $constants = get_defined_constants(true);
+            unset($constants['user']);
+            return array_merge($classes, $interfaces, $functions, $constants);
+        }
+        
+        private function getListOfExcludableFunctions() {
+            $funcs = [];
+            if (file_exists(ABSPATH.'wp-includes/compat.php')) {
+                $file_content = file_get_contents(ABSPATH.'wp-includes/compat.php');
+                $pattern = '/\bfunction\s+([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\s*\(/';
+                preg_match_all($pattern, $file_content, $matches);
+                $funcs = $matches[1];
+            }
+            return $funcs;
+        }
+    });
+
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($inDir)
+    );
+
+    $files = new RegexIterator($files, '/\.php$/');
+
+    // $findComposerFiles = function ($directory) {
+    //     $files = [];
+    //     $iterator = new RecursiveIteratorIterator(
+    //         new RecursiveDirectoryIterator(
+    //             $directory, RecursiveDirectoryIterator::SKIP_DOTS
+    //         ), RecursiveIteratorIterator::SELF_FIRST
+    //     );
+    //     foreach ($iterator as $file) {
+    //         if ($file->isFile() && $file->getFilename() === 'composer.json') {
+    //             $files[] = $file->getPathname();
+    //         }
+    //     }
+    //     return $files;
+    // };
+
+    $composerFiles = [];
+    foreach ($files as $file) {
+        try {
+            $code = file_get_contents($path = $file->getPathName());
+            
+            // Add namespace to user-defined function files
+            
+            // Check if function defination exists
+            $pattern = '/\bfunction\s+([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*)\s*\(/';
+            if (preg_match($pattern, $code, $matches)) {
+                if (!preg_match("/\bnamespace\s+$namespace\b/", $code)) {
+                    if (strpos($code, 'namespace') !== false) {
+                        $code = preg_replace(
+                            '/namespace (.+?);/', "namespace $namespace\\\\$1;", $code, 1
+                        );
+                    } else {
+                        $code = str_replace('<?php', '', $code);
+                        $code = "<?php\n\nnamespace $namespace;\n\n" . $code;
+                    }
+                }
+
+                $ds = DIRECTORY_SEPARATOR;
+                $tokens = array_map(function($t) {
+                    if (is_array($t) && isset($t[0])) return $t[0];
+                }, token_get_all($code));
+
+                $tokens = array_values(array_unique(array_filter($tokens)));
+
+                // Prepare for updating composer files in autoload->files section
+                if (!array_intersect($tokens, [T_CLASS, T_TRAIT, T_INTERFACE])) {
+                    $pieces = explode('vendor', $path);
+                    $root = $pieces[0] . 'vendor';
+                    $dirName = pathinfo(trim($pieces[1], $ds))['dirname'];
+                    $parts = explode($ds, $dirName);
+                    
+                    do {
+                        $imploded = implode($ds, $parts);
+                        $f = $root.$ds.$imploded.$ds.'composer.json';
+                        if (!file_exists($f)) continue;
+
+                        $data = json_decode(file_get_contents($f), true);
+                        if (isset($data['autoload']['files'])) {
+                            $filesKey = $data['autoload']['files'];
+                            $fileGetFilename = $file->getFilename();
+                            if (!($nameExists = in_array($fileGetFilename, $filesKey))) {
+                                foreach ($filesKey as $fn) {
+                                    if (str_contains($fn, $file->getFilename())) {
+                                        if (str_contains($file->getPathname(), $fn)) {
+                                            $nameExists = true;
+                                            $fileGetFilename = $fn;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            if ($nameExists) {
+                                $newReportComposerData = (array) json_decode(
+                                    file_get_contents($composerUpdateReport), true
+                                );
+                                file_put_contents(
+                                    $composerUpdateReport, json_encode(
+                                        array_merge($newReportComposerData, [
+                                            $f => [
+                                                'name' => $fileGetFilename,
+                                                'package' => $data['name'],
+                                                'path' => $path
+                                            ]
+                                        ]),
+                                        JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES
+                                    )
+                                );
+                            }
+                        }
+                    } while (array_pop($parts));
+
+                    // Change the function_exists('fn') with function_exists('Ns\fn')
+                    $pattern = '/\bfunction_exists\s*\(\s*[\'"]([^\'"]+)[\'"]\s*\)/';
+                    if (preg_match_all($pattern, $code, $matches, PREG_OFFSET_CAPTURE)) {
+                        foreach (array_reverse($matches[1]) as $match) {
+                            $originalFunctionName = $match[0];
+                            if (str_starts_with($match[0], $namespace)) continue;
+                            $replacement = $namespace . '\\' . $originalFunctionName;
+                            $code = substr_replace(
+                                $code, $replacement, $match[1], strlen($originalFunctionName)
+                            );
+                        }
+                        file_put_contents($file->getPathname(), $code);
+                    }
+                }
+            }
+
+            file_put_contents($path, $printer->prettyPrintFile(
+                $traverser->traverse($parser->parse($code))
+            ));
+
+        } catch (Error $e) {
+            echo 'Error Occured'.PHP_EOL;
+            echo 'File: '.$e->getFile().PHP_EOL;
+            echo 'Line: '.$e->getLine().PHP_EOL;
+            echo 'Message: '.$e->getMessage().PHP_EOL;
+            continue;
+        }
+    }
+};

--- a/dev/cli/update_static.php
+++ b/dev/cli/update_static.php
@@ -1,0 +1,198 @@
+<?php require __DIR__.'/../vendor/autoload.php';
+
+if (!function_exists('dd')) {
+    function dd(/*args*/) {
+        ob_start();
+        foreach (func_get_args() as $arg) {
+            echo "<pre>";
+            print_r($arg);
+            echo "</pre>";
+        }
+        $ret = ob_get_clean();
+
+        if (str_contains(strtolower(php_sapi_name()), 'cli')) {
+            echo PHP_EOL.PHP_EOL . strip_tags($ret) . PHP_EOL.PHP_EOL;
+        } else {
+            echo strip_tags($ret);
+        }
+        die;
+    }
+}
+
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\NodeTraverser;
+use PhpParser\ParserFactory;
+use PhpParser\NodeVisitor\NameResolver;
+
+$classData = [
+	'props' => [],
+	'methods' => [],
+	'className' => '',
+];
+
+$classSourceCode = file_get_contents(
+	$filePath = __DIR__.'/../../vendor/composer/autoload_static.php'
+);
+
+$parser = (new ParserFactory)->createForNewestSupportedVersion();
+$traverser = new NodeTraverser();
+$traverser->addVisitor(new NameResolver());
+
+try {
+	$ns = json_decode(
+		file_get_contents(__DIR__.'/../../composer.json'), true
+	)['extra']['wpfluent']['namespace']['current'];
+
+    $stmts = $parser->parse($classSourceCode);
+
+    $methodVisitor = new class (
+    	$ns, $filePath, $classData
+    ) extends \PhpParser\NodeVisitorAbstract {
+    	private $ns = null;
+    	private $filePath = null;
+    	private $classData = null;
+    	public function __construct($ns, $filePath, &$classData) {
+    		$this->ns = $ns;
+    		$this->filePath = $filePath;
+    		$this->classData = &$classData;
+    	}
+        public function enterNode(Node $node) {
+        	if ($node instanceof Node\Stmt\Class_) {
+        		$this->classData['className'] = $node->name->name;
+        	} elseif ($node instanceof Node\Stmt\ClassMethod) {
+                $this->classData['methods'][] = $this->getFormattedCode($node);
+            } elseif ($node instanceof Node\Stmt\Property) {
+                $propertyName = $node->props[0]->name->name;
+                $propertyType = $node->isStatic() ? 'static' : '';
+                $visibility = $this->getPropertyVisibility($node);
+                $defaultValue = $this->getPropertyDefaultValue($node);
+                
+                eval('$defaultValue = ' . $defaultValue . ';');
+
+                if ($propertyName === 'prefixDirsPsr4') {
+                	$defaultValue = array_filter($defaultValue, function($key) {
+                		return strpos($key, $this->ns.'\\') === 0;
+                	}, ARRAY_FILTER_USE_KEY);
+                }
+
+                $this->classData['props'][$propertyName] = [
+                	'visibility' => $visibility,
+                	'propertyType' => $propertyType,
+                	'propertyName' => $propertyName,
+                	'defaultValue' => $defaultValue,
+                ];
+            }
+        }
+
+        private function getFormattedCode(Node $node): string {
+            $startPos = $node->getAttribute('startFilePos');
+            $endPos = $node->getAttribute('endFilePos');
+            $content = file_get_contents($this->filePath);
+            return $startPos !== null && $endPos !== null
+                ? substr($content, $startPos, $endPos - ($startPos-1))
+                : '';
+        }
+
+        private function getPropertyVisibility(Node\Stmt\Property $property): string {
+            if ($property->isPublic()) {
+                return 'public';
+            } elseif ($property->isProtected()) {
+                return 'protected';
+            } elseif ($property->isPrivate()) {
+                return 'private';
+            } else {
+                return 'unknown';
+            }
+        }
+
+        private function getPropertyDefaultValue(Node\Stmt\Property $property): string {
+            if (isset($property->props[0]->default)) {
+                return $this->getFormattedCode($property->props[0]->default);
+            }
+        }
+    };
+
+    $traverser->addVisitor($methodVisitor);
+    $traverser->traverse($stmts);
+    
+} catch (Error $error) {
+    echo 'Parse Error: ', $error->getMessage();
+}
+
+(function($path) use ($ns, $classData) {
+	$clsName = $classData['className'];
+	$props = $classData['props'];
+	$methods = $classData['methods'];
+	$filesArray = isset($props['files']) ? $props['files'] : [];
+	$prefixDirsPsr4Array = $props['prefixDirsPsr4'];
+	$prefixLengthsPsr4Array = $props['prefixLengthsPsr4'];
+	$classMapArray = $props['classMap'];
+
+	$filesEntry = '';
+	if ($filesArray) {
+		$filesEntry = "{$filesArray['visibility']} {$filesArray['propertyType']} \${$filesArray['propertyName']}";
+		$filesArray = var_export($filesArray['defaultValue'], 1);
+	}
+
+	$prefixDirsPsr4Entry = "{$prefixDirsPsr4Array['visibility']} {$prefixDirsPsr4Array['propertyType']} \${$prefixDirsPsr4Array['propertyName']}";
+	$prefixDirsPsr4Array = var_export($prefixDirsPsr4Array['defaultValue'], 1);
+
+	$prefixLengthsPsr4Entry = "{$prefixLengthsPsr4Array['visibility']} {$prefixLengthsPsr4Array['propertyType']} \${$prefixLengthsPsr4Array['propertyName']}";
+	$prefixLengthsPsr4Array = var_export($prefixLengthsPsr4Array['defaultValue'], 1);
+
+	$foundKey = null;
+	eval('$arr = ' . $prefixLengthsPsr4Array . ';');
+	foreach ($arr as $key => $value) {
+		foreach ($value as $k => $v) {
+			if (str_starts_with($k, $ns)) {
+				$foundKey = $key;
+				$prefixLengthsPsr4Array = $arr[$key];
+			}
+		}
+	}
+	
+	foreach ($prefixLengthsPsr4Array as $k => $v) {
+		if (!str_starts_with($k, $ns)) {
+			unset($prefixLengthsPsr4Array[$k]);
+		}
+	}
+
+	$prefixLengthsPsr4Array = [$foundKey => $prefixLengthsPsr4Array];
+	$prefixLengthsPsr4Array = var_export($prefixLengthsPsr4Array, 1);
+
+	$classMapEntry = "{$classMapArray['visibility']} {$classMapArray['propertyType']} \${$classMapArray['propertyName']}";
+	$classMapArray = var_export($classMapArray['defaultValue'], 1);
+
+	$methodCode = '';
+	foreach ($methods as $method) {
+		$methodCode .= $method.PHP_EOL;
+	}
+
+	if ($filesEntry) {
+		$filesEntry = "$filesEntry = $filesArray;";
+	}
+	
+	$classCode = <<<CODE
+	<?php
+
+	namespace Composer\Autoload;
+
+	class $clsName
+	{
+		$filesEntry
+		$prefixDirsPsr4Entry = $prefixDirsPsr4Array;
+		$prefixLengthsPsr4Entry = $prefixLengthsPsr4Array;
+		$classMapEntry = $classMapArray;
+
+		$methodCode
+	}
+	CODE;
+
+	$classCode = str_replace(__DIR__, '__DIR__.\'', $classCode);
+	$classCode = str_replace("'__DIR__", "__DIR__", $classCode);
+
+	file_put_contents($path, $classCode);
+})(
+	__DIR__.'/../../vendor/composer/autoload_static.php',
+);

--- a/dev/cli/wpf.php
+++ b/dev/cli/wpf.php
@@ -10,7 +10,6 @@ if (!defined('ABSPATH') && $command && !$isMakeCommand && !in_array($command, ['
 
 (require $cwd."/dev/cli/commands/init.php")($args, $loader);
 
-chdir($cwd.'/dev/');exec('composer dump');chdir($cwd);
 $require([$loader, $devGlobals, $functions]);
 
 if ($args) {

--- a/dev/cli/wpf.php
+++ b/dev/cli/wpf.php
@@ -1,0 +1,121 @@
+<?php
+
+$args = array_slice($argvals, 1);
+$command = isset($args[0]) ? $args[0] : null;
+
+if (!defined('ABSPATH') && $command && !in_array($command, ['init', 'test'], true)) {
+	require_once $cwd."/../../../wp-load.php";
+}
+
+(require $cwd."/dev/cli/commands/init.php")($args, $loader);
+
+chdir($cwd.'/dev/');exec('composer dump');chdir($cwd);
+$require([$loader, $devGlobals, $functions]);
+
+if ($args) {
+	if (strtolower(reset($args)) === 'about') {
+		$readMe = file_get_contents(
+			$cwd.'/vendor/wpfluent/framework/README.md'
+		);
+		
+		$about = require $cwd.'/config/app.php';
+		$about = array_merge(['PHP version' => PHP_VERSION], $about);
+		
+		if (preg_match('/version - \d+\.\d+.\d+/i', $readMe, $matches)) {
+			$pieces = explode('-', $matches[0]);
+			$about = array_merge(['Framework version' => trim(end($pieces))], $about);
+		}
+
+		foreach ($about as $key => $value) {
+			echo 'Plugin ' . str_pad(
+				ucwords(str_replace('_', ' ', $key)), 18
+			) . ' : ' . $value . PHP_EOL;
+		}
+	} elseif (($arg = reset($args)) === 'build') {
+		return (require $cwd.'/dev/cli/build.php')($cwd);
+	} elseif (($arg = reset($args)) === 'logmon') {
+		exec("pkill -f 'logmon'");
+		exec('php '.$cwd.'/dev/cli/logmon.php > /dev/null 2>&1 &');
+		echo "Log monitor started...\n";
+	} elseif (($arg = reset($args)) === 'logoff') {
+		exec("pkill -f 'logmon'");
+		echo "Log monitor stopped.\n";
+	} elseif (($arg = reset($args)) === 'test') {
+		$tmpDir = sys_get_temp_dir();
+		$init = require $cwd . "/dev/cli/commands/init.php";
+		
+		$del = function ($path) use (&$del) {
+		    if (is_file($path) || is_link($path)) {
+		        if (!@unlink($path)) {
+		            throw new RuntimeException(
+		            	"Failed to delete file: $path"
+		            );
+		        }
+		    } elseif (is_dir($path)) {
+		        $items = array_diff(scandir($path), ['.', '..']);
+		        foreach ($items as $item) {
+		            $del($path . DIRECTORY_SEPARATOR . $item);
+		        }
+		        // Try to remove the directory, handle errors
+		        if (!@rmdir($path)) {
+		            throw new RuntimeException(
+		            	"Failed to delete directory: $path"
+		            );
+		        }
+		    }
+		};
+
+		register_shutdown_function(function() use (
+			&$del, &$loader, &$init, $tmpDir
+		) {
+		    $error = error_get_last();
+		    if ($error !== null) {
+		    	echo "\nIf this error is related to test suit then run ";
+		    	die("./wpf init\n");
+		    }
+		});
+
+		try {
+			$funcPath = $tmpDir . '/wordpress-tests-lib/includes/functions.php';
+			if (!file_exists($funcPath)) {
+				echo "\nNeed to install the test suite, please wait..., \n\n";
+		        foreach (['/wordpress', '/wordpress-tests-lib'] as $p) {
+		            $del($tmpDir . $p);
+		        }
+				$init(['init'], $loader);
+				die('Run ./wpf test'.PHP_EOL);
+			}
+
+			// Make the plugin active during the testing
+			$p = substr($cwd, strrpos($cwd, '/') + 1);
+			$GLOBALS['wp_tests_options'] = [
+				'active_plugins' => [$p.'/fluentform.php']
+			];
+			// Run the test suite
+			chdir($cwd.'/dev');
+			$args = array_merge($args, ['--exclude', 'skip']);
+		    $command = new PHPUnit\TextUI\Command;
+		    $result = $command->run(
+		    	['phpunit', ...array_splice($args, 1)], false
+		    );
+
+		    if ($result > 2) {
+		    	$msg = 'If nothing works, try running: '.PHP_EOL.PHP_EOL;
+				$msg .='rm -rf "$(echo $TMPDIR)wordpress" ';
+				$msg .= '"$(echo $TMPDIR)wordpress-tests-lib"'.PHP_EOL.PHP_EOL; 
+				$msg .= './wpf test or ./dev/test/setup.sh'.PHP_EOL.PHP_EOL;
+				die($msg);
+		    }
+		} catch (Exception $e) {
+			die($e->getMessage().PHP_EOL);
+		}
+	} elseif ($arg === 'fix') {
+		echo "Please wait a few moments...".PHP_EOL;
+		return (require $cwd.'/dev/cli/update_static.php');
+	} elseif ($arg !== 'init') {
+		(require $cwd.'/dev/cli/index.php')($args);
+	}
+} else {
+	// Show the available commands list
+	require $cwd.'/dev/cli/list_commands.php';
+}

--- a/dev/cli/wpf.php
+++ b/dev/cli/wpf.php
@@ -2,8 +2,9 @@
 
 $args = array_slice($argvals, 1);
 $command = isset($args[0]) ? $args[0] : null;
+$isMakeCommand = is_string($command) && strpos($command, 'make:') === 0;
 
-if (!defined('ABSPATH') && $command && !in_array($command, ['init', 'test'], true)) {
+if (!defined('ABSPATH') && $command && !$isMakeCommand && !in_array($command, ['init', 'test'], true)) {
 	require_once $cwd."/../../../wp-load.php";
 }
 

--- a/dev/composer.json
+++ b/dev/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "wpfluent/frameworktest",
+    "version": "1.0.0",
+    "require-dev": {
+        "phpunit/phpunit": "^8",
+        "yoast/phpunit-polyfills": "^2.0",
+        "symfony/console": "^4.0|^5.0",
+        "fakerphp/faker": "^1.24",
+        "nikic/php-parser": "^5.0"
+    },
+    "autoload": {
+        "psr-4": {},
+        "classmap": [
+            "cli", "factories", "test"
+        ]
+    },
+    "authors": [
+        {
+            "name": "Sheikh Heera",
+            "email": "heera.sheikh77@gmail.com"
+        }
+    ],
+    "require": {}
+}

--- a/dev/composer.json
+++ b/dev/composer.json
@@ -6,7 +6,13 @@
         "yoast/phpunit-polyfills": "^2.0",
         "symfony/console": "^4.0|^5.0",
         "fakerphp/faker": "^1.24",
-        "nikic/php-parser": "^5.0"
+        "nikic/php-parser": "^5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+        "phpcompatibility/php-compatibility": "^9.0",
+        "phpcompatibility/phpcompatibility-wp": "^2.1",
+        "squizlabs/php_codesniffer": "^3.7",
+        "phpstan/phpstan": "^1.11",
+        "szepeviktor/phpstan-wordpress": "^1.3"
     },
     "autoload": {
         "psr-4": {},
@@ -20,5 +26,14 @@
             "email": "heera.sheikh77@gmail.com"
         }
     ],
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "scripts": {
+        "phpcs": "php -d error_reporting=8191 vendor/bin/phpcs -p",
+        "phpstan": "phpstan analyse ../app --configuration=phpstan.neon --memory-limit=2G --autoload-file=vendor/autoload.php"
+    },
     "require": {}
 }

--- a/dev/composer.lock
+++ b/dev/composer.lock
@@ -4,9 +4,105 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "806fcd4ae8669b88b7a0e060cbcdcf95",
+    "content-hash": "b79bdf9721e62e67c3ba546ccf74631f",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-11T04:32:07+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.5.0",
@@ -375,6 +471,324 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+            },
+            "time": "2026-02-03T19:29:21+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.33",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "reference": "37982d6fc7cbb746dda7773530cda557cdf119e1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-28T20:30:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1609,6 +2023,85 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v5.4.47",
             "source": {
@@ -2448,6 +2941,69 @@
                 }
             ],
             "time": "2026-02-08T20:44:54+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+                "phpstan/phpstan": "^1.10.31",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+            },
+            "time": "2024-06-28T22:27:19+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/dev/composer.lock
+++ b/dev/composer.lock
@@ -1,0 +1,2574 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "806fcd4ae8669b88b7a0e060cbcdcf95",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
+            "name": "fakerphp/faker",
+            "version": "v1.24.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/FakerPHP/Faker.git",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "psr/container": "^1.0 || ^2.0",
+                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+            },
+            "conflict": {
+                "fzaninotto/faker": "*"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "doctrine/persistence": "^1.3 || ^2.0",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.5.26",
+                "symfony/phpunit-bridge": "^5.4.16"
+            },
+            "suggest": {
+                "doctrine/orm": "Required to use Faker\\ORM\\Doctrine",
+                "ext-curl": "Required by Faker\\Provider\\Image to download images.",
+                "ext-dom": "Required by Faker\\Provider\\HtmlLorem for generating random HTML.",
+                "ext-iconv": "Required by Faker\\Provider\\ru_RU\\Text::realText() for generating real Russian text.",
+                "ext-mbstring": "Required for multibyte Unicode string functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Faker\\": "src/Faker/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "François Zaninotto"
+                }
+            ],
+            "description": "Faker is a PHP library that generates fake data for you.",
+            "keywords": [
+                "data",
+                "faker",
+                "fixtures"
+            ],
+            "support": {
+                "issues": "https://github.com/FakerPHP/Faker/issues",
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+            },
+            "time": "2024-11-21T13:46:39+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "7.0.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
+                "reference": "40a4ed114a4aea5afd6df8d0f0c9cd3033097f66",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=7.2",
+                "phpunit/php-file-iterator": "^2.0.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.1.3 || ^4.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^4.2.2",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2.2"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/7.0.17"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:09:37+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "2.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "69deeb8664f611f156a924154985fbd4911eb36b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/69deeb8664f611f156a924154985fbd4911eb36b",
+                "reference": "69deeb8664f611f156a924154985fbd4911eb36b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/2.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:39:50+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/1.2.1"
+            },
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/a691211e94ff39a34811abd521c31bd5b305b0bb",
+                "reference": "a691211e94ff39a34811abd521c31bd5b305b0bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/2.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:42:41+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "reference": "a853a0e183b9db7eed023d7933a858fa1c8d25a3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
+                "source": "https://github.com/sebastianbergmann/php-token-stream/tree/master"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "abandoned": true,
+            "time": "2020-08-04T08:28:15+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "8.5.52",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/1015741814413c156abb0f53d7db7bbd03c6e858",
+                "reference": "1015741814413c156abb0f53d7db7bbd03c6e858",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.2",
+                "phpunit/php-code-coverage": "^7.0.17",
+                "phpunit/php-file-iterator": "^2.0.6",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.1.4",
+                "sebastian/comparator": "^3.0.7",
+                "sebastian/diff": "^3.0.6",
+                "sebastian/environment": "^4.2.5",
+                "sebastian/exporter": "^3.1.8",
+                "sebastian/global-state": "^3.0.6",
+                "sebastian/object-enumerator": "^3.0.5",
+                "sebastian/resource-operations": "^2.0.3",
+                "sebastian/type": "^1.1.5",
+                "sebastian/version": "^2.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage",
+                "phpunit/php-invoker": "To allow enforcing time limits"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.5-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/8.5.52"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:20:18+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
+                "reference": "92a1a52e86d34cde6caa54f1b5ffa9fda18e5d54",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/1.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:45:45+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "3.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52",
+                "reference": "bc7d8ac2fe1cce229bff9b5fd4efe65918a1ff52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/3.0.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:20:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/98ff311ca519c3aa73ccd3de053bdb377171d7b6",
+                "reference": "98ff311ca519c3aa73ccd3de053bdb377171d7b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:16:36+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "4.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "56932f6049a0482853056ffd617c91ffcc754205"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/56932f6049a0482853056ffd617c91ffcc754205",
+                "reference": "56932f6049a0482853056ffd617c91ffcc754205",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/4.2.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:49:59+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/64cfeaa341951ceb2019d7b98232399d57bb2296",
+                "reference": "64cfeaa341951ceb2019d7b98232399d57bb2296",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/3.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T05:55:14+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "800689427e3e8cf57a8fe38fcd1d4344c9b2f046"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/800689427e3e8cf57a8fe38fcd1d4344c9b2f046",
+                "reference": "800689427e3e8cf57a8fe38fcd1d4344c9b2f046",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T05:40:12+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "ac5b293dba925751b808e02923399fb44ff0d541"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/ac5b293dba925751b808e02923399fb44ff0d541",
+                "reference": "ac5b293dba925751b808e02923399fb44ff0d541",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:54:02+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/1d439c229e61f244ff1f211e5c99737f90c67def",
+                "reference": "1d439c229e61f244ff1f211e5c99737f90c67def",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/1.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:56:04+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/8fe7e75986a9d24b4cceae847314035df7703a5a",
+                "reference": "8fe7e75986a9d24b4cceae847314035df7703a5a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T05:25:53+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/72a7f7674d053d548003b16ff5a106e7e0e06eee",
+                "reference": "72a7f7674d053d548003b16ff5a106e7e0e06eee",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T13:59:09+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/18f071c3a29892b037d35e6b20ddf3ea39b42874",
+                "reference": "18f071c3a29892b037d35e6b20ddf3ea39b42874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/1.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-01T14:04:07+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/master"
+            },
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v5.4.47",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "reference": "c4ba980ca61a9eb18ee6bcc73f28e475852bb1ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/string": "^5.1|^6.0"
+            },
+            "conflict": {
+                "psr/log": ">=3",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/dotenv": "<5.1",
+                "symfony/event-dispatcher": "<4.4",
+                "symfony/lock": "<4.4",
+                "symfony/process": "<4.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/event-dispatcher": "^4.4|^5.0|^6.0",
+                "symfony/lock": "^4.4|^5.0|^6.0",
+                "symfony/process": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "suggest": {
+                "psr/log": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/lock": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.4.47"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-06T11:30:55+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "reference": "ad1b7b9092976d6c948b8a187cec9faaea9ec1df",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.36.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.6-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v6.4.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/2adaf4106f2ef4c67271971bde6d3fe0a6936432",
+                "reference": "2adaf4106f2ef4c67271971bde6d3fe0a6936432",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/intl": "^6.2|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v6.4.34"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-08T20:44:54+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/dev/factories/Core/Factory.php
+++ b/dev/factories/Core/Factory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Dev\Factories\Core;
+
+use Faker\Factory as Faker;
+
+abstract class Factory
+{
+	use Methods;
+
+	protected $count = 0;
+	
+	protected $factory = null;
+
+	protected static $model = null;
+
+	abstract public function defination($data = []);
+
+	public function __construct($factory = null)
+	{
+		$this->fake = $factory ?: Faker::create('en_GB');
+	}
+
+	public function __call($method, $args = [])
+	{
+		$method = $method.'Method';
+
+		return $this->{$method}(...$args);
+	}
+
+	public static function __callStatic($method, $args = [])
+	{
+		return (new static)->{$method}(...$args);
+	}
+}

--- a/dev/factories/Core/Methods.php
+++ b/dev/factories/Core/Methods.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Dev\Factories\Core;
+
+trait Methods
+{
+	protected $shouldCreateModel = false;
+
+	protected function createMethod($data = [])
+	{
+		$this->checkForModelExistance();
+		$this->shouldCreateModel = true;
+		$data = $this->makeMethod($data);
+		$this->shouldCreateModel = false;
+		return is_array($data) ? (new static::$model)->newCollection($data) : $data;
+	}
+
+	protected function makeMethod($data = [])
+	{
+		$data = is_array($data) ? $data : $data->toArray();
+		
+		if ($this->count) {
+			$result = [];
+			
+			do {
+				$result[] = $this->toArray($data);
+			} while (--$this->count);
+
+			return $result;
+		}
+
+		return $this->toArray($data);
+		
+	}
+
+	protected function countMethod($count)
+	{
+		$this->count = $count;
+
+		return $this;
+	}
+
+	protected function freshMethod()
+	{
+		$this->checkForModelExistance();
+
+		static::$model::truncate();
+
+		return $this;
+	}
+
+	protected function resetPrimaryKeyMethod()
+	{
+		$this->checkForModelExistance();
+		
+		$db = $GLOBALS['wpdb'];
+		$table = (new static::$model)->getTable();
+		$db->query('alter table '.$db->prefix.$table.' auto_increment = 1');
+		return $this;
+	}
+
+	protected function toArray($data = [])
+	{
+		$defination = $this->defination($data);
+
+		$data = array_merge(
+			$defination, array_map(function($value) {
+				return is_callable($value) ? $value($this->fake) : $value;
+			}, $data)
+		);
+
+		return $this->shouldCreateModel ? static::$model::create($data) : $data;
+	}
+
+	protected function checkForModelExistance()
+	{
+		if (!static::$model) {
+			if (str_contains(strtolower(php_sapi_name()), 'cli')) {
+				if (class_exists($c = 'Symfony\Component\Console\Output\ConsoleOutput')) {
+					(new $c)->writeln('<error>The static property '.static::class.'::$model must contain a fully qualified model name.</error>'
+					);die;
+				}
+			}
+
+			throw new \BadMethodCallException(
+				'The static property '.static::class.'::$model must contain a model name with namespace.'
+			);
+		}
+	}
+}

--- a/dev/factories/PostFactory.php
+++ b/dev/factories/PostFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Dev\Factories;
+
+// use PluginNamespace\App\Models\Post;
+use Dev\Factories\Core\Factory;
+
+class PostFactory extends Factory
+{
+	// Required to use Factory::create method
+	// protected static $model = Post::class;
+
+	public function defination($data = [])
+	{
+		return [
+			'post_author' => $data['ID'],
+			'post_title' => $this->fake->sentence(2),
+			'post_content' => $this->fake->paragraph(5)
+		];
+	}
+}

--- a/dev/factories/UserFactory.php
+++ b/dev/factories/UserFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Dev\Factories;
+
+// use PluginNamespace\App\Models\User;
+use Dev\Factories\Core\Factory;
+
+class UserFactory extends Factory
+{
+	// Required to use Factory::create method
+	// protected static $model = User::class;
+
+	public function defination($data = [])
+	{
+		return [
+			'user_login' => $this->fake->name,
+			'user_pass' => wp_hash_password(12345678),
+			'post_email' => $this->fake->email,
+		];
+	}
+}

--- a/dev/globals.php
+++ b/dev/globals.php
@@ -1,0 +1,94 @@
+<?php
+
+if (!function_exists('dd')) {
+    /**
+     * Dump & Die
+     */
+    function dd(/*args*/)
+    {
+        ob_start();
+        foreach (func_get_args() as $arg) {
+            echo "<pre>";
+            print_r($arg);
+            echo "</pre>";
+        }
+        $ret = ob_get_clean();
+
+        if (str_contains(strtolower(php_sapi_name()), 'cli')) {
+            echo PHP_EOL.PHP_EOL . strip_tags($ret) . PHP_EOL.PHP_EOL;
+        } else {
+            echo strip_tags($ret);
+        }
+        die;
+    }
+}
+
+if (!function_exists('ddd')) {
+    /**
+     * Dump & Don't Die
+     */
+    function ddd(/*args*/)
+    {
+        ob_start();
+        foreach (func_get_args() as $arg) {
+            echo "<pre>";
+            print_r($arg);
+            echo "</pre>";
+        }
+        $ret = ob_get_clean();
+
+        if (str_contains(strtolower(php_sapi_name()), 'cli')) {
+            echo PHP_EOL.PHP_EOL . strip_tags($ret) . PHP_EOL.PHP_EOL;
+        } else {
+            echo strip_tags($ret);
+        }
+    }
+}
+
+if (!function_exists('wpf_log')) {
+    function wpf_log($m) {
+        $m = is_array($m) || is_object($m) ? json_encode($m, JSON_PRETTY_PRINT) : $m;
+        $format = get_option('date_format') . ' ' . get_option('time_format');
+        error_log($m);
+    }
+}
+
+if (!function_exists('wpf_eql')) {
+    /**
+     * Enable Query Log
+     */
+    function wpf_eql() {
+        $lastIndex = 0;
+        defined('SAVEQUERIES') || define('SAVEQUERIES', true);
+        if ($queries = (array) $GLOBALS['wpdb']->queries) {
+            $lastIndex = count($queries);
+        }
+        return $lastIndex;
+    }
+}
+
+if (!function_exists('wpf_gql')) {
+    /**
+     * Get Query Log
+     */
+    function wpf_gql($start = 0) {
+        $result = [];
+        $queries = (array) $GLOBALS['wpdb']->queries;
+        $queries = $start > 0 ? array_slice($queries, $start) : $queries;
+        foreach ($queries as $key => $query) {
+            $result[++$key] = array_combine([
+                'query', 'execution_time'
+            ], array_slice($query, 0, 2));
+        }
+        return $result;
+    }
+}
+
+if (!function_exists('wpf_wql')) {
+    /**
+     * Write Query Log
+     */
+    function wpf_wql($start) {
+        wpf_log(wpf_gql($start));
+    }
+}

--- a/dev/phpcs.xml
+++ b/dev/phpcs.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<ruleset name="Fluent Forms PHP Compatibility">
+    <description>PHP compatibility checks for Fluent Forms plugin code.</description>
+
+    <arg name="extensions" value="php"/>
+
+    <file>../app</file>
+
+    <rule ref="PHPCompatibility">
+        <properties>
+            <property name="testVersion" value="7.4-8.4"/>
+        </properties>
+    </rule>
+
+    <rule ref="PHPCompatibilityWP"/>
+
+    <rule ref="PHPCompatibility.FunctionUse.ArgumentFunctionsReportCurrentValue">
+        <severity>0</severity>
+    </rule>
+</ruleset>

--- a/dev/phpstan.neon
+++ b/dev/phpstan.neon
@@ -1,0 +1,17 @@
+parameters:
+    level: 2
+    scanDirectories:
+        - ../vendor
+
+    bootstrapFiles:
+        - ../vendor/autoload.php
+
+    ignoreErrors:
+        - '#Unsafe usage of new static\(\)#'
+        - '#Call to an undefined static method .*#'
+        - '#Call to an undefined method .*#'
+        - '#Method .* should return .* but return statement is missing#'
+        - '#@param .* contains generic type .* but class .* is not generic#'
+
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon

--- a/dev/phpunit.xml.dist
+++ b/dev/phpunit.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<phpunit
+	colors="true"
+	cacheResult ="false"
+	backupGlobals="false"
+	stopOnFailure="true"
+	bootstrap="test/inc/bootstrap.php"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite name="wpftest">
+			<directory suffix=".php">./test/tests</directory>
+		</testsuite>
+	</testsuites>
+	<php>
+		<env name="ENV" value="testing"/>
+        <ini name="display_errors" value="On" />
+        <ini name="display_startup_errors" value="On" />
+    </php>
+    <logging>
+        <log type="testdox-text" target="php://stdout"/>
+    </logging>
+</phpunit>

--- a/dev/seeds/index.php
+++ b/dev/seeds/index.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * This is an example for seeding. In the given code below, the CustomUserFactory is
+ * reseting the primary key starting from 1, creating 5 users and looping each user
+ * from the collection and creating 5 posts for each user using the hasMany relation.
+ */
+
+/*
+use Dev\Factories\{
+	CustomUserFactory,
+	CustomPostFactory
+};
+
+CustomUserFactory::resetPrimaryKey()->count(5)->create()->each(function($user) {
+	$user->posts()->createMany(
+		CustomPostFactory::resetPrimaryKey()->count(5)->make()
+	);
+});
+*/

--- a/dev/test/inc/App.php
+++ b/dev/test/inc/App.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+class App
+{
+	public static function __callStatic($method, $args)
+	{
+		$application = static::getInstance();
+
+		if (str_starts_with(reset($args) ?: '', '_NS')) {
+			
+			$ns = $application->getComposer(
+				'extra.wpfluent.namespace.current'
+			);
+
+			$args[0] = str_replace('_NS', $ns, $args[0]);
+		}
+
+		$method = 'getInstance' ? 'make' : $method;
+
+		return !$args ? $application : $application->{$method}(...$args);
+	}
+
+	public static function getInstance()
+	{
+		static $appClass, $application;
+		
+		$appClass = json_decode(
+			file_get_contents(
+				__DIR__ . '/../../../composer.json'
+			), true
+		)['extra']['wpfluent']['namespace']['current'] . '\\App\\App';
+
+		return $appClass::make();
+	}
+}

--- a/dev/test/inc/Concerns.php
+++ b/dev/test/inc/Concerns.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+use InvalidArgumentException;
+
+trait Concerns
+{
+	public function get($uri, $params = [])
+	{
+		$response = $this->server->dispatch(
+			$this->createRequest('GET', $uri, $params)
+		);
+
+		return new Response($response);
+	}
+
+	public function post($uri, $params = [])
+	{
+		$response = $this->server->dispatch(
+			$this->createRequest('POST', $uri, $params)
+		);
+
+		return new Response($response);
+	}
+
+	public function createRequest($method, $uri, $params = [])
+    {
+    	do_action('rest_api_init');
+
+        $request = new \WP_REST_Request(
+        	$method, $this->getRestNamespace() . trim($uri, '/')
+        );
+
+        if (count($params)) {
+    		foreach ($params as $param => $value) {
+                $request->set_param($param, $value);
+            }
+        }
+
+        return $request;
+    }
+
+	protected function getRestNamespace()
+	{
+		$ns = $this->plugin->config->get('app.rest_namespace');
+
+		$ver = $this->plugin->config->get('app.rest_version');
+
+		return '/' . $ns . '/' . $ver . '/';
+	}
+
+	public function login($id)
+	{
+		return $this->setUser($id);
+	}
+
+	public function logout()
+	{
+		return $this->setUser(0);
+	}
+
+	public function setUser($id)
+	{
+		$exception = new InvalidArgumentException(
+			'The argument must be a valid user ID or WP_User object'
+		);
+
+		if (is_int($id) || $id instanceof \WP_User) {
+			$user = wp_set_current_user(
+				is_object($id) ? $id->ID : $id
+			);
+
+			if ($id && !$user->ID) {
+				throw $exception;
+			}
+
+			return $this;
+		}
+
+		throw $exception;
+	}
+}

--- a/dev/test/inc/Factory.php
+++ b/dev/test/inc/Factory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+use Exception;
+use WP_UnitTest_Factory;
+
+class Factory
+{
+	public function __get($key)
+	{
+		return $this->resolveCustomFactory($key);
+	}
+
+	protected function resolveCustomFactory($key)
+	{
+		$keyName = strtoupper($key[0]).substr($key, 1);
+
+		$file = realpath(__DIR__.'/../../factories/'.$keyName.'Factory.php');
+		
+		if (file_exists($file)) {
+			$class = '\\Dev\\Factories\\'.basename($file, '.php');
+			if (!class_exists($class)) {
+				require $file;
+			}
+
+			return new $class;
+		}
+
+		$cls = __CLASS__;
+		throw new Exception("Undefined property {$cls}::{$key}.");
+	}
+}

--- a/dev/test/inc/RefreshDatabase.php
+++ b/dev/test/inc/RefreshDatabase.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+trait RefreshDatabase
+{
+	protected static $tables = [
+		'users', 'usermeta',
+		'posts', 'postmeta',
+		'terms', 'termmeta',
+		'comments', 'commentmeta',
+		'links', 'tags', 'taggables',
+		'term_taxonomy', 'term_relationships',
+	];
+
+	private function getNamespace()
+	{
+		static $ns;
+
+		if (!$ns) {
+			$ns = json_decode(
+				file_get_contents(
+					realpath(__DIR__.'/../../../composer.json')
+				), true
+			)['extra']['wpfluent']['namespace']['current'];
+		}
+
+		return $ns;
+	}
+
+	private function migrator()
+	{
+		return ($this->getNamespace().'\Database\DBMigrator');
+	}
+
+	private function schema()
+	{	
+		return ($this->getNamespace().'\Framework\Database\Schema');
+	}
+
+	public function setUp() : void
+	{
+		parent::setUp();
+
+		[$migrator, $schema] = [$this->migrator(), $this->schema()];
+
+		$migrator::migrateUp();
+
+		foreach (static::$tables as $table) {
+			$schema::truncateTableIfExists($table);
+		}
+	}
+
+	public function tearDown() : void
+	{
+		parent::tearDown();
+
+		$this->migrator()::migrateDown();
+	}
+}

--- a/dev/test/inc/Response.php
+++ b/dev/test/inc/Response.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+class Response
+{
+	protected $response = null;
+
+	public function __construct($response)
+	{
+		$this->response = $response;
+	}
+
+	public function dd()
+	{
+		dd([
+			'status' => $this->response->get_status(),
+			'data' => $this->response->get_data()
+		]);
+	}
+
+	public function ddd()
+	{
+		ddd([
+			'status' => $this->response->get_status(),
+			'data' => $this->response->get_data()
+		]);
+	}
+
+	public function isOkay()
+	{
+		return $this->getStatus() === 200;
+	}
+
+	public function isForbidden()
+	{
+		return $this->getStatus() === 403;
+	}
+
+	public function __call($method, $params = [])
+	{
+		if (preg_match('/[A-Z]/', $method, $matches)) {
+			foreach ($matches as $match) {
+				$method = str_replace($match, '_'.strtolower($match), $method);
+			}
+		}
+		
+		return $this->response->{$method}(...$params);
+	}
+}

--- a/dev/test/inc/TestCase.php
+++ b/dev/test/inc/TestCase.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+use WP_REST_Server;
+use InvalidArgumentException;
+use PHPUnit_Framework_TestCase;
+
+class TestCase extends PHPUnit_Framework_TestCase
+{
+	use Concerns;
+	use RefreshDatabase {
+	    RefreshDatabase::setUp as refreshDatabaseSetup;
+	    RefreshDatabase::tearDown as refreshDatabaseTearDown;
+	}
+
+	protected $plugin = null;
+	
+	protected $router = null;
+	
+	protected $server = null;
+	
+	protected $factory = null;
+
+	public function setUp() : void
+	{
+		global $wp_rest_server;
+
+        $this->server = $wp_rest_server = new WP_REST_Server;
+
+        $this->plugin = include realpath(__DIR__ . '/../../../fluentform.php');
+        
+        $this->router = $this->plugin->router;
+
+        $this->factory = new Factory;
+
+        App::make('config')->set('app.env', 'testing');
+
+        $this->refreshDatabaseSetup();
+
+        do_action('rest_api_init');
+	}
+
+	public function tearDown() : void
+	{
+		global $wp_rest_server;
+        
+        $wp_rest_server = null;
+
+		$this->refreshDatabaseTearDown();
+	}
+}

--- a/dev/test/inc/UsersAndPostsSeeder.php
+++ b/dev/test/inc/UsersAndPostsSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Dev\Test\Inc;
+
+trait UsersAndPostsSeeder
+{
+	public function seedUsersAndPosts($count = 10)
+	{
+		$users = $this->factory->user->count($count)->create();
+
+		foreach ($users as $user) {
+
+			foreach (range(1, 2) as $i) {
+				$post = $user->posts()->create(
+					$this->factory->post->make($user)
+				);
+
+				foreach (range(1, 2) as $j) {
+					wp_insert_comment([
+						'user_id' => $user->ID,
+						'comment_post_ID' => $post->ID,
+						'comment_content' => 'Comment - ' . $j . ' of user - ' . $user->ID,
+					]);
+				}
+			}
+		}
+	}
+}

--- a/dev/test/inc/bootstrap.php
+++ b/dev/test/inc/bootstrap.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * PHPUnit bootstrap file.
+ *
+ * @package Wpftest
+ */
+
+ini_set('error_reporting', E_ALL);
+ini_set('display_errors', '1');
+ini_set('display_startup_errors', '1');
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+
+if ( ! $_tests_dir ) {
+	$_tests_dir = rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+}
+
+// Forward custom PHPUnit Polyfills configuration to PHPUnit bootstrap file.
+$_phpunit_polyfills_path = getenv( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH' );
+if ( false !== $_phpunit_polyfills_path ) {
+	define( 'WP_TESTS_PHPUNIT_POLYFILLS_PATH', $_phpunit_polyfills_path );
+}
+
+if ( ! file_exists( "{$_tests_dir}/includes/functions.php" ) ) {
+	echo "Could not find {$_tests_dir}/includes/functions.php, have you run dev/test/setup.sh ?" . PHP_EOL; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	exit( 1 );
+}
+
+// Give access to tests_add_filter() function.
+require_once "{$_tests_dir}/includes/functions.php";
+
+tests_add_filter('muplugins_loaded', function() {
+	require dirname(realpath(__DIR__.'/../../')) . '/fluentform.php';
+});
+
+// Start up the WP testing environment.
+require "{$_tests_dir}/includes/bootstrap.php";

--- a/dev/test/setup.sh
+++ b/dev/test/setup.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+\-(beta|RC)[0-9]+$ ]]; then
+	WP_BRANCH=${WP_VERSION%\-*}
+	WP_TESTS_TAG="branches/$WP_BRANCH"
+
+elif [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+	WP_TESTS_TAG="branches/$WP_VERSION"
+elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+	if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+		# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+		WP_TESTS_TAG="tags/${WP_VERSION%??}"
+	else
+		WP_TESTS_TAG="tags/$WP_VERSION"
+	fi
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p $TMPDIR/wordpress-trunk
+		rm -rf $TMPDIR/wordpress-trunk/*
+		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
+		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
+			# https serves multiple offers, whereas http serves single.
+			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
+				LATEST_VERSION=${WP_VERSION%??}
+			else
+				# otherwise, scan the releases and get the most up to date minor version of the major release
+				local VERSION_ESCAPED=`echo $WP_VERSION | sed 's/\./\\\\./g'`
+				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+			fi
+			if [[ -z "$LATEST_VERSION" ]]; then
+				local ARCHIVE_NAME="wordpress-$WP_VERSION"
+			else
+				local ARCHIVE_NAME="wordpress-$LATEST_VERSION"
+			fi
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  $TMPDIR/wordpress.tar.gz
+		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.githubusercontent.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i.bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		rm -rf $WP_TESTS_DIR/{includes,data}
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+recreate_db() {
+	shopt -s nocasematch
+	if [[ $1 =~ ^(y|yes)$ ]]
+	then
+		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		create_db
+		echo "Recreated the database ($DB_NAME)."
+	else
+		echo "Leaving the existing database ($DB_NAME) in place."
+	fi
+	shopt -u nocasematch
+}
+
+create_db() {
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]
+	then
+		echo "Reinstalling will delete the existing test database ($DB_NAME)"
+		read -p 'Are you sure you want to proceed? [y/N]: ' DELETE_EXISTING_DB
+		recreate_db $DELETE_EXISTING_DB
+	else
+		create_db
+	fi
+}
+
+install_wp
+install_test_suite
+install_db

--- a/dev/test/tests/DB/TestDBWorks.php
+++ b/dev/test/tests/DB/TestDBWorks.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Dev\Test\Tests\DB;
+
+use Dev\Test\Inc\TestCase;
+
+class TestDBWorks extends TestCase
+{	
+	public function test_db_works()
+	{
+		$this->assertIsArray(
+			$this->plugin->db->getColumns('users')
+		);
+
+		// Check the users table is empty, initially it should be empty.
+		$this->assertEquals(0, $this->plugin->db->table('users')->count());
+	}
+}

--- a/dev/test/tests/Rest/TestRestWorks.php
+++ b/dev/test/tests/Rest/TestRestWorks.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Dev\Test\Tests\Rest;
+
+use Dev\Test\Inc\TestCase;
+
+class TestRestWorks extends TestCase
+{
+	public function test_rest_works()
+	{
+		$this->router->get('test', function() {});
+		
+		$response = $this->get('test');
+
+		$this->assertTrue($response->isOkay());
+	}
+}

--- a/dev/test/tests/TestSample.php
+++ b/dev/test/tests/TestSample.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Dev\Test\Tests;
+
+use Dev\Test\Inc\App;
+use Dev\Test\Inc\TestCase;
+use Dev\Test\Inc\UsersAndPostsSeeder;
+// use PluginNamespace\App\Models\User;
+
+class TestSample extends TestCase
+{
+	use UsersAndPostsSeeder;
+
+	public function setUp(): void
+	{
+		parent::setUp();
+		$this->seedUsersAndPosts();
+	}
+
+	public function test_works()
+	{
+		$this->assertTrue(true);
+		// $this->assertCount(10, User::get());
+	}
+}

--- a/wpf
+++ b/wpf
@@ -1,0 +1,14 @@
+#!/usr/bin/env php
+
+<?php
+
+(function($argvals, $cwd, $loader, $devGlobals, $functions, $require) {
+	require $cwd.'/dev/cli/wpf.php';
+})(
+	$argv,
+	__DIR__,
+	__DIR__. '/dev/vendor/autoload.php',
+	__DIR__. '/dev/globals.php',
+	__DIR__. '/dev/cli/functions.php',
+	function($a) {foreach($a as $f) require $f;},
+);


### PR DESCRIPTION
## What does this PR do and why?

Fluent Forms lost its plugin-level `dev/` toolkit and `wpf` launcher on the current branch lineage, which made local dev/test bootstrap unavailable. This PR restores the historical dev scaffold, updates its PHP 8.3-compatible Composer dependencies, and makes `wpf init` read test DB settings from `wp-config.php` so it can initialize without being blocked by unrelated active-plugin fatals during full WordPress bootstrap.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [x] Build/config (Vite, composer, CI)

## How to test

1. Run `composer install` in the plugin root if needed.
2. From the plugin root, run `php ./wpf`.
3. Confirm the command completes and list available commands
4. Verify `dev/vendor/` exists, `dev/test.log` points to the temp WordPress debug log, and `wp-tests-config.php` is linked in the WordPress root.


## Screenshots

## Anything the reviewer should know?

This PR is intended for local development tooling only and excludes `dev/` and `wpf` from packaged builds. The restored toolkit was adapted to use `fakerphp/faker` instead of the abandoned `fzaninotto/faker` so the dev dependencies install on PHP 8.3.
