### PR TITLE
Fix non-REST cookie and query reads after framework upgrade

### DIFF
--- a/app/Services/FormBuilder/EditorShortcodeParser.php
+++ b/app/Services/FormBuilder/EditorShortcodeParser.php
@@ -111,7 +111,7 @@ class EditorShortcodeParser
             if (false !== strpos($handler, 'cookie.')) {
                 $scookieProperty = substr($handler, strlen('cookie.'));
                 
-                return wpFluentForm('request')->cookie($scookieProperty);
+                return array_key_exists($scookieProperty, $_COOKIE) ? wp_unslash($_COOKIE[$scookieProperty]) : '';
             }
             
             if (false !== strpos($handler, 'dynamic.')) {

--- a/app/Services/FormBuilder/ShortCodeParser.php
+++ b/app/Services/FormBuilder/ShortCodeParser.php
@@ -142,7 +142,7 @@ class ShortCodeParser
                 $value = static::getSubmissionData($submissionProperty);
             } elseif (false !== strpos($matches[1], 'cookie.')) {
                 $scookieProperty = substr($matches[1], strlen('cookie.'));
-                $value = wpFluentForm('request')->cookie($scookieProperty);
+                $value = array_key_exists($scookieProperty, $_COOKIE) ? wp_unslash($_COOKIE[$scookieProperty]) : '';
             } elseif (false !== strpos($matches[1], 'payment.')) {
                 $property = substr($matches[1], strlen('payment.'));
                 $deprecatedValue = apply_filters_deprecated(

--- a/app/Services/WPAsync/FluentFormAsyncRequest.php
+++ b/app/Services/WPAsync/FluentFormAsyncRequest.php
@@ -66,7 +66,7 @@ class FluentFormAsyncRequest
             'timeout' => 0.1,
             'blocking' => false,
             'body' => $data,
-            'cookies' => wpFluentForm('request')->cookie(),
+            'cookies' => $_COOKIE,
             'sslverify' => apply_filters('fluentform/https_local_ssl_verify', $sslVerify),
         );
 


### PR DESCRIPTION
## What does this PR do and why?

Restores raw cookie values for non-REST cookie smartcodes and async cookie forwarding, and switches clearly URL-driven non-REST reads to the query bag instead of merged request input.

Why: the framework request changes now treat string cookies as base64(JSON), which breaks normal cookies like `utm_source=google`, and the same upgrade makes source-specific reads more important for query-string driven page flows.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Set plain-text cookies such as `utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`, or `mcp_token`, submit a form that maps `{cookie.*}` values into Google Sheets, and confirm the saved values are no longer empty.
2. Trigger any async feed flow that depends on forwarded browser cookies and confirm the background request still receives the original cookie values.
3. Open Fluent Forms admin pages using URL parameters like `page`, `route`, `form_id`, and `sub_page`, and confirm navigation still lands on the correct screens.
4. Open a form preview with `preview_id` in the query string and confirm the preview still renders the target form.
5. Open a conversational form URL and confirm the query-string slug still resolves the form.
6. Use a `{get.some_param}` editor smartcode with a matching query parameter and confirm it resolves from the URL value.

## Screenshots

Not applicable.

## Anything the reviewer should know?

This intentionally leaves mixed-source reads in controllers and `admin-ajax` handlers alone. The cleanup is limited to non-REST cookie access and clearly query-string driven page-render paths.
