### PR TITLE
SECURITY: harden form HTML output

### DIFF
--- a/app/Modules/Component/Component.php
+++ b/app/Modules/Component/Component.php
@@ -510,7 +510,7 @@ class Component
 
         if (!empty($atts['permission'])) {
             if (!current_user_can($atts['permission'])) {
-                return "<div id='ff_form_{$form->id}' class='ff_form_not_render'>{$atts['permission_message']}</div>";
+                return $this->getNotRenderableHtml($form->id, $atts['permission_message']);
             }
         }
 
@@ -565,7 +565,7 @@ class Component
         $isRenderable = $this->app->applyFilters('fluentform/is_form_renderable', $isRenderable, $form);
 
         if (is_array($isRenderable) && !$isRenderable['status']) {
-            return "<div id='ff_form_{$form->id}' class='ff_form_not_render'>{$isRenderable['message']}</div>";
+            return $this->getNotRenderableHtml($form->id, $isRenderable['message']);
         }
 
         $instanceCssClass = Helper::getFormInstaceClass($form->id);
@@ -803,6 +803,13 @@ class Component
         }
 
         return $output . $otherScripts;
+    }
+
+    protected function getNotRenderableHtml($formId, $message)
+    {
+        return "<div id='ff_form_" . esc_attr($formId) . "' class='ff_form_not_render'>"
+            . wp_kses_post($message)
+            . "</div>";
     }
 
     /**


### PR DESCRIPTION
Hardens Fluent Forms user-controlled HTML output by escaping permission-denied shortcode messages and removing event-handler attributes from sanitized form HTML. This closes the reported permission_message stored XSS path and prevents unquoted button onclick payloads from surviving fluentform_sanitize_html().

**Related issue:** N/A

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

1. Run php -l app/Modules/Component/Component.php and php -l boot/globals.php.
2. Run the WP-CLI sanitizer proof for fluentform_sanitize_html() and confirm quoted, unquoted, and mixed-case on* handlers are stripped.

N/A

The sanitizer strips event-handler attributes after the fluentform/allowed_html_tags filter so integrations cannot accidentally re-allow inline JavaScript handlers.

DOCS: add Fluent Forms security audit plan

Adds durable OpenSpec changes and a plugin audit report for the Fluent Forms security review. This keeps the XSS fix plan, full plugin audit checklist, findings, verification notes, and follow-up remediation backlog in the repo.

**Related issue:** N/A

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

- [ ] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [x] Build/config (Vite, composer, CI)

1. Run openspec validate full-plugin-security-audit --type change --strict --no-interactive.
2. Run openspec validate harden-user-controlled-output-security --type change --strict --no-interactive.
3. Review plugin-audit.md for severity counts, verified fixes, open findings, and follow-up backlog.

N/A

This audit execution covers the Free plugin checkout only. The report calls out the sibling Pro plugin as a separate release-gate audit follow-up.