### PR TITLE
Fix: preserve post feed draft values on resume

### DIFF
--- a/resources/assets/public/Pro/slider.js
+++ b/resources/assets/public/Pro/slider.js
@@ -104,6 +104,9 @@ class FluentFormSlider {
         let choiceJsInputs = [];
         const self = this;
 
+        this.$theForm.data('ff_restoring_draft_state', true);
+        this.$theForm.data('ff_restored_draft_state', true);
+
         $.each(response, (key, value) => {
             if (!value) return;
             let type = Object.prototype.toString.call(value);
@@ -311,6 +314,8 @@ class FluentFormSlider {
                 }
             }
         }
+
+        this.$theForm.data('ff_restoring_draft_state', false);
 
         this.isPopulatingStepData = true;
         const animDuration = this.fluentFormVars.stepAnimationDuration;


### PR DESCRIPTION
## Summary
- preserve step draft restore state while frontend data hydration runs
- let Pro post-update logic distinguish draft restoration from a real post re-selection
- prevent mapped post feed values from being overwritten on resume

## Verification
- reproduced on https://forms.test/dhrupo/ with the Post Update flow
- changed a mapped field, advanced to the next step, left the page, and resumed
- confirmed the saved draft value now restores instead of being replaced by the original post value
- confirmed the updated New Post flow still restores correctly after advancing steps
- confirmed explicit save/resume link flow also restores correctly when the save button is present

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/20628-post-feeds-step-form-per-step-save-save-continue