### PR TITLE
Fix: Block event handlers in sanitized HTML

### DIFF
--- a/boot/globals.php
+++ b/boot/globals.php
@@ -387,9 +387,6 @@ function fluentform_sanitize_html($html)
         'style'           => [],
     ];
     
-    //button
-    $tags['button']['onclick'] = [];
-
     //svg
     if (empty($tags['svg'])) {
         $svg_args = [
@@ -433,6 +430,19 @@ function fluentform_sanitize_html($html)
     );
 
     $tags = apply_filters('fluentform/allowed_html_tags', $tags);
+
+    // Event-handler attributes are executable JavaScript and must not be re-enabled by filters.
+    foreach ($tags as $tagName => $attributes) {
+        if (!is_array($attributes)) {
+            continue;
+        }
+
+        foreach (array_keys($attributes) as $attribute) {
+            if (preg_match('/^on[a-z]+/i', $attribute)) {
+                unset($tags[$tagName][$attribute]);
+            }
+        }
+    }
 
     return wp_kses($html, $tags);
 }


### PR DESCRIPTION
## What does this PR do and why?

Fixes a stored XSS sanitizer bypass in "fluentform_sanitize_html()". The sanitizer is used for users who cannot save unfiltered HTML, but it previously re-allowed "button" elements with an "onclick" attribute. Because "onclick" is executable JavaScript, a non-"unfiltered_html" Fluent Forms manager could persist event-handler payloads in HTML-capable form settings that are later rendered on public forms or confirmation views.

This PR removes the explicit "button[onclick]" allowance and adds a final allowlist cleanup after "fluentform/allowed_html_tags" filters run, so executable "on*" attributes cannot be re-enabled by custom filters.

## Affected area

- Free plugin
- Function: "fluentform_sanitize_html()"
- File: "boot/globals.php"
- Affected users: users without WordPress "unfiltered_html" who can manage Fluent Forms content/settings
- No database schema changes
- No asset rebuild required

## Important permission context

Fluent Forms intentionally treats raw HTML/JS capability separately from Fluent Forms management capability:

```php
function fluentformCanUnfilteredHTML()
{
    return current_user_can('unfiltered_html') || apply_filters('fluentform/disable_fields_sanitize', false);
}
```

So this PR does not change what "fluentform_forms_manager" can access. It fixes the sanitizer path used when the current user cannot save unfiltered HTML. Even if a Fluent Forms manager has broad form-management access, they should not be able to persist executable JavaScript unless they also have "unfiltered_html" or a developer explicitly disables sanitization.

## Root cause

Before this patch, "fluentform_sanitize_html()" did two unsafe things for this class of payload:

1. It tried to strip event handlers with a regex that only matched quoted attributes.
2. It explicitly allowed "button[onclick]" in the "wp_kses()" allowlist.

That allowed an unquoted event-handler payload to survive sanitization.

## Reproduction

Run this on a site with Fluent Forms loaded:

```bash
wp eval 'echo fluentform_sanitize_html("<button onclick=alert(document.domain)>Click me</button>");'
```

Before this patch, the output preserved an executable event handler:

```html
<button onclick="alert(document.domain)">Click me</button>
```

After this patch, the output is:

```html
<button>Click me</button>
```

## Form-manager reproduction path

1. Use a user that can manage Fluent Forms but does not have WordPress "unfiltered_html".
2. Edit a form setting that is saved through "fluentform_sanitize_html()", such as same-page confirmation message, custom HTML, section break description, Terms and Conditions HTML, or submit button text.
3. Save a payload such as:

```html
<button onclick=alert(document.domain)>Click me</button>
```

4. Render the affected form or trigger the confirmation view.
5. Before this patch, the event handler could be retained in the saved/rendered HTML.
6. After this patch, "onclick" is stripped while safe button markup remains.

Additional sink-style payloads from the audit:

```html
</button><button onclick=alert(document.domain)>Injected</button>
```

```html
<button onclick=alert(document.domain)>Injected content</button>
```

## Changes

- Removed the explicit "button[onclick]" allowance.
- Added a final pass over the allowed HTML tags after extension filters execute.
- Strips any allowed attributes matching "on*" before calling "wp_kses()".
- Preserves safe allowed HTML and attributes, such as "class" on "button".

## Verification performed

- Ran "php -l boot/globals.php".
- Confirmed the original unquoted "onclick" payload is stripped.
- Confirmed quoted "onclick" payloads are stripped.
- Confirmed safe button class output remains: "<button class=\"ff-btn\">Click me</button>".
- Confirmed a test "fluentform/allowed_html_tags" filter attempting to re-add "button[onclick]" is neutralized by the final allowlist cleanup.

## Reviewer notes

This is intentionally a sanitizer/root-cause fix rather than a per-sink fix because "fluentform_sanitize_html()" is used across multiple HTML-capable form settings and render paths.