### PR TITLE
Ensure form settings exists and is array

### DIFF
--- a/app/Modules/Component/Component.php
+++ b/app/Modules/Component/Component.php
@@ -950,7 +950,7 @@ class Component
             $checkables = ['limitNumberOfEntries', 'scheduleForm', 'requireLogin'];
 
             // Ensure settings is an array
-            if (!is_array($form->settings)) {
+            if (!isset($form->settings) || !is_array($form->settings)) {
                 $form->settings = [];
             }
 


### PR DESCRIPTION
Add an isset() check before is_array() when normalizing $form->settings so missing/null settings won't trigger notices. Defaults $form->settings to an empty array when it's undefined or not an array.