### PR TITLE
Fix: harden notification attachment paths

### DIFF
--- a/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
+++ b/app/Services/FormBuilder/Notifications/EmailNotificationActions.php
@@ -130,13 +130,9 @@ class EmailNotificationActions
                 $fileUrls = ArrayHelper::get($formData, $name);
                 if ($fileUrls && is_array($fileUrls)) {
                     foreach ($fileUrls as $url) {
-                        if (strpos($url, $uploadDir['baseurl']) === 0) {
-                            $relativePath = str_replace($uploadDir['baseurl'], '', $url);
-                            $filePath = wp_normalize_path($uploadDir['basedir'] . $relativePath);
-
-                            if (file_exists($filePath)) {
-                                $attachments[] = $filePath;
-                            }
+                        $filePath = $this->resolveUploadAttachmentPath($url, $uploadDir);
+                        if ($filePath) {
+                            $attachments[] = $filePath;
                         }
                     }
                 }
@@ -148,13 +144,9 @@ class EmailNotificationActions
             $attachments = [];
             foreach ($mediaAttachments as $file) {
                 $fileUrl = ArrayHelper::get($file, 'url');
-                if ($fileUrl && strpos($fileUrl, $uploadDir['baseurl']) === 0) {
-                    $relativePath = str_replace($uploadDir['baseurl'], '', $fileUrl);
-                    $filePath = wp_normalize_path($uploadDir['basedir'] . $relativePath);
-
-                    if (file_exists($filePath)) {
-                        $attachments[] = $filePath;
-                    }
+                $filePath = $this->resolveUploadAttachmentPath($fileUrl, $uploadDir);
+                if ($filePath) {
+                    $attachments[] = $filePath;
                 }
             }
             $emailAttachments = array_merge($emailAttachments, $attachments);
@@ -183,6 +175,44 @@ class EmailNotificationActions
             $form
         );
         return $emailAttachments;
+    }
+
+    private function resolveUploadAttachmentPath($fileUrl, $uploadDir)
+    {
+        if (!$fileUrl || empty($uploadDir['baseurl']) || empty($uploadDir['basedir'])) {
+            return null;
+        }
+
+        $normalizedUrl = strtok($fileUrl, '?#');
+        if (strpos($normalizedUrl, $uploadDir['baseurl']) !== 0) {
+            return null;
+        }
+
+        $relativePath = rawurldecode(str_replace($uploadDir['baseurl'], '', $normalizedUrl));
+        $relativePath = ltrim(wp_normalize_path($relativePath), '/');
+
+        if (!$relativePath || strpos($relativePath, '../') !== false) {
+            return null;
+        }
+
+        $uploadsBaseDir = realpath($uploadDir['basedir']);
+        if (!$uploadsBaseDir) {
+            return null;
+        }
+
+        $uploadsBaseDir = trailingslashit(wp_normalize_path($uploadsBaseDir));
+        $resolvedPath = realpath($uploadsBaseDir . $relativePath);
+
+        if (!$resolvedPath) {
+            return null;
+        }
+
+        $resolvedPath = wp_normalize_path($resolvedPath);
+        if (strpos($resolvedPath, $uploadsBaseDir) !== 0 || !is_file($resolvedPath)) {
+            return null;
+        }
+
+        return $resolvedPath;
     }
 
     public function getFormData($submissionId)


### PR DESCRIPTION
## What does this PR do and why?

This hardens notification email attachment resolution for uploaded files and media attachments. The previous logic accepted any upload-base-URL-prefixed path and converted it directly into a filesystem path, which allowed traversal-style URLs to escape the uploads directory if the target file existed.

Related Issue: https://gist.github.com/techjewel/438f9a27f51b1ca64a602516470beba7

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP - app/Services/FormBuilder/Notifications/EmailNotificationActions.php: route both file-upload attachments and media attachments through a shared uploads-directory containment check
- [x] PHP - app/Services/FormBuilder/Notifications/EmailNotificationActions.php: strip query and fragment suffixes, decode URL paths, reject traversal segments, and require the resolved file to remain inside the real uploads root

## How to test

1. Configure a notification that attaches uploaded files or media attachments.
2. Submit a form with a normal uploaded file and confirm the notification still includes the attachment.
3. Verify upload URLs with encoded filenames and cache-busting query strings still resolve.
4. Verify a traversal-style uploads URL such as /uploads/.../../../wp-config.php is rejected and not attached.

## Anything the reviewer should know?

- I manually verified the attachment resolver in the live WordPress context for both attachment sources.
- The stricter path handling still resolves valid upload URLs with encoded characters, query strings, and fragments.