### PR TITLE
Fix: Restrict delegated full access checks

### DIFF
--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -159,38 +159,38 @@ class Acl
         if ($formId && !FormManagerService::hasFormPermission($formId)) {
             return false;
         }
-        $userCapability = static::getCurrentUserCapability();
 
-        if ($userCapability) {
+        if (current_user_can('fluentform_full_access') || current_user_can('manage_options')) {
             return true;
-        } else {
-            if (current_user_can('fluentform_full_access')) {
-                return true;
-            }
-
-            $permissions = (array) $permissions;
-
-            foreach ($permissions as $permission) {
-                $allowed = current_user_can($permission);
-
-                if ($allowed) {
-                    $allowed = apply_filters_deprecated(
-                        'fluentform_verify_user_permission_' . $permission,
-                        [
-                            $allowed,
-                            $formId
-                        ],
-                        FLUENTFORM_FRAMEWORK_UPGRADE,
-                        'fluentform/verify_user_permission_' . $permission,
-                        'Use fluentform/verify_user_permission_' . $permission . ' instead of fluentform_verify_user_permission_' . $permission
-                    );
-
-                    return apply_filters('fluentform/verify_user_permission_' . $permission, $allowed, $formId);
-                }
-            }
-
-            return false;
         }
+
+        $userCapability = static::getCurrentUserCapability();
+        $permissions = (array) $permissions;
+
+        foreach ($permissions as $permission) {
+            $allowed = current_user_can($permission);
+
+            if (!$allowed && $userCapability && 'fluentform_full_access' !== $permission) {
+                $allowed = true;
+            }
+
+            if ($allowed) {
+                $allowed = apply_filters_deprecated(
+                    'fluentform_verify_user_permission_' . $permission,
+                    [
+                        $allowed,
+                        $formId
+                    ],
+                    FLUENTFORM_FRAMEWORK_UPGRADE,
+                    'fluentform/verify_user_permission_' . $permission,
+                    'Use fluentform/verify_user_permission_' . $permission . ' instead of fluentform_verify_user_permission_' . $permission
+                );
+
+                return apply_filters('fluentform/verify_user_permission_' . $permission, $allowed, $formId);
+            }
+        }
+
+        return false;
     }
 
     public static function hasAnyFormPermission($form_id = false)

--- a/app/Modules/Acl/Acl.php
+++ b/app/Modules/Acl/Acl.php
@@ -160,37 +160,50 @@ class Acl
             return false;
         }
 
