### PR TITLE
Fix: harden predefined form creation edge cases

### DIFF
--- a/app/Models/FormMeta.php
+++ b/app/Models/FormMeta.php
@@ -42,7 +42,7 @@ class FormMeta extends Model
     
         $formMeta[] = [
             'meta_key' => 'template_name',
-            'value'    => Arr::get($attributes, 'predefined'),
+            'value'    => Arr::get($attributes, 'predefined', Arr::get($attributes, 'type', '')),
         ];
     
         if (isset($predefinedForm['notifications'])) {
@@ -84,7 +84,13 @@ class FormMeta extends Model
     public static function store(Form $form, $formMeta)
     {
         foreach ($formMeta as $meta) {
-            $meta['value'] = trim(preg_replace('/\s+/', ' ', $meta['value']));
+            $metaValue = $meta['value'];
+
+            if (is_array($metaValue) || is_object($metaValue)) {
+                $metaValue = wp_json_encode($metaValue);
+            }
+
+            $meta['value'] = trim(preg_replace('/\s+/', ' ', (string) $metaValue));
 
             $form->formMeta()->create([
                 'meta_key' => $meta['meta_key'],

--- a/app/Models/Traits/PredefinedForms.php
+++ b/app/Models/Traits/PredefinedForms.php
@@ -18,7 +18,19 @@ trait PredefinedForms
             );
         }
 
-        $predefinedForm = json_decode($predefinedForm['json'], true)[0];
+        $predefinedJson = Arr::get($predefinedForm, 'json');
+
+        if ($predefinedJson) {
+            $decodedForm = json_decode($predefinedJson, true);
+            $predefinedForm = isset($decodedForm[0]) ? $decodedForm[0] : [];
+        }
+
+        if (!$predefinedForm || !is_array($predefinedForm)) {
+            throw new Exception(
+                // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message, not output
+                __("The selected template is invalid.", 'fluentform')
+            );
+        }
 
         if (isset($predefinedForm['form_fields'])) {
             $predefinedForm['form_fields'] = json_encode($predefinedForm['form_fields']);

--- a/app/Services/Settings/Validator/Confirmations.php
+++ b/app/Services/Settings/Validator/Confirmations.php
@@ -38,7 +38,7 @@ class Confirmations extends Validate
     public static function conditionalValidations(Validator $validator)
     {
         $validator->sometimes('customUrl', 'required', function ($input) {
-            return 'customUrl' === $input['redirectTo'];
+            return isset($input['redirectTo']) && 'customUrl' === $input['redirectTo'];
         });
 
         return $validator;


### PR DESCRIPTION
## What does this PR do and why?

This PR pulls a small set of defensive fixes out of the broader request-compat work so they can be reviewed and merged independently. It hardens predefined form creation and confirmation validation against malformed template payloads, missing template identifiers, and missing redirect keys that can otherwise cause brittle form-creation behavior or PHP notices.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Create a blank conversational form and confirm form creation succeeds without template warnings.
2. Create a normal predefined blank form and confirm the template name is stored even when only the form type is available.
3. Save confirmation settings with and without redirectTo present and confirm validation no longer throws undefined index notices.
4. Try creating a form from an invalid or malformed predefined template payload and confirm the code now fails with a clear invalid-template exception instead of using a broken decoded value.

## Anything the reviewer should know?

- This intentionally excludes the cookie smartcode and request-compat changes from PR #882.
- The scope here is limited to form-template decoding, form-meta persistence, and confirmation validation guards.
Co-authored-by:  @dhrupo 
