### PR TITLE
FIX: stabilize long entry content previews

### DIFF
--- a/resources/assets/admin/styles/entries.scss
+++ b/resources/assets/admin/styles/entries.scss
@@ -635,6 +635,81 @@ tr.el-table__row td {
   padding: 18px 0px;
 }
 
+.ff_entry_table_cell {
+  display: block;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.ff_entry_table_cell__content {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  line-height: 1.55;
+  max-height: calc(1.55em * 3);
+
+  > * {
+    max-width: 100%;
+    white-space: normal !important;
+    word-break: break-word;
+    overflow-wrap: anywhere;
+  }
+
+  > *:first-child {
+    margin-top: 0 !important;
+  }
+
+  > *:last-child {
+    margin-bottom: 0 !important;
+  }
+
+  p,
+  ul,
+  ol,
+  blockquote,
+  pre,
+  table {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+
+  br {
+    display: none;
+  }
+}
+
+.compact .ff_entry_table_cell__content {
+  -webkit-line-clamp: 2;
+  max-height: calc(1.55em * 2);
+}
+
+.ff-entry-cell-popover {
+  max-width: min(520px, calc(100vw - 32px));
+}
+
+.ff_entry_table_popover_content {
+  max-height: min(60vh, 560px);
+  overflow: auto;
+  white-space: normal;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+  line-height: 1.55;
+
+  > *:first-child {
+    margin-top: 0;
+  }
+
+  > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
 .add_note_wrapper {
   padding: 20px;
 }

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -332,13 +332,36 @@
                         <el-table-column
                                 v-for="(column, index) in formattedColumn"
                                 :label="column.label"
-                                :show-overflow-tooltip="isCompact"
                                 min-width="200"
                                 sortable="custom"
                                 :prop="'user_inputs_column_field-' + column.field"
                                 :key="index">
                             <template slot-scope="scope">
-                                <span v-html="scope.row.user_inputs[column.field]"></span>
+                                <el-popover
+                                    v-if="getEntryCellValue(scope.row.user_inputs[column.field])"
+                                    popper-class="ff-entry-cell-popover"
+                                    placement="top-start"
+                                    trigger="hover"
+                                    :open-delay="150"
+                                    :width="420"
+                                >
+                                    <div
+                                        class="ff_entry_table_popover_content"
+                                        v-html="getEntryCellValue(scope.row.user_inputs[column.field])"
+                                    ></div>
+                                    <div
+                                        slot="reference"
+                                        class="ff_entry_table_cell"
+                                    >
+                                        <div
+                                            class="ff_entry_table_cell__content"
+                                            v-html="getEntryCellValue(scope.row.user_inputs[column.field])"
+                                        ></div>
+                                    </div>
+                                </el-popover>
+                                <div v-else class="ff_entry_table_cell">
+                                    <div class="ff_entry_table_cell__content"></div>
+                                </div>
                             </template>
                         </el-table-column>
 
@@ -794,6 +817,9 @@
 	        }
         },
         methods: {
+            getEntryCellValue(value) {
+                return value || '';
+            },
             getStatusName(status) {
                 if (this.entry_statuses[status]) {
                     return this.entry_statuses[status];
@@ -1286,4 +1312,3 @@
 	    }
     };
 </script>
-


### PR DESCRIPTION
## What does this PR do and why?

Long textarea and text input values in the single-form entries table could make the row preview unstable and visually flash. This updates the entries list UI to keep previews clamped in-row and reveal the full value in a bounded hover popover without changing the underlying parsed submission data.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [ ] PHP (backend logic, models, services, hooks)
- [x] Vue/React (admin UI, block editor)
- [x] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Open a single form entries page that has very long textarea or text input content.
2. Confirm the table cell stays clamped instead of expanding and flashing.
3. Hover the truncated cell and confirm the full content appears in a bounded scrollable popover.
4. Toggle compact view and confirm the preview still clamps cleanly.

## Screenshots

N/A

## Anything the reviewer should know?

This change is intentionally limited to the single-form entries list UI and does not modify the separate all-entries summary screen.
