### PR TITLE
Fix global integration settings access control

### DIFF
--- a/app/Http/Policies/GlobalIntegrationPolicy.php
+++ b/app/Http/Policies/GlobalIntegrationPolicy.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace FluentForm\App\Http\Policies;
+
+use FluentForm\App\Modules\Acl\Acl;
+use FluentForm\Framework\Foundation\Policy;
+use FluentForm\Framework\Http\Request\Request;
+
+class GlobalIntegrationPolicy extends Policy
+{
+    public function verifyRequest(Request $request)
+    {
+        return $this->canManageGlobalIntegrations();
+    }
+
+    public function index()
+    {
+        return $this->canManageGlobalIntegrations();
+    }
+
+    public function updateIntegration()
+    {
+        return $this->canManageGlobalIntegrations();
+    }
+
+    public function updateModuleStatus()
+    {
+        return $this->canManageGlobalIntegrations();
+    }
+
+    private function canManageGlobalIntegrations()
+    {
+        if (
+            current_user_can('manage_options') ||
+            current_user_can('fluentform_full_access') ||
+            current_user_can('fluentform_settings_manager')
+        ) {
+            return true;
+        }
+
+        $roleCapability = Acl::getCurrentUserCapability();
+
+        // Legacy role-level Fluent Forms access stores the WP role key here.
+        // Granular Fluent Forms permissions must not imply settings access.
+        return $roleCapability && !in_array($roleCapability, Acl::getPermissionSet(), true);
+    }
+}

--- a/app/Http/Routes/api.php
+++ b/app/Http/Routes/api.php
@@ -93,15 +93,15 @@ $router->prefix('logs')->withPolicy('SubmissionPolicy')->group(function ($router
 /*
 * Global Integrations
 */
-$router->prefix('integrations')->withPolicy('FormPolicy')->group(function ($router) {
-    $router->get('/', 'GlobalIntegrationController@index');
-    $router->post('/', 'GlobalIntegrationController@updateIntegration');
-    $router->post('update-status', 'GlobalIntegrationController@updateModuleStatus');
+$router->prefix('integrations')->group(function ($router) {
+    $router->get('/', 'GlobalIntegrationController@index')->withPolicy('GlobalIntegrationPolicy');
+    $router->post('/', 'GlobalIntegrationController@updateIntegration')->withPolicy('GlobalIntegrationPolicy');
+    $router->post('update-status', 'GlobalIntegrationController@updateModuleStatus')->withPolicy('GlobalIntegrationPolicy');
     
     /*
     * Form Integrations
     */
-    $router->prefix('{form_id}')->group(function ($router) {
+    $router->prefix('{form_id}')->withPolicy('FormPolicy')->group(function ($router) {
         $router->get('/form-integrations', 'FormIntegrationController@index');
         $router->get('/', 'FormIntegrationController@find');
         $router->post('/', 'FormIntegrationController@update');


### PR DESCRIPTION
## What does this PR do and why?

This PR restricts global integration settings reads and writes to users who can manage Fluent Forms global settings. Previously, the global integration settings endpoints lived under the same `integrations` route group as form-level integration feed endpoints, so `GET /integrations?settings_key=...` inherited `FormPolicy::index()` and allowed users with only dashboard access to retrieve configured integration settings.

That exposed raw Pro integration secrets returned by the existing Pro filters, such as HubSpot access tokens, OAuth client secrets, access tokens, refresh tokens, API keys, and similar credential fields.

## Related Issue

Security audit finding: HIGH: Pro global integration secrets disclosed through weakly guarded integration read endpoint

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- Added `GlobalIntegrationPolicy` for global integration settings endpoints.
- Moved the following global endpoints from `FormPolicy` to `GlobalIntegrationPolicy`:
  - `GET /integrations`
  - `POST /integrations`
  - `POST /integrations/update-status`
- Kept form-specific integration routes under `FormPolicy`:
  - `/integrations/{form_id}/...`

## Why a new policy was introduced

The existing `integrations` route group contains two different permission domains:

- Global integration settings endpoints read/write site-wide API credentials and should require settings-level access.
- Form-specific integration feed endpoints are part of form management and should remain available to form managers.

Changing `FormPolicy::index()` would be too broad because it is shared by other form/dashboard routes and could break normal dashboard/form listing access.

Putting `GlobalSettingsPolicy` on the whole `integrations` group would be too strict because it would also restrict form-specific integration feed routes that form managers currently use.

A dedicated `GlobalIntegrationPolicy` keeps the security boundary precise: global credentials require settings-level access, while form-specific integration management keeps its existing `FormPolicy` behavior.

## Who remains allowed

- WordPress administrators.
- Users with `fluentform_full_access`.
- Users with `fluentform_settings_manager`.
- Existing legacy role-level Fluent Forms access configured through `_fluentform_form_permission`.

## Who is now blocked

- Users with only granular `fluentform_dashboard_access` can no longer read global integration settings/secrets.

## How to recreate the issue before this fix

1. Configure a Pro global integration that stores secrets, for example HubSpot.
2. Ensure the stored option contains an access token, for example `_fluentform_hubspot_settings.accessToken`.
3. Create or use a low-trust WordPress user with only granular Fluent Forms dashboard access:
   - `fluentform_dashboard_access=yes`
   - `fluentform_settings_manager=no`
4. Authenticate as that user and send a REST request:

```http
GET /wp-json/fluentform/v1/integrations?settings_key=hubspot
X-WP-Nonce: <rest_nonce>
```

5. Before this fix, the response is HTTP 200 and includes the raw integration settings, including secret fields such as `integration.accessToken`.
6. After this fix, the same user receives HTTP 403.
7. A real settings manager still receives HTTP 200 for the same endpoint.

## How to test this PR

1. Configure a Pro global integration such as HubSpot.
2. Log in as a user with only `fluentform_dashboard_access`.
3. Request:

```http
GET /wp-json/fluentform/v1/integrations?settings_key=hubspot
```

4. Confirm the response is HTTP 403.
5. Log in as a user with `fluentform_settings_manager`.
6. Request the same endpoint and confirm the response is HTTP 200.
7. Log in as a user with `fluentform_forms_manager` for a form.
8. Request a form-specific integration route, for example:

```http
GET /wp-json/fluentform/v1/integrations/{form_id}/form-integrations
```

9. Confirm form-specific integration access still works.

## Verification performed

- `php -l app/Http/Policies/GlobalIntegrationPolicy.php`
- `php -l app/Http/Routes/api.php`
- `git diff --check HEAD~1..HEAD`
- Runtime REST check: dashboard-only user now receives 403 for global integration settings.
- Runtime REST check: settings manager still receives 200 for global integration settings.
- Runtime REST check: legacy role-level Fluent Forms access still receives 200.
- Runtime REST check: form manager still receives 200 on form-specific integration route.
- Temporary test users were cleaned up.

## Anything the reviewer should know?

This PR does not mask secret fields. It fixes the authorization boundary so only settings-level users can access the existing global integration settings payload. Masking/redaction can be considered separately if product wants read responses to hide secrets even from settings managers.