### PR TITLE
Fix: Escape permission message shortcode output

### DIFF
--- a/app/Modules/Component/Component.php
+++ b/app/Modules/Component/Component.php
@@ -510,7 +510,7 @@ class Component
 
         if (!empty($atts['permission'])) {
             if (!current_user_can($atts['permission'])) {
-                return "<div id='ff_form_{$form->id}' class='ff_form_not_render'>{$atts['permission_message']}</div>";
+                return "<div id='ff_form_" . intval($form->id) . "' class='ff_form_not_render'>" . wp_kses_post($atts['permission_message']) . "</div>";
             }
         }
 


### PR DESCRIPTION

## What does this PR do and why?

Fixes a HIGH severity stored cross-site scripting issue in the free Fluent Forms shortcode renderer. The "fluentform" shortcode accepts a "permission_message" attribute and, when a "permission" attribute is configured and the current visitor lacks that capability, "renderForm()" previously returned the supplied "permission_message" directly inside the frontend "ff_form_not_render" wrapper.

That created a shortcode-attribute HTML sink. WordPress KSES does not reliably protect this case because the dangerous content is stored as shortcode text and later expanded by Fluent Forms at render time.

Related Issue: https://gist.github.com/techjewel/d5111effc14c9c353af5fb79514a05fc

## Affected area

- Free plugin only
- Shortcode: "[fluentform]"
- Attribute: "permission_message"
- Vulnerable sink before this patch: "app/Modules/Component/Component.php" in the permission-denied branch of "renderForm()"
- No database schema changes
- No asset rebuild required

## Impact

A contributor/editor, or any user who can place shortcode content into rendered posts or pages, could store JavaScript that executes for visitors who do not satisfy the requested shortcode permission. If an administrator previews or visits the affected page while the permission branch renders the message, the payload runs in the site origin.

## Reproduction from audit

As a contributor-level or higher user who can create or edit a post/page containing shortcodes, add the gist-provided shortcode variant:

```text
[fluentform id="1" permission="admin" permission_message="\x3c\x73\x63\x72\x69\x70\x74\x3e\x61\x6c\x65\x72\x74\x28\x64\x6f\x63\x75\x6d\x65\x6e\x74\x2e\x63\x6f\x6f\x6b\x69\x65\x29\x3c\x2f\x73\x63\x72\x69\x70\x74\x3e"]
```

Then publish or preview the page and visit it as a user who does not satisfy the configured permission. Before this patch, Fluent Forms rendered "permission_message" directly in the form-not-render wrapper.

Additional direct-sink confirmation payload:

```text
[fluentform id="1" permission="manage_options" permission_message="<script>alert(document.cookie)</script>"]
```

## Changes

- Sanitizes "permission_message" with "wp_kses_post()" immediately before rendering it in the permission-denied branch.
- Normalizes the generated form wrapper ID with "intval()" before concatenating it into the HTML id attribute.
- Preserves intended safe formatting in "permission_message" while blocking script tags and event-handler payloads.

## How to test

1. Create or edit a page as a user who can place shortcodes.
2. Add the gist-provided shortcode payload above with a valid form id.
3. Visit the page as a user without the configured permission.
4. Confirm the form-not-render wrapper appears but the script payload does not execute.
5. Repeat with the direct-sink confirmation payload and confirm the script tag is stripped.
6. Repeat with benign HTML such as "<strong>Access denied</strong>" in "permission_message" and confirm the allowed formatting still renders.

## Verification performed

- Ran "php -l app/Modules/Component/Component.php".
- Confirmed the public gist maps to the same unescaped sink and recommended fix location in "Component.php".
- Verified the fix is limited to "app/Modules/Component/Component.php".
- Confirmed "SECURITY_AUDIT_2026-04-22.md" was not included in this branch.