### PR TITLE
Fix predefined form validation fallback for legacy options

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -1027,10 +1027,19 @@ class Helper
                 if (ArrayHelper::isTrue($rawField, 'attributes.multiple')) {
                     $fieldType = 'multi_select';
                 }
-                $options = array_column(
-                    ArrayHelper::get($rawField, 'settings.advanced_options', []),
-                    'value'
-                );
+                $formattedOptions = ArrayHelper::get($rawField, 'settings.advanced_options', []);
+                if (!$formattedOptions) {
+                    $formattedOptions = [];
+                    foreach (ArrayHelper::get($rawField, 'options', []) as $value => $label) {
+                        $formattedOptions[] = [
+                            'label' => $label,
+                            'value' => $value,
+                        ];
+                    }
+                    // @todo : Update all reference in form templates
+                }
+
+                $options = array_column($formattedOptions, 'value');
                 
                 // Add field-specific __ff_other__ to options if "Other" option is enabled
                 if (in_array($fieldType, ['input_checkbox', 'input_radio']) &&


### PR DESCRIPTION
## What does this PR do and why?

Predefined forms can render radio, select, and checkbox choices from legacy `options` data, but submission validation only accepts `settings.advanced_options`. This updates validation to fall back to legacy options so older predefined templates submit correctly instead of failing with "The given data was invalid".

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Create a predefined form that still stores choice fields with legacy `options`, such as Support Form or Polling Form.
2. Submit a radio, select, or checkbox field from the frontend without resaving the form in the builder.
3. Confirm the submission succeeds instead of returning "The given data was invalid".

## Anything the reviewer should know?

This is a compatibility fallback in validation only. It does not rewrite stored form data or touch the unrelated local changes present in this worktree.
