### PR TITLE
Refactor: share admin dependency evaluation

### DIFF
--- a/resources/assets/admin/components/editor-field-settings/FieldOptionsSettings.vue
+++ b/resources/assets/admin/components/editor-field-settings/FieldOptionsSettings.vue
@@ -124,6 +124,7 @@ import selectGroup from "./templates/selectGroup.vue";
 import CustomSettingsField from "./templates/CustomSettingsField.vue";
 import dynamicFilter from "./templates/dynamicFilter.vue";
 import repeaterContainers from "./templates/repeaterContainers.vue";
+import { dependencyPasses } from '../../dependency';
 
 export default {
     name: 'FieldOptionsSettings',
@@ -243,18 +244,11 @@ export default {
             return total;
         },
 
-        /**
-        * Helper function for show/hide dependent elements
-        & @return {Boolean}
-         */
-        compare(operand1, operator, operand2) {
-            switch(operator) {
-                case '==':
-                    return operand1 == operand2
-                    break;
-                case '!=':
-                    return operand1 != operand2
-                    break;
+        resolveDependencyValue(dependency) {
+            if (dependency && dependency.depends_on === 'parent_container') {
+                const isInsideRepeater = this.isInsideRepeaterContainer(this.editItem);
+
+                return isInsideRepeater ? 'repeater_container' : '';
             }
         },
 
@@ -263,29 +257,12 @@ export default {
          * @param listItem
          * @return {boolean}
          */
-        // @todo add multiple dependency support
         dependancyPass(listItem) {
-            if (listItem.dependency) {
-                let optionPaths = listItem.dependency.depends_on.split('/');
-                
-                // Special handling for parent_container check
-                if (listItem.dependency.depends_on === 'parent_container') {
-                    const isInsideRepeater = this.isInsideRepeaterContainer(this.editItem);
-                    const parentType = isInsideRepeater ? 'repeater_container' : '';
-                    
-                    return this.compare(parentType, listItem.dependency.operator, listItem.dependency.value);
-                }
-
-                let dependencyVal = optionPaths.reduce((obj, prop) => {
-                    return obj[prop]
-                }, this.editItem);
-
-                if ( this.compare(listItem.dependency.value, listItem.dependency.operator, dependencyVal) ) {
-                    return true;
-                }
-                return false;
-            }
-            return true;
+            return dependencyPasses(
+                listItem.dependencies || listItem.dependency,
+                this.editItem,
+                dependency => this.resolveDependencyValue(dependency)
+            );
         },
         willShow(key, listItem) {
             return this.elementOptions.includes(key) && this.dependancyPass(listItem) && this.conversionPass(listItem, key);

--- a/resources/assets/admin/components/editor-field-settings/templates/paymentMethodsConfig.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/paymentMethodsConfig.vue
@@ -68,6 +68,7 @@
     import inputText from './inputText.vue'
     import InputYesNoCheckBox from "./inputYesNoCheckbox";
     import InputRadio from "./inputRadio";
+    import { dependencyPasses } from '../../../dependency';
 
     export default {
         name: 'paymentMethodConfig',
@@ -127,29 +128,7 @@
                 }
             },
             dependancyPass(listItem, settings) {
-                if (listItem.dependency) {
-                    let optionPaths = listItem.dependency.depends_on.split('/');
-
-                    let dependencyVal = optionPaths.reduce((obj, prop) => {
-                        return obj[prop]
-                    }, settings);
-
-                    if ( this.compare(listItem.dependency.value, listItem.dependency.operator, dependencyVal) ) {
-                        return true;
-                    }
-                    return false;
-                }
-                return true;
-            },
-            compare(operand1, operator, operand2) {
-                switch(operator) {
-                    case '==':
-                        return operand1 == operand2
-                        break;
-                    case '!=':
-                        return operand1 != operand2
-                        break;
-                }
+                return dependencyPasses(listItem.dependency, settings);
             }
         }
     };

--- a/resources/assets/admin/dependency.js
+++ b/resources/assets/admin/dependency.js
@@ -1,0 +1,62 @@
+export const compareDependencyValue = (expectedValue, operator, actualValue) => {
+    switch (operator) {
+        case '==':
+            return expectedValue == actualValue;
+        case '!=':
+            return expectedValue != actualValue;
+        default:
+            return true;
+    }
+};
+
+export const getDependencyValue = (target, dependency, resolveSpecialValue = null) => {
+    if (!dependency || !dependency.depends_on) {
+        return undefined;
+    }
+
+    if (typeof resolveSpecialValue === 'function') {
+        const resolvedValue = resolveSpecialValue(dependency, target);
+
+        if (typeof resolvedValue !== 'undefined') {
+            return resolvedValue;
+        }
+    }
+
+    return dependency.depends_on.split('/').reduce((obj, prop) => {
+        if (typeof obj === 'undefined' || obj === null) {
+            return undefined;
+        }
+
+        return obj[prop];
+    }, target);
+};
+
+export const normalizeDependencies = rawDependencies => {
+    if (!rawDependencies) {
+        return [];
+    }
+
+    return Array.isArray(rawDependencies) ? rawDependencies : [rawDependencies];
+};
+
+export const dependencyPasses = (rawDependencies, target, resolveSpecialValue = null) => {
+    const dependencies = normalizeDependencies(rawDependencies);
+
+    if (!dependencies.length) {
+        return true;
+    }
+
+    return dependencies.every(dependency => {
+        if (!dependency || !dependency.depends_on || !dependency.operator) {
+            return true;
+        }
+
+        const dependencyValue = getDependencyValue(target, dependency, resolveSpecialValue);
+
+        return compareDependencyValue(
+            dependency.value,
+            dependency.operator,
+            dependencyValue
+        );
+    });
+};

--- a/resources/assets/admin/settings/GeneralIntegrationSettings.vue
+++ b/resources/assets/admin/settings/GeneralIntegrationSettings.vue
@@ -128,6 +128,7 @@ import Card from '@/admin/components/Card/Card.vue';
 import CardHead from '@/admin/components/Card/CardHead.vue';
 import CardBody from '@/admin/components/Card/CardBody.vue';
 import wpEditor from '@/common/_wp_editor';
+import { dependencyPasses } from '@/admin/dependency';
 
 
 export default {
@@ -218,38 +219,7 @@ export default {
                 });
         },
         dependancyPass(inputItem, settings) {
-            if (inputItem.dependency) {
-                let status = true;
-                let continueLoop = true;
-                inputItem.dependency.forEach((item) => {
-                    if (!continueLoop){
-                        return;
-                    }
-                    let optionItem = item.depends_on;
-                    let dependencyVal = settings[optionItem];
-
-                    if (!this.compare(item.value, item.operator, dependencyVal)) {
-                        status = false;
-                        continueLoop = false;
-                    } else {
-                        status = true;
-                    }
-                });
-
-                return status;
-
-            }
-            return true;
-        },
-        compare(operand1, operator, operand2) {
-            switch(operator) {
-                case '==':
-                    return operand1 == operand2
-                    break;
-                case '!=':
-                    return operand1 != operand2
-                    break;
-            }
+            return dependencyPasses(inputItem.dependency, settings);
         },
         disconnect(data) {
             this.integration = data;


### PR DESCRIPTION
## What does this PR do and why?

This refactors the admin dependency evaluator into a shared helper so the editor sidebar, payment method settings, and global integration settings all use the same logic for conditional field visibility.

It keeps the existing structure compatible while adding support for dependency arrays under the existing dependency key, so settings can now declare multiple conditions without template-specific workarounds.

Related issue: N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] JS/Vue — resources/assets/admin/dependency.js: add shared dependency evaluation helpers
- [x] JS/Vue — resources/assets/admin/components/editor-field-settings/FieldOptionsSettings.vue: use shared helper and keep parent_container handling
- [x] JS/Vue — resources/assets/admin/components/editor-field-settings/templates/paymentMethodsConfig.vue: remove duplicated dependency evaluator
- [x] JS/Vue — resources/assets/admin/settings/GeneralIntegrationSettings.vue: remove duplicated dependency evaluator

## How to test

1. Open a form with conditional editor settings, including a payment item with inventory enabled.
2. Select the field, go to Input Customization, then Advanced Options.
3. Confirm the correct inventory-dependent setting is shown and the unrelated one stays hidden.
4. Verify any setting using a single dependency still shows and hides as before.
5. Verify a setting defined with a dependency array now requires all rules to pass.

## Anything the reviewer should know?

I verified the payment item inventory path on form 382 with browser automation. In the editor, Stock Quantity stayed visible while Global Inventory remained hidden under Advanced Options.