### PR TITLE
Fix: honor submission info selection in entry export

### DIFF
--- a/app/Modules/Entries/EntryViewRenderer.php
+++ b/app/Modules/Entries/EntryViewRenderer.php
@@ -36,7 +36,7 @@ class EntryViewRenderer
         }
 
         $form = wpFluent()->table('fluentform_forms')->find($form_id);
-        $submissionShortcodes = \FluentForm\App\Services\FormBuilder\EditorShortCode::getSubmissionShortcodes();
+        $submissionShortcodes = \FluentForm\App\Services\FormBuilder\EditorShortCode::getSubmissionShortcodes($form);
         $submissionShortcodes['shortcodes']['{submission.ip}'] = __('Submitter IP', 'fluentform');
         if ($form->has_payment) {
             $submissionShortcodes['shortcodes']['{payment.payment_status}'] = __('Payment Status','fluentform');

--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -187,6 +187,8 @@ class TransferService
         $submissions = FormDataParser::parseFormEntries($submissions, $form, $formInputs);
         $parsedShortCodes = [];
         $exportData = [];
+        $selectedShortcodes = self::getSelectedExportShortcodes($args, $form);
+        $legacyShortcodeHeaders = self::getLegacyExportShortcodeHeaders();
 
         // Preload notes for all submissions in a single query to avoid N+1
         $notesMap = [];
@@ -229,38 +231,35 @@ class TransferService
                 $temp[] = Helper::sanitizeForCSV($content);
             }
     
-            if($selectedShortcodes = Arr::get($args,'shortcodes_to_export')){
-                $selectedShortcodes = fluentFormSanitizer($selectedShortcodes);
-                $parsedShortCodes = ShortCodeParser::parse(
-                    $selectedShortcodes,
-                    $submission->id,
-                    $submission->response,
-                    $form,
-                    false,
-                    true
-                );
-                if(!empty($parsedShortCodes)){
-                    foreach ($parsedShortCodes as $code){
-                        $temp[] = Arr::get($code,'value');
-                    }
+            if (!empty($selectedShortcodes)) {
+                $regularShortcodes = self::getRegularExportShortcodes($selectedShortcodes, $legacyShortcodeHeaders);
+
+                if (!empty($regularShortcodes)) {
+                    $parsedShortCodes = ShortCodeParser::parse(
+                        $regularShortcodes,
+                        $submission->id,
+                        $submission->response,
+                        $form,
+                        false,
+                        true
+                    );
                 }
+
+                $temp = array_merge(
+                    $temp,
+                    self::getSelectedShortcodeExportValues(
+                        $selectedShortcodes,
+                        $parsedShortCodes,
+                        $legacyShortcodeHeaders,
+                        $submission
+                    )
+                );
             }
             if ($withNotes) {
                 $noteValues = isset($notesMap[$submission->id]) ? $notesMap[$submission->id] : [];
                 if (!empty($noteValues)) {
                     $temp[] = implode(", ", $noteValues);
                 }
-            }
-
-            if (!$tableName) {
-                if ($form->has_payment) {
-                    $temp[] = round(($submission->payment_total ?? 0) / 100, 1);
-                    $temp[] = $submission->payment_status ?? '';
-                    $temp[] = $submission->currency ?? '';
-                }
-                $temp[] = $submission->id ?? '';
-                $temp[] = $submission->status ?? '';
-                $temp[] = $submission->created_at ?? '';
             }
 
             $temp = apply_filters('fluentform/export_entry_metadata', $temp, $submission, $form, $args);
@@ -270,26 +269,15 @@ class TransferService
 
         $extraLabels = [];
 
-        if(!empty($parsedShortCodes)){
-            foreach ($parsedShortCodes as $code){
-                $extraLabels[] = Arr::get($code,'label');
-            }
-        }
+        $extraLabels = self::getSelectedShortcodeExportLabels(
+            $selectedShortcodes,
+            $parsedShortCodes,
+            $legacyShortcodeHeaders
+        );
         
         $inputLabels = array_merge($inputLabels, $extraLabels);
         if($withNotes){
             $inputLabels[] = __('Notes','fluentform');
-        }
-
-        if (!$tableName) {
-            if ($form->has_payment) {
-                $inputLabels[] = 'payment_total';
-                $inputLabels[] = 'payment_status';
-                $inputLabels[] = 'currency';
-            }
-            $inputLabels[] = 'entry_id';
-            $inputLabels[] = 'entry_status';
-            $inputLabels[] = 'created_at';
         }
         $inputLabels = apply_filters('fluentform/export_entry_metadata_labels', $inputLabels, $form, $args);
 
@@ -309,6 +297,145 @@ class TransferService
                 )
             )
         );
