### PR TITLE
Fix: preserve multilingual AI form field hints

### DIFF
--- a/app/Modules/Ai/AiFormBuilder.php
+++ b/app/Modules/Ai/AiFormBuilder.php
@@ -106,6 +106,7 @@ class AiFormBuilder extends FormService
             'user_prompt'    => $this->getUserPrompt($args),
             'site_url'       => site_url(),
             'site_title'     => get_bloginfo('name'),
+            'site_locale'    => determine_locale(),
             'has_pro'        => Helper::hasPro(),
             'has_payment'    => $paymentSetting['status'] == 'yes',
             'request_id'     => uniqid('ff_ai_')
@@ -126,7 +127,7 @@ class AiFormBuilder extends FormService
         if (json_last_error() !== JSON_ERROR_NONE || empty($decoded) || empty($decoded['fields'])) {
             throw new Exception(esc_html__('Invalid response: Please try again!', 'fluentform'));
         }
-        return $decoded;
+        return $this->applyPromptHints($decoded, $args);
     }
     
     protected function getDefaultFields()
@@ -453,7 +454,299 @@ class AiFormBuilder extends FormService
         if ($additionalQuery) {
             $query .= "\n including questions for information like  " . $additionalQuery . ".";
         }
-        return $startingQuery . $query;
+        return $startingQuery . $query . $this->getPromptContractInstructions();
     }
