### PR TITLE
Fix: defer multisite site setup until initialization

### DIFF
--- a/boot/app.php
+++ b/boot/app.php
@@ -37,13 +37,25 @@ return function ($file) {
         ($app->make(ActivationHandler::class))->handle($network_wide);
     });
 
-    add_action('wp_insert_site', function ($blog) use ($app) {
-        if (is_plugin_active_for_network('fluentform/fluentform.php')) {
-            switch_to_blog($blog->blog_id);
-            ($app->make(ActivationHandler::class))->handle(false);
-            restore_current_blog();
+    $initializeNewSite = function ($blogId) use ($app) {
+        if (!is_plugin_active_for_network('fluentform/fluentform.php')) {
+            return;
         }
-    });
+
+        switch_to_blog($blogId);
+        ($app->make(ActivationHandler::class))->handle(false);
+        restore_current_blog();
+    };
+
+    if (function_exists('wp_initialize_site')) {
+        add_action('wp_initialize_site', function ($newSite) use ($initializeNewSite) {
+            $initializeNewSite($newSite->id);
+        }, 20, 1);
+    } else {
+        add_action('wpmu_new_blog', function ($blogId) use ($initializeNewSite) {
+            $initializeNewSite($blogId);
+        }, 10, 1);
+    }
 
     register_deactivation_hook($file, function () use ($app) {
         ($app->make(DeactivationHandler::class))->handle();


### PR DESCRIPTION
## What does this PR do and why?

This defers Fluent Forms new-site setup for multisite installs until WordPress site initialization is ready.

Previously, Fluent Forms hooked into wp_insert_site for network-activated installs and immediately ran activation/migration logic on the new subsite. That was too early in the multisite site creation flow, so option writes and migration flags could run before the new subsite options table existed.

This produced errors like the following during subsite creation:

WordPress database error Table 'forms1.wp_5_options' doesn't exist

The failing call path was:

wpmu_create_blog -> wp_insert_site -> FluentForm ActivationHandler->handle()

This change moves that setup work off wp_insert_site and defers it to wp_initialize_site, with wpmu_new_blog as the fallback for older WordPress versions.

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/20994-Fluent-Forms-Multi-Site-Error

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — boot/app.php: replace the early wp_insert_site hook with deferred site initialization logic
- [x] PHP — boot/app.php: use wp_initialize_site on supported WordPress versions and wpmu_new_blog as the fallback
- [x] PHP — boot/app.php: keep the network-active guard and run the same ActivationHandler flow only after site initialization timing is safe

## How to test

1. Convert a local WordPress install to multisite.
2. Network-activate Fluent Forms.
3. Create a new subsite from Network Admin.
4. Confirm the site is created successfully.
5. Confirm the PHP/debug log no longer records errors like "Table 'wp_X_options' doesn't exist" during Fluent Forms migration.

## Verification notes

I reproduced the issue locally on a multisite test install where the plugin still used wp_insert_site. The debug log showed repeated writes to wp_3_options/wp_5_options before those tables existed, including:

- fluentform_entry_details_migrated
- fluentform_db_fluentform_logs_added
- fluentform_scheduled_actions_migrated
- _fluentform_global_form_settings
- _fluentform_installed_version
- fluentform_global_modules_status

After applying the deferred hook change to the installed plugin copy, creating another subsite no longer produced those missing options table errors.

## Anything the reviewer should know?

This change is intentionally minimal. It does not change the activation/migration logic itself; it only moves the trigger point to the correct stage of the WordPress multisite lifecycle.