### PR TITLE
Add AI Settings link to form list row actions

### DIFF
--- a/app/Api/Form.php
+++ b/app/Api/Form.php
@@ -140,6 +140,7 @@ class Form
             $form->settings_url = Helper::getFormSettingsUrl($form);
             $form->entries_url = Helper::getFormAdminPermalink('entries', $form);
             $form->analytics_url = Helper::getFormAdminPermalink('analytics', $form);
+            $form->ai_chat_settings_url = Helper::getFormAdminPermalink('ai-chat-settings', $form);
 
             // Use pre-fetched counts instead of individual queries
             $form->total_views = $viewsMap[$form->id] ?? 0;

--- a/resources/assets/admin/views/AllForms.vue
+++ b/resources/assets/admin/views/AllForms.vue
@@ -122,6 +122,9 @@
                                         <span v-if="hasPermission('fluentform_entries_viewer')" class="row-actions-item ff_entries">
                                                 <a :href="scope.row.entries_url"> {{ $t('Entries') }}</a>
                                         </span>
+                                        <span v-if="hasPro() && hasPermission('fluentform_forms_manager')" class="row-actions-item">
+                                                <a :href="scope.row.ai_chat_settings_url"> {{ $t('AI Settings') }}</a>
+                                        </span>
                                         <span v-if="scope.row.conversion_preview" class="row-actions-item ff_entries">
                                                 <a target="_blank" :href="scope.row.conversion_preview"> {{ $t('Conversational Preview') }}</a>
                                         </span>


### PR DESCRIPTION
Adds ai_chat_settings_url to Form API and displays an "AI Settings" link after Entries in the forms list for Pro users.