+    }
+
+    private static function getSelectedExportShortcodes($args, $form)
+    {
+        $selectedShortcodes = fluentFormSanitizer(Arr::get($args, 'shortcodes_to_export', []));
+
+        if (!Arr::has($args, 'shortcodes_to_export_defined') && empty($selectedShortcodes)) {
+            return self::getDefaultExportShortcodes($form);
+        }
+
+        return $selectedShortcodes;
+    }
+
+    private static function getDefaultExportShortcodes($form)
+    {
+        $defaults = [
+            [
+                'label' => __('Submission ID', 'fluentform'),
+                'value' => '{submission.id}',
+            ],
+            [
+                'label' => __('Submission Create Date', 'fluentform'),
+                'value' => '{submission.created_at}',
+            ],
+            [
+                'label' => __('Submission Status', 'fluentform'),
+                'value' => '{submission.status}',
+            ],
+        ];
+
+        if ($form->has_payment) {
+            $defaults[] = [
+                'label' => __('Payment Status', 'fluentform'),
+                'value' => '{payment.payment_status}',
+            ];
+            $defaults[] = [
+                'label' => __('Payment Total', 'fluentform'),
+                'value' => '{payment.payment_total}',
+            ];
+            $defaults[] = [
+                'label' => __('Currency', 'fluentform'),
+                'value' => '{submission.currency}',
+            ];
+        }
+
+        return $defaults;
+    }
+
+    private static function getLegacyExportShortcodeHeaders()
+    {
+        return [
+            '{submission.id}'             => 'entry_id',
+            '{submission.status}'         => 'entry_status',
+            '{submission.created_at}'     => 'created_at',
+            '{payment.payment_status}'    => 'payment_status',
+            '{submission.payment_status}' => 'payment_status',
+            '{payment.payment_total}'     => 'payment_total',
+            '{submission.payment_total}'  => 'payment_total',
+            '{submission.currency}'       => 'currency',
+        ];
+    }
+
+    private static function getRegularExportShortcodes($selectedShortcodes, $legacyShortcodeHeaders)
+    {
+        $regularShortcodes = [];
+
+        foreach ($selectedShortcodes as $index => $shortcode) {
+            if (!isset($legacyShortcodeHeaders[Arr::get($shortcode, 'value')])) {
+                $regularShortcodes[$index] = $shortcode;
+            }
+        }
+
+        return $regularShortcodes;
+    }
+
+    private static function getSelectedShortcodeExportValues($selectedShortcodes, $parsedShortCodes, $legacyShortcodeHeaders, $submission)
+    {
+        $values = [];
+
+        foreach ($selectedShortcodes as $index => $shortcode) {
+            $shortcodeValue = Arr::get($shortcode, 'value');
+
+            if (!isset($legacyShortcodeHeaders[$shortcodeValue])) {
+                $values[] = Arr::get($parsedShortCodes, $index . '.value');
+                continue;
+            }
+
+            $values[] = self::getLegacyExportValue($legacyShortcodeHeaders[$shortcodeValue], $submission);
+        }
+
+        return $values;
+    }
+
+    private static function getSelectedShortcodeExportLabels($selectedShortcodes, $parsedShortCodes, $legacyShortcodeHeaders)
+    {
+        $labels = [];
+
+        foreach ($selectedShortcodes as $index => $shortcode) {
+            $shortcodeValue = Arr::get($shortcode, 'value');
+
+            if (isset($legacyShortcodeHeaders[$shortcodeValue])) {
+                $labels[] = $legacyShortcodeHeaders[$shortcodeValue];
+                continue;
+            }
+
+            $labels[] = Arr::get($parsedShortCodes, $index . '.label');
+        }
+
+        return $labels;
+    }
+
+    private static function getLegacyExportValue($header, $submission)
+    {
+        $legacyValueResolvers = [
+            'entry_id' => function ($submission) {
+                return $submission->id ?? '';
+            },
+            'entry_status' => function ($submission) {
+                return $submission->status ?? '';
+            },
+            'created_at' => function ($submission) {
+                return $submission->created_at ?? '';
+            },
+            'payment_status' => function ($submission) {
+                return $submission->payment_status ?? '';
+            },
+            'payment_total' => function ($submission) {
+                return round(($submission->payment_total ?? 0) / 100, 1);
+            },
+            'currency' => function ($submission) {
+                return $submission->currency ?? '';
+            },
+        ];
+
+        if (!isset($legacyValueResolvers[$header])) {
+            return '';
+        }
+
+        return $legacyValueResolvers[$header]($submission);
     }
 
     private static function exportAsJSON($form, $args)

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -1133,6 +1133,7 @@
                     payment_statuses: this.selectedPaymentStatuses,
                     fields_to_export: JSON.stringify(this.fieldsToExport),
                     shortcodes_to_export: selectedShortcodes,