-        if (current_user_can('fluentform_full_access') || current_user_can('manage_options')) {
+        // Only explicit full-access users should bypass individual permission checks.
+        if (static::hasExplicitFullAccess()) {
             return true;
         }
 
-        $userCapability = static::getCurrentUserCapability();
-        $permissions = (array) $permissions;
+        $grantedRole = static::getCurrentUserCapability();
 
-        foreach ($permissions as $permission) {
+        foreach ((array) $permissions as $permission) {
             $allowed = current_user_can($permission);
 
-            if (!$allowed && $userCapability && 'fluentform_full_access' !== $permission) {
+            // A granted role can satisfy scoped permissions, but never full access.
+            if (!$allowed && $grantedRole && 'fluentform_full_access' !== $permission) {
                 $allowed = true;
             }
 
-            if ($allowed) {
-                $allowed = apply_filters_deprecated(
-                    'fluentform_verify_user_permission_' . $permission,
-                    [
-                        $allowed,
-                        $formId
-                    ],
-                    FLUENTFORM_FRAMEWORK_UPGRADE,
-                    'fluentform/verify_user_permission_' . $permission,
-                    'Use fluentform/verify_user_permission_' . $permission . ' instead of fluentform_verify_user_permission_' . $permission
-                );
-
-                return apply_filters('fluentform/verify_user_permission_' . $permission, $allowed, $formId);
+            if (!$allowed) {
+                continue;
             }
+
+            return static::filterPermissionCheck($permission, $allowed, $formId);
         }
 
         return false;
+    }
+
+    private static function hasExplicitFullAccess()
+    {
+        return current_user_can('fluentform_full_access') || current_user_can('manage_options');
+    }
+
+    private static function filterPermissionCheck($permission, $allowed, $formId)
+    {
+        $allowed = apply_filters_deprecated(
+            'fluentform_verify_user_permission_' . $permission,
+            [
+                $allowed,
+                $formId
+            ],
+            FLUENTFORM_FRAMEWORK_UPGRADE,
+            'fluentform/verify_user_permission_' . $permission,
+            'Use fluentform/verify_user_permission_' . $permission . ' instead of fluentform_verify_user_permission_' . $permission
+        );
+
+        return apply_filters('fluentform/verify_user_permission_' . $permission, $allowed, $formId);
     }
 
     public static function hasAnyFormPermission($form_id = false)


### PR DESCRIPTION
## What does this PR do and why?

Fixes a permission-confusion issue in the Fluent Forms ACL helper. A delegated Fluent Forms manager capability, such as "fluentform_forms_manager", could satisfy checks for "fluentform_full_access" because "Acl::hasPermission()" returned true whenever "getCurrentUserCapability()" returned any configured Fluent Forms capability.

That made lower delegated Fluent Forms access pass routes intended only for full Fluent Forms administrators, including role and manager administration endpoints.

## Affected area

- Free plugin
- File: "app/Modules/Acl/Acl.php"
- Function: "Acl::hasPermission()"
- Full-access policy affected: "RoleManagerPolicy"
- Routes affected:
  - "GET /wp-json/fluentform/v1/roles"
  - "POST /wp-json/fluentform/v1/roles"
  - "GET /wp-json/fluentform/v1/managers"
  - "POST /wp-json/fluentform/v1/managers"
  - "DELETE /wp-json/fluentform/v1/managers"
  - "GET /wp-json/fluentform/v1/managers/users"

## Root cause

Before this patch, "Acl::hasPermission()" did this:

```php
$userCapability = static::getCurrentUserCapability();

if ($userCapability) {
    return true;
}
```

So if "_fluentform_form_permission" was configured to "fluentform_forms_manager", a user with only that capability could pass unrelated ACL checks, including "Acl::hasPermission('fluentform_full_access')".

## Impact

A user delegated only form-management level Fluent Forms access could reach full-access-only role/manager APIs.

Confirmed impact:

- "fluentform_forms_manager" user can enumerate users through "GET /wp-json/fluentform/v1/managers/users?search=admin".
- The same policy protects manager mutation routes, so the user could reach APIs intended to add/remove Fluent Forms managers or update delegated permissions.

## How to recreate before the fix

1. Configure Fluent Forms delegated role permission so "_fluentform_form_permission" contains "fluentform_forms_manager".
2. Create a non-admin user, for example a Subscriber.
3. Grant that user only the "fluentform_forms_manager" capability.
4. Log in or execute code as that user.
5. Confirm WordPress says the user does not have full Fluent Forms access:

```php
current_user_can('fluentform_full_access'); // false
```

6. Confirm the Fluent Forms ACL incorrectly grants full access:

```php
FluentForm\App\Modules\Acl\Acl::hasPermission('fluentform_full_access'); // true before this patch
```

7. Request the full-access-only manager user-search route:

```http
GET /wp-json/fluentform/v1/managers/users?search=admin
```

8. Before this patch, the request returns HTTP 200 and user-search results even though "RoleManagerPolicy" requires "fluentform_full_access".

## WP-CLI reproduction used locally

```bash
wp eval '$login = "ff_acl_route_tmp_" . time(); $userId = wp_create_user($login, wp_generate_password(24), $login . "@example.test"); update_option("_fluentform_form_permission", "fluentform_forms_manager"); $user = new WP_User($userId); $user->set_role("subscriber"); $user->add_cap("fluentform_forms_manager"); wp_set_current_user($userId); $request = new WP_REST_Request("GET", "/fluentform/v1/managers/users"); $request->set_param("search", "admin"); $response = rest_do_request($request); echo "can_full=" . (current_user_can("fluentform_full_access") ? "true" : "false") . "\n"; echo "acl_full=" . (FluentForm\\App\\Modules\\Acl\\Acl::hasPermission("fluentform_full_access") ? "true" : "false") . "\n"; echo "route_status=" . $response->get_status() . "\n"; wp_delete_user($userId);'
```

Before this patch:

```text
can_full=false
acl_full=true
route_status=200
```

After this patch:

```text
can_full=false
acl_full=false
route_status=403
```

## Changes

- Keeps actual "fluentform_full_access" and "manage_options" users as full-access users.
- Keeps delegated Fluent Forms manager capability behavior for non-full-access checks.
- Prevents a delegated capability from satisfying the specific "fluentform_full_access" check.
- Preserves existing deprecated/current permission filters for allowed checks.

## Regression checks

Verified with a temporary Subscriber user having only "fluentform_forms_manager":

```text
Acl::hasPermission("fluentform_forms_manager") = true
Acl::hasPermission("fluentform_dashboard_access") = true
Acl::hasPermission("fluentform_full_access") = false
GET /wp-json/fluentform/v1/managers/users?search=admin = 403
```

Verified with an Administrator:

```text
current_user_can("manage_options") = true
Acl::hasPermission("fluentform_full_access") = true
```

## Verification performed

- Ran "php -l app/Modules/Acl/Acl.php".
- Reproduced the vulnerable full-access ACL result before patching.
- Verified the route is denied after patching.
- Verified normal delegated form-manager ACL checks still pass.