### PR TITLE
Protect payment filters AJAX metadata endpoint

### DIFF
--- a/app/Modules/Payments/Classes/PaymentEntries.php
+++ b/app/Modules/Payments/Classes/PaymentEntries.php
@@ -248,7 +248,31 @@ class PaymentEntries
 
     public function getFilters()
     {
-        $transactionTypes = Transaction::select('transaction_type')
+        $request = wpFluentForm()->request;
+        $attributes = $request->all();
+
+        $sanitizeMap = [
+            'form_id' => function ($value) {
+                return Acl::normalizeFormId($value);
+            },
+        ];
+        $attributes = fluentform_backend_sanitizer($attributes, $sanitizeMap);
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified by Acl::verify() below
+        Acl::verify('fluentform_view_payments', ArrayHelper::get($attributes, 'form_id'));
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified by Acl::verify() above
+        $selectedFormId = ArrayHelper::get($attributes, 'form_id');
+        $allowFormIds = apply_filters('fluentform/current_user_allowed_forms', false);
+
+        $transactionTypesQuery = Transaction::select('transaction_type');
+        if ($selectedFormId) {
+            $transactionTypesQuery = $transactionTypesQuery->where('form_id', $selectedFormId);
+        }
+        if (false !== $allowFormIds && is_array($allowFormIds)) {
+            $transactionTypesQuery = $transactionTypesQuery->whereIn('form_id', $allowFormIds ?: [0]);
+        }
+
+        $transactionTypes = $transactionTypesQuery
             ->groupBy('transaction_type')
             ->get();
         // Define transaction type labels
@@ -268,7 +292,15 @@ class PaymentEntries
             ];
         }
         
-        $statuses = Transaction::select('status')
+        $statusesQuery = Transaction::select('status');
+        if ($selectedFormId) {
+            $statusesQuery = $statusesQuery->where('form_id', $selectedFormId);
+        }
+        if (false !== $allowFormIds && is_array($allowFormIds)) {
+            $statusesQuery = $statusesQuery->whereIn('form_id', $allowFormIds ?: [0]);
+        }
+
+        $statuses = $statusesQuery
             ->groupBy('status')
             ->get();
         $statusTypes = PaymentHelper::getPaymentStatuses();
@@ -276,11 +308,15 @@ class PaymentEntries
         foreach ($statuses as $status) {
             $formattedStatuses[] = ArrayHelper::get($statusTypes, $status->status, $status->status);
         }
-        $allowFormIds = apply_filters('fluentform/current_user_allowed_forms', false);
-        $forms = Transaction::select('fluentform_transactions.form_id', 'fluentform_forms.title')
-            ->when(false !== $allowFormIds && is_array($allowFormIds), function ($q) use ($allowFormIds){
-                return $q->whereIn('fluentform_transactions.form_id', $allowFormIds ?: [0]);
-            })
+        $formsQuery = Transaction::select('fluentform_transactions.form_id', 'fluentform_forms.title');
+        if ($selectedFormId) {
+            $formsQuery = $formsQuery->where('fluentform_transactions.form_id', $selectedFormId);
+        }
+        if (false !== $allowFormIds && is_array($allowFormIds)) {
+            $formsQuery = $formsQuery->whereIn('fluentform_transactions.form_id', $allowFormIds ?: [0]);
+        }
+
+        $forms = $formsQuery
             ->groupBy('fluentform_transactions.form_id')
             ->orderBy('fluentform_transactions.form_id', 'DESC')
             ->join('fluentform_forms', 'fluentform_forms.id', '=', 'fluentform_transactions.form_id')
@@ -294,7 +330,15 @@ class PaymentEntries
             ];
         }
 
-        $paymentMethods = Transaction::select('payment_method')
+        $paymentMethodsQuery = Transaction::select('payment_method');
+        if ($selectedFormId) {
+            $paymentMethodsQuery = $paymentMethodsQuery->where('form_id', $selectedFormId);
+        }
+        if (false !== $allowFormIds && is_array($allowFormIds)) {
+            $paymentMethodsQuery = $paymentMethodsQuery->whereIn('form_id', $allowFormIds ?: [0]);
+        }
+
+        $paymentMethods = $paymentMethodsQuery
             ->groupBy('payment_method')
             ->get();
 


### PR DESCRIPTION
## What does this PR do and why?

This PR fixes an authenticated metadata disclosure in the AJAX endpoint `fluentform_get_all_payments_entries_filters`.

Before this change, `PaymentEntries::getFilters()` returned payment filter metadata for any logged-in WordPress user because it had no Fluent Forms capability guard and no nonce/capability verification flow. A low-privileged user could call the endpoint directly and enumerate payment workflow metadata.

## Security impact

Before fix:
- Any authenticated user could query available payment transaction types, statuses, payment methods, and form titles/IDs with payment activity.
- This leaked payment-related business metadata to users who do not have payment-view permissions.

After fix:
- `getFilters()` now enforces `Acl::verify('fluentform_view_payments', form_id)`.
- This applies the same permission and nonce verification model already used by `getPayments()`.
- Unauthorized callers are blocked.

## Root cause

`getFilters()` had no authorization gate, while `getPayments()` correctly required `fluentform_view_payments`.

## What changed

File changed:
- `app/Modules/Payments/Classes/PaymentEntries.php`

Changes made in `getFilters()`:
1. Read and sanitize request attributes, including `form_id` via `Acl::normalizeFormId`.
2. Add `Acl::verify('fluentform_view_payments', form_id)` to enforce capability + nonce verification flow.
3. Apply consistent query scoping for all grouped metadata queries (`transaction_type`, `status`, `forms`, `payment_method`):
   - filter by selected `form_id` when provided.
   - filter by `fluentform/current_user_allowed_forms` when available.

## How to reproduce (before fix)

1. Log in with a low-privileged WordPress user (for example `subscriber`) without Fluent Forms payment permissions.
2. Send an authenticated request:

```http
POST /wp-admin/admin-ajax.php
Content-Type: application/x-www-form-urlencoded

action=fluentform_get_all_payments_entries_filters
```

3. Observe JSON response includes metadata such as:
- `available_payment_types`
- `available_statuses`
- `available_forms`
- `available_methods`

## How to verify (after fix)

1. Repeat the same request as a low-privileged user.
2. Confirm the request is rejected by ACL verification.
3. As an authorized user with `fluentform_view_payments`, open Payment Entries UI and verify filters still load correctly.
4. Optionally pass a specific `form_id` and verify all filter groups remain scoped to that form/allowed forms.

## Regression notes

- No frontend changes required.
- Existing authorized Payment Entries behavior remains intact.
- Fix tightens only unauthorized access and inconsistent metadata scoping.

## Checks run

- `php -l app/Modules/Payments/Classes/PaymentEntries.php`
- `git diff --check dev..HEAD`