-    
+
+    private function getPromptContractInstructions()
+    {
+        return "\n\nReturn strict JSON only. The user's instructions may be written in any language. "
+            . "Preserve labels and help text in the user's original language, but always return machine-readable field settings. "
+            . "For every field, explicitly set whether it is required in settings.validation_rules.required.value when the prompt marks it as required or optional. "
+            . "If the prompt lists allowed upload extensions, map them into settings.validation_rules.allowed_file_types.value. "
+            . "If the prompt asks for a multi-step form with sections, include form_step elements between sections.";
+    }
+
+    private function applyPromptHints(array $form, array $args)
+    {
+        $query = (string) Arr::get($args, 'query', '');
+        $additionalQuery = (string) Arr::get($args, 'additional_query', '');
+        $hints = $this->extractPromptFieldHints(trim($query . "\n" . $additionalQuery));
+
+        if (!$hints) {
+            return $form;
+        }
+
+        $hintIndex = 0;
+        $form['fields'] = $this->applyHintsToFields(Arr::get($form, 'fields', []), $hints, $hintIndex);
+
+        return $form;
+    }
+
+    private function applyHintsToFields(array $fields, array $hints, &$hintIndex)
+    {
+        foreach ($fields as &$field) {
+            if (!is_array($field)) {
+                continue;
+            }
+
+            if (count($field) === 1) {
+                $field = reset($field);
+            }
+
+            $element = Arr::get($field, 'element');
+
+            if ('container' === $element) {
+                $columns = Arr::get($field, 'columns', []);
+                foreach ($columns as &$column) {
+                    $column['fields'] = $this->applyHintsToFields(Arr::get($column, 'fields', []), $hints, $hintIndex);
+                }
+                $field['columns'] = $columns;
+                continue;
+            }
+
+            if (in_array($element, ['form_step', 'section_break'])) {
+                continue;
+            }
+
+            $hint = Arr::get($hints, $hintIndex);
+            $hintIndex++;
+
+            if (!$hint) {
+                continue;
+            }
+
+            $field = $this->mergeFieldHint($field, $hint);
+        }
+
+        return $fields;
+    }
+
+    private function mergeFieldHint(array $field, array $hint)
+    {
+        if (array_key_exists('required', $hint)) {
+            Arr::set($field, 'settings.validation_rules.required.value', (bool) $hint['required']);
+        }
+
+        if (!empty($hint['help_message'])) {
+            Arr::set($field, 'settings.help_message', $hint['help_message']);
+        }
+
+        if (!empty($hint['allowed_file_types']) && in_array(Arr::get($field, 'element'), ['input_file', 'input_image'])) {
+            Arr::set($field, 'settings.validation_rules.allowed_file_types.value', array_values(array_unique($hint['allowed_file_types'])));
+        }
+
+        return $field;
+    }
+
+    private function extractPromptFieldHints($prompt)
+    {
+        if (!$prompt) {
+            return [];
+        }
+
+        $lines = preg_split('/\R/u', $prompt);
+        $hints = [];
+
+        foreach ($lines as $line) {
+            $line = trim(wp_strip_all_tags($line));
+            $line = preg_replace('/^[\-\*\d\.\)\s]+/u', '', $line);
+
+            if (!$line || !$this->looksLikeFieldLine($line)) {
+                continue;
+            }
+
+            $attributesText = '';
+            if (preg_match('/\(([^()]*)\)/u', $line, $matches)) {
+                $attributesText = trim($matches[1]);
+            }
+
+            $hint = [];
+            $normalizedLine = function_exists('mb_strtolower') ? mb_strtolower($line, 'UTF-8') : strtolower($line);
+
+            if ($this->containsAnyPhrase($normalizedLine, $this->getRequiredKeywords())) {
+                $hint['required'] = true;
+            } elseif ($this->containsAnyPhrase($normalizedLine, $this->getOptionalKeywords())) {
+                $hint['required'] = false;
+            }
+
+            $helpMessage = $this->extractHelpMessage($attributesText);
+            if ($helpMessage) {
+                $hint['help_message'] = $helpMessage;
+            }
+
+            if ($this->containsAnyPhrase($normalizedLine, $this->getFileUploadKeywords())) {
+                $allowedTypes = $this->extractAllowedFileTypes($line);
+                if ($allowedTypes) {
+                    $hint['allowed_file_types'] = $allowedTypes;
+                }
+            }
+
+            $hints[] = $hint;
+        }
+
+        return $hints;
+    }
+
+    private function looksLikeFieldLine($line)
+    {
+        if (preg_match('/^(create|erstelle|crée|crear|criar|crea|maak|utw[oó]rz|oluştur|创建|作成)\b/ui', $line)) {
+            return false;
+        }
+
+        if (preg_match('/^(section|abschnitt|secci[oó]n|sectione|seção|sectie|sekcja|b[oö]l[uü]m|章节|セクション)\b/ui', $line)) {
+            return false;
+        }
+
+        if (false === strpos($line, '(')) {
+            return false;
+        }
+
+        preg_match('/\(([^()]*)\)/u', $line, $matches);
+        $attributesText = isset($matches[1]) ? $matches[1] : '';
+
+        return $this->containsAnyPhrase(
+            function_exists('mb_strtolower') ? mb_strtolower($attributesText, 'UTF-8') : strtolower($attributesText),
+            $this->getFieldDescriptorKeywords()
+        );
+    }
+
+    private function extractHelpMessage($attributesText)
+    {
+        if (!$attributesText) {
+            return '';
+        }
+
+        if (preg_match('/(?:note|hint|hinweis|remarque|nota|nota bene|opmerking|uwaga|not|说明|備考)\s*:\s*["“]?(.+?)["”]?$/ui', $attributesText, $matches)) {
+            return trim($matches[1], " \t\n\r\0\x0B\"'“”");
+        }
+
+        return '';
+    }
+
+    private function extractAllowedFileTypes($line)
+    {
+        preg_match_all('/\b(jpe?g|gif|png|tiff?|bmp|webp|svg|pdf|docx?|xlsx?|xls|csv|zip|rar|txt)\b/ui', $line, $matches);
+
+        if (empty($matches[1])) {
+            return [];
+        }
+
+        $types = array_map(function ($type) {
+            $type = strtolower($type);
+
+            if ('jpeg' === $type) {
+                return 'jpg';
+            }
+
+            if ('tif' === $type) {
+                return 'tiff';
+            }
+
+            return $type;
+        }, $matches[1]);
+
+        return array_values(array_unique($types));
+    }
+
+    private function containsAnyPhrase($text, array $phrases)
+    {
+        foreach ($phrases as $phrase) {
+            if (false !== strpos($text, $phrase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getRequiredKeywords()
+    {
+        return [
+            'required',
+            'mandatory',
+            'pflichtfeld',
+            'erforderlich',
+            'obligatoire',
+            'requis',
+            'obligatorio',
+            'obrigatório',
+            'obbligatorio',
+            'verplicht',
+            'wymagane',
+            'zorunlu',
+            '必填',
+            '必須'
+        ];
+    }
+
+    private function getOptionalKeywords()
+    {
+        return [
+            'optional',
+            'facultatif',
+            'facoltativo',
+            'opcjonalne',
+            'isteğe bağlı',
+            'opcional',
+            'opcionales',
+            '选填',
+            '任意'
+        ];
+    }
+
+    private function getFileUploadKeywords()
+    {
+        return [
+            'file upload',
+            'upload',
+            'datei',
+            'datei upload',
+            'foto upload',
+            'image upload',
+            'upload de fichier',
+            'carga de archivo',
+            'subida de archivo',
+            'carregamento de arquivo',
+            'caricamento file',
+            'bestandsupload',
+            'yükleme',
+            '上传'
+        ];
+    }
+
+    private function getFieldDescriptorKeywords()
+    {
+        return [
+            'text',
+            'textarea',
+            'email',
+            'date',
+            'file',
+            'upload',
+            'phone',
+            'number',
+            'radio',
+            'checkbox',
+            'select',
+            'dropdown',
+            'image',
+            'foto',
+            'bild',
+            'datei',
+            'telefon',
+            'mobil',
+            'correo',
+            'texte',
+            'texto',
+            'testo',
+            'fecha',
+            'fichier',
+            'archivo',
+            'caricamento',
+            'ficheiro',
+            'bestand',
+            'yükleme',
+            '上传'
+        ];
+    }
 }


### PR DESCRIPTION
## What does this PR do and why?

Improves the AI form builder so prompts written in non-English languages are less dependent on the remote model returning perfectly normalized Fluent Forms JSON. Previously, the local builder mostly passed raw prompt text through to the AI endpoint and trusted the response structure. That made prompts like German "Pflichtfeld" or localized upload constraints easy to lose, even when the intent was clear.

This change strengthens the AI prompt contract and adds a local normalization layer that restores explicit field semantics from the original prompt text before the form is saved.

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/20967-AI-Form-Builder%3A-Missing-%E2%80%9CRequ

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- Pass site locale with the AI builder request
- Extend the prompt contract to require machine-readable required and upload settings
- Add multilingual prompt hint extraction for required and optional markers
- Add multilingual hint extraction for note and help-message text
- Add upload extension extraction for file fields
- Apply prompt-derived hints back onto generated field settings before save

## How to test

1. Open the AI form builder
2. Generate a form with a non-English prompt such as the provided German multi-step example
3. Verify required fields are marked correctly
4. Verify localized note or hint text is added to the intended field help message
5. Verify file upload fields preserve allowed extensions when listed in the prompt
6. Repeat with an English prompt and confirm existing behavior is unchanged

## Anything the reviewer should know?

This is a local fallback and normalization layer. It does not replace the remote AI response, but it reduces the chance of losing clear prompt semantics across common top-language variants.