+                    shortcodes_to_export_defined: 'yes',
 	                fluent_forms_admin_nonce: window.fluent_forms_global_var.fluent_forms_admin_nonce
                 };
                 if (this.exportWithNotes){
@@ -1223,6 +1224,23 @@
             showImport() {
                 this.showImportEntriesModal = !this.showImportEntriesModal;
             },
+            getDefaultShortcodesToExport() {
+                const defaults = ['{submission.id}', '{submission.created_at}', '{submission.status}'];
+
+                if (this.editor_shortcodes['{payment.payment_status}']) {
+                    defaults.push('{payment.payment_status}');
+                }
+
+                if (this.editor_shortcodes['{payment.payment_total}']) {
+                    defaults.push('{payment.payment_total}');
+                }
+
+                if (this.editor_shortcodes['{submission.currency}']) {
+                    defaults.push('{submission.currency}');
+                }
+
+                return defaults;
+            },
             /**
              * Load last used export fields from localStorage
              */
@@ -1233,7 +1251,7 @@
                     try {
                         const lastFields = JSON.parse(saved);
                         this.fieldsToExport = lastFields.fieldsToExport || Object.keys(this.input_labels);
-                        this.shortcodesToExport = lastFields.shortcodesToExport || ['{submission.id}','{submission.created_at}','{submission.status}'];
+                        this.shortcodesToExport = lastFields.shortcodesToExport || this.getDefaultShortcodesToExport();
                         this.exportWithNotes = lastFields.exportWithNotes || false;
 
                         this.updateCheckAllState();
@@ -1273,7 +1291,7 @@
 	        });
             this.isCompact = ( localStorage.getItem('compactView') == 'true' || localStorage.getItem("compactView") === null) ? true : false;
             this.fieldsToExport = Object.keys(this.input_labels)
-            this.shortcodesToExport = ['{submission.id}','{submission.created_at}','{submission.status}']
+            this.shortcodesToExport = this.getDefaultShortcodesToExport()
             this.loadLastExportFields();
         },
         beforeCreate() {
@@ -1286,4 +1304,3 @@
 	    }
     };
 </script>
-


### PR DESCRIPTION
## Summary
This fixes the entries export flow so `Submission Info` fields are selected by default for backward compatibility, but are removed from the exported file when the user explicitly unchecks them.

It also keeps older export callers working by synthesizing the legacy metadata selection server-side when `shortcodes_to_export` is not provided.

## Changes
- route the entries page submission-info list through the current form so payment metadata is available only where relevant
- keep legacy `{payment.*}` aliases available for saved export selections
- default the export modal to include the historical metadata columns
- remove those metadata columns from the CSV/XLSX/ODS output when the user unchecks them
- preserve the old export contract for legacy callers that do not send shortcode selections

## Verification
Tested against form `386`.

Confirmed these cases:
- legacy export caller without `shortcodes_to_export` still exports:
  - `entry_id`
  - `created_at`
  - `entry_status`
  - `payment_status`
  - `payment_total`
  - `currency`
- entries UI with all `Submission Info` unchecked exports only the selected form input columns
- entries UI with default `Submission Info` selected exports the legacy metadata columns again

## Related Issue
https://lounge.authlab.io/projects#/boards/16/tasks/20796-payment-forms-export-issue
