### PR TITLE
Fix: persist integration default field mappings

### DIFF
--- a/resources/assets/admin/components/settings/GeneralIntegration/_field_maps.vue
+++ b/resources/assets/admin/components/settings/GeneralIntegration/_field_maps.vue
@@ -148,6 +148,11 @@
             if (Array.isArray(this.merge_model) || !this.merge_model) {
                 this.$emit('merge-model');
             }
+
+            if (Array.isArray(this.settings.default_fields) || !this.settings.default_fields) {
+                this.$set(this.settings, 'default_fields', {});
+            }
+
             this.appReady = true;
         }
 


### PR DESCRIPTION
## Summary
- normalize `default_fields` to an object in the shared integration field-mapping editor
- preserve typed default field mappings on save/reload for integrations that use `default_fields`
- keep the fix scoped to the shared admin mapping component

## Verification
- reproduced on form `385` ActiveCampaign feed `9379`
- entered `{inputs.names.first_name}` and `{inputs.names.last_name}` for First Name and Last Name
- confirmed the previous save payload sent `default_fields: []`
- after the fix, confirmed the save payload sends keyed `default_fields` values
- reloaded the page and verified both values persisted in the UI
- confirmed this applies to integrations using the same `map_fields` + `default_fields` pattern, including ActiveCampaign, Aweber, Drip, IContact, Platformly, and Sendinblue

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/20919-activecampaign-field-mapping-is-not-saving
