### PR TITLE
Feature: Step form tab navigation

### DIFF
--- a/app/Hooks/actions.php
+++ b/app/Hooks/actions.php
@@ -229,6 +229,18 @@ $app->addAction('fluentform/loading_editor_assets', function ($form) {
         return $field;
     });
 
+    add_filter('fluentform/editor_init_element_step_start', function ($item) {
+        if (!isset($item['settings']['progress_layout'])) {
+            $item['settings']['progress_layout'] = 'top';
+        }
+
+        if (!isset($item['settings']['tabs_show_progress_bar'])) {
+            $item['settings']['tabs_show_progress_bar'] = 'no';
+        }
+
+        return $item;
+    });
+
     $upgradableCheckInputs = [
         'input_radio',
         'select',

--- a/app/Modules/Component/Component.php
+++ b/app/Modules/Component/Component.php
@@ -636,6 +636,7 @@ class Component
             'ajaxUrl'                       => admin_url('admin-ajax.php'),
             'forms'                         => [],
             'step_text'                     => $stepText,
+            'step_completed_text'          => __('Completed', 'fluentform'),
             'is_rtl'                        => is_rtl(),
             'date_i18n'                     => self::getDatei18n(),
             'pro_version'                   => (defined('FLUENTFORMPRO_VERSION')) ? FLUENTFORMPRO_VERSION : false,

--- a/app/Modules/Registerer/Menu.php
+++ b/app/Modules/Registerer/Menu.php
@@ -973,6 +973,16 @@ class Menu
                     }
                 }
 
+                if (!empty($formFields['stepsWrapper']['stepStart'])) {
+                    $stepStart = $formFields['stepsWrapper']['stepStart'];
+
+                    $formFields['stepsWrapper']['stepStart'] = apply_filters(
+                        'fluentform/editor_init_element_' . $stepStart['element'],
+                        $stepStart,
+                        $form
+                    );
+                }
+
                 $formFields['fields'] = array_values($formFields['fields']);
                 $formFields = json_encode($formFields, true);
             }

--- a/app/Services/Form/Updater.php
+++ b/app/Services/Form/Updater.php
@@ -351,6 +351,15 @@ class Updater
                     }
                 }
 
+                if (isset($field['settings']['tabs_show_progress_bar'])) {
+                    $field['settings']['tabs_show_progress_bar'] = sanitize_text_field($field['settings']['tabs_show_progress_bar']) === 'yes' ? 'yes' : 'no';
+                }
+
+                if (isset($field['settings']['progress_layout'])) {
+                    $progressLayout = sanitize_text_field($field['settings']['progress_layout']);
+                    $field['settings']['progress_layout'] = in_array($progressLayout, ['top', 'left'], true) ? $progressLayout : 'top';
+                }
+
                 if (!empty($field['settings']['prev_btn']) && is_array($field['settings']['prev_btn'])) {
                     foreach ($field['settings']['prev_btn'] as $key => $value) {
                         if (isset($stepsSanitizationMap['prev_btn'][$key])) {

--- a/app/Services/FormBuilder/ElementCustomization.php
+++ b/app/Services/FormBuilder/ElementCustomization.php
@@ -293,9 +293,43 @@ $fluentformElementCustomizationSettings = [
                 'label' => __('Steps', 'fluentform'),
             ],
             [
+                'value' => 'tabs',
+                'label' => __('Tabs', 'fluentform'),
+            ],
+            [
                 'value' => '',
                 'label' => __('None', 'fluentform'),
             ],
+        ],
+    ],
+    'progress_layout' => [
+        'template'  => 'radioButton',
+        'label'     => __('Tab Position', 'fluentform'),
+        'help_text' => __('Choose how step tabs should be displayed on the frontend.', 'fluentform'),
+        'options'   => [
+            [
+                'value' => 'top',
+                'label' => __('Top', 'fluentform'),
+            ],
+            [
+                'value' => 'left',
+                'label' => __('Left', 'fluentform'),
+            ],
+        ],
+        'dependency' => [
+            'depends_on' => 'settings/progress_indicator',
+            'value'      => 'tabs',
+            'operator'   => '==',
+        ],
+    ],
+    'tabs_show_progress_bar' => [
+        'template'   => 'inputYesNoCheckBox',
+        'label'      => __('Show Progress Bar Under Tabs', 'fluentform'),
+        'help_text'  => __('Enable a compact progress bar under the step tabs.', 'fluentform'),
+        'dependency' => [
+            'depends_on' => 'settings/progress_indicator',
+            'value'      => 'tabs',
+            'operator'   => '==',
         ],
     ],
     'step_animation' => [

--- a/app/Services/FormBuilder/ElementSettingsPlacement.php
+++ b/app/Services/FormBuilder/ElementSettingsPlacement.php
@@ -440,6 +440,8 @@ return [
         'general' => [
             'class',
             'progress_indicator',
+            'progress_layout',
+            'tabs_show_progress_bar',
             'step_animation',
             'step_titles',
             'disable_auto_focus',

--- a/resources/assets/admin/components/editor-field-settings/templates/customStepTitles.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/customStepTitles.vue
@@ -1,15 +1,23 @@
 <template>
-    <el-form-item v-if="editItem.settings.progress_indicator != ''">
-        <b><elLabel slot="label" :label="listItem.label" :helpText="listItem.help_text"></elLabel></b>
-        <hr class="mb-3" />
+    <div v-if="editItem.settings.progress_indicator != ''">
+        <el-form-item>
+            <b><elLabel slot="label" :label="listItem.label" :helpText="listItem.help_text"></elLabel></b>
+            <hr class="mb-3" />
 
-        <div v-for="(number, index) in formStepsCount" class="el-form-item" :key="index">
-            <label class="el-form-item__label">{{ $t('Step %d', number) }}</label>
-            <div class="el-form-item__content">
-                <el-input size="small" v-model="editItem.settings.step_titles[index]" @input="sanitizeStep(index)" @paste="sanitizeStep(index)"></el-input>
+            <div v-for="(number, index) in formStepsCount" class="el-form-item" :key="index">
+                <label class="el-form-item__label">{{ $t('Step %d', number) }}</label>
+                <div class="el-form-item__content">
+                    <el-input
+                        size="small"
+                        v-model="editItem.settings.step_titles[index]"
+                        :placeholder="defaultStepTitle(index)"
+                        @input="sanitizeStep(index)"
+                        @paste="sanitizeStep(index)"
+                    ></el-input>
+                </div>
             </div>
-        </div>
-    </el-form-item>
+        </el-form-item>
+    </div>
 </template>
 
 <script>
@@ -24,15 +32,48 @@ export default {
     computed: {
         formStepsCount() {
             let count = 1;
-            _ff.map(this.form_items, (field) => {
+            _ff.map(this.form_items, field => {
                 if (field.editor_options.template == "formStep") {
                     count++;
                 }
             });
             return count;
+        }
+    },
+    watch: {
+        formStepsCount() {
+            this.ensureStepSettings();
         },
+        'editItem.settings.progress_indicator'() {
+            this.ensureStepSettings();
+        }
+    },
+    mounted() {
+        this.ensureStepSettings();
     },
     methods: {
+        ensureStepSettings() {
+            if (!this.editItem.settings.progress_layout) {
+                this.$set(this.editItem.settings, 'progress_layout', 'top');
+            }
+
+            if (!this.editItem.settings.tabs_show_progress_bar) {
+                this.$set(this.editItem.settings, 'tabs_show_progress_bar', 'no');
+            }
+
+            if (!Array.isArray(this.editItem.settings.step_titles)) {
+                this.$set(this.editItem.settings, 'step_titles', []);
+            }
+
+            for (let index = 0; index < this.formStepsCount; index++) {
+                if (typeof this.editItem.settings.step_titles[index] === 'undefined') {
+                    this.$set(this.editItem.settings.step_titles, index, '');
+                }
+            }
+        },
+        defaultStepTitle(index) {
+            return this.$t('Step %d', index + 1);
+        },
         sanitizeInput(input) {
             // Decode HTML entities to their actual characters
             input = input.replace(/&gt;/gi, '>').replace(/&lt;/gi, '<').replace(/&amp;/gi, '&').replace(/&quot;/gi, '"').replace(/&apos;/gi, "'");

--- a/resources/assets/admin/editor_app.js
+++ b/resources/assets/admin/editor_app.js
@@ -133,6 +133,8 @@ window.fluentFormEditorApp = new Vue({
                 },
                 settings: {
                     progress_indicator: "progress-bar",
+                    progress_layout: 'top',
+                    tabs_show_progress_bar: 'no',
                     step_titles: [],
                     disable_auto_focus: 'no',
                     enable_auto_slider: 'no',
@@ -238,6 +240,14 @@ window.fluentFormEditorApp = new Vue({
 
                 if(!formData.stepsWrapper.stepStart.settings.enable_auto_slider) {
                     formData.stepsWrapper.stepStart.settings.enable_auto_slider = 'no';
+                }
+
+                if(!formData.stepsWrapper.stepStart.settings.progress_layout) {
+                    formData.stepsWrapper.stepStart.settings.progress_layout = 'top';
+                }
+
+                if(!formData.stepsWrapper.stepStart.settings.tabs_show_progress_bar) {
+                    formData.stepsWrapper.stepStart.settings.tabs_show_progress_bar = 'no';
                 }
 
                 if(!formData.stepsWrapper.stepStart.settings.enable_step_data_persistency) {

--- a/resources/assets/public/Pro/slider.js
+++ b/resources/assets/public/Pro/slider.js
@@ -73,6 +73,72 @@ class FluentFormSlider {
     }
 
     /**
+     * Apply visual and accessibility state to clickable step titles.
+     * @param {object} stepTitles
+     * @param {number} activeStep
+     */
+    syncStepTitleState(stepTitles, activeStep) {
+        const $ = this.$;
+
+        if (!stepTitles || !stepTitles.length) {
+            return;
+        }
+
+        stepTitles.removeClass('ff_active ff_completed').removeAttr('aria-current');
+
+        $.each(stepTitles, (index, stepTitle) => {
+            const $stepTitle = $(stepTitle);
+
+            if (index < activeStep) {
+                $stepTitle.addClass('ff_completed');
+            } else if (index === activeStep) {
+                $stepTitle.addClass('ff_active').attr('aria-current', 'step');
+            }
+        });
+    }
+
+    /**
+     * Add button semantics to step titles.
+     * @param {object} stepTitlesNavs
+     */
+    enhanceClickableStepTitles(stepTitlesNavs) {
+        const $ = this.$;
+
+        $.each(stepTitlesNavs, function (i, elm) {
+            $(elm).attr('data-step-number', i);
+            $(elm).attr({
+                'role': 'button',
+                'tabindex': '0',
+                'aria-label': 'Go to step ' + (i + 1)
+            });
+        });
+    }
+
+    /**
+     * Keep top tabs centered only when they fit within the available width.
+     */
+    syncTopTabOverflowState() {
+        const $ = this.$;
+
+        this.$theForm.find('.ff-step-header--tabs-top .ff-step-titles').each(function () {
+            const $titles = $(this);
+            const isOverflowing = this.scrollWidth > this.clientWidth + 1;
+
+            $titles.toggleClass('ff-step-titles--overflowing', isOverflowing);
+        });
+    }
+
+    /**
+     * Determine if the current indicator should use tabs behavior.
+     * Supports legacy `steps_with_nav` for mixed free/pro version compatibility.
+     * @param {string} progressIndicator
+     * @return {boolean}
+     */
+    isTabsIndicator(progressIndicator) {
+        return progressIndicator === 'tabs' || progressIndicator === 'steps_with_nav';
+    }
+
+    /**
      * Initialize form with saved state if step persistence is enabled
      */
     initFormWithSavedState() {
@@ -340,6 +406,8 @@ class FluentFormSlider {
         const formSteps = this.$theForm.find('.fluentform-step');
         const totalSteps = formSteps.length;
         const stepTitles = this.$theForm.find('.ff-step-titles li');
+        const progressIndicator = this.$theForm.find('.ff-step-container').first().data('progress_indicator');
+        const shouldUseClickableTabs = this.isTabsIndicator(progressIndicator);
 
         // Pre-skip steps that are fully hidden by conditions on initial load to avoid flicker
         if (!window.ff_disable_auto_step) {
@@ -366,7 +434,7 @@ class FluentFormSlider {
         $(formSteps[this.activeStep]).attr('aria-hidden', 'false');
 
         $(formSteps[this.activeStep]).addClass('active');
-        $(stepTitles[this.activeStep]).addClass('active');
+        this.syncStepTitleState(stepTitles, this.activeStep);
 
         const firstStep = formSteps.first();
         if (firstStep.hasClass('active')) {
@@ -382,7 +450,16 @@ class FluentFormSlider {
 
         this.registerStepNavigators(this.fluentFormVars.stepAnimationDuration);
 
-        this.registerClickableStepNav(stepTitles, formSteps);
+        if (shouldUseClickableTabs) {
+            this.registerClickableStepNav(stepTitles, formSteps);
+            this.syncTopTabOverflowState();
+
+            $(window)
+                .off('resize.ff_step_tabs_' + this.$theForm.data('form_id'))
+                .on('resize.ff_step_tabs_' + this.$theForm.data('form_id'), this.syncTopTabOverflowState.bind(this));
+        } else {
+            $(window).off('resize.ff_step_tabs_' + this.$theForm.data('form_id'));
+        }
     }
 
     /**
@@ -398,18 +475,7 @@ class FluentFormSlider {
             return;
         }
 
-        // Add this line to assign step numbers to each title
-        $.each(stepTitlesNavs, function (i, elm) {
-            $(elm).attr('data-step-number', i);
-
-            // Also add these for accessibility and visual indication
-            $(elm).attr({
-                'role': 'button',
-                'tabindex': '0',
-                'aria-label': 'Go to step ' + (i + 1),
-                'style': 'cursor: pointer;'
-            });
-        });
+        this.enhanceClickableStepTitles(stepTitlesNavs);
 
         stepTitlesNavs.on('click keydown', function (e) {
             // Handle keyboard events
@@ -423,24 +489,30 @@ class FluentFormSlider {
 
             let formInstance = self.getFormInstance();
             let $this = $(this);
-            let currentStep = 0;
             const animDuration = self.fluentFormVars.stepAnimationDuration;
+            const currentActiveStep = formSteps.index(self.$theForm.find('.fluentform-step.active'));
 
             try {
-                let targetStep = $this.data('step-number');
+                let targetStep = parseInt($this.data('step-number'), 10);
                 if (isNaN(targetStep)) {
                     return;
                 }
-                //validate other steps before target step before next step
-                $.each(formSteps, (index, steps) => {
-                    currentStep = index
-                    if (index < targetStep) {
-                        const elements = $(steps).find(':input').not(':button').filter(function (i, el) {
-                            return !$(el).closest('.has-conditions').hasClass('ff_excluded');
-                        });
-                        elements.length && formInstance.validate(elements)
-                    }
-                });
+
+                if (targetStep === currentActiveStep) {
+                    return;
+                }
+
+                if (targetStep > currentActiveStep) {
+                    // Validate only the intermediate steps when navigating forward.
+                    $.each(formSteps, (index, steps) => {
+                        if (index < targetStep) {
+                            const elements = $(steps).find(':input').not(':button').filter(function (i, el) {
+                                return !$(el).closest('.has-conditions').hasClass('ff_excluded');
+                            });
+                            elements.length && formInstance.validate(elements)
+                        }
+                    });
+                }
 
                 self.updateSlider(targetStep, animDuration, true)
                     .then(() => {
@@ -453,7 +525,7 @@ class FluentFormSlider {
                 if (!(e instanceof window.ffValidationError)) {
                     throw e;
                 }
-                self.updateSlider(currentStep, animDuration, true)
+                self.updateSlider(currentActiveStep, animDuration, true)
                     .then(() => {
                         self.handleFocus(animDuration);
                     })
@@ -479,6 +551,8 @@ class FluentFormSlider {
             const stepTitles = this.$theForm.find('.ff-el-progress-title li');
             const progressBar = this.$theForm.find('.ff-step-header .ff-el-progress-bar');
             const span = progressBar.find('span');
+            const $stepContainer = this.$theForm.find('.ff-step-container').first();
+            const isTabsProgress = this.isTabsIndicator($stepContainer.data('progress_indicator'));
 
             // Add smooth animation to progress bar
             progressBar.css({
@@ -495,10 +569,14 @@ class FluentFormSlider {
             let stepText = this.fluentFormVars.step_text;
 
             let stepTitle = $(stepTitles[activeStep]).text();
-            stepText = stepText
-                .replace('%activeStep%', activeStep + 1)
-                .replace('%totalStep%', totalSteps)
-                .replace('%stepTitle%', stepTitle);
+            if (isTabsProgress) {
+                stepText = parseInt(completeness) + '% ' + this.fluentFormVars.step_completed_text;
+            } else {
+                stepText = stepText
+                    .replace('%activeStep%', activeStep + 1)
+                    .replace('%totalStep%', totalSteps)
+                    .replace('%stepTitle%', stepTitle);
+            }
 
             // Add ARIA live region for step announcements
             this.$theForm.find('.ff-el-progress-status')
@@ -688,11 +766,7 @@ class FluentFormSlider {
             $(formSteps[this.activeStep]).css('display', 'block').addClass('active').attr('aria-hidden', 'false');
 
             // Change step title
-            stepTitles.removeClass('ff_active ff_completed');
-            $.each([...Array(this.activeStep).keys()], (step) => {
-                $($(stepTitles[step])).addClass('ff_completed');
-            });
-            $(stepTitles[this.activeStep]).addClass('ff_active');
+            this.syncStepTitleState(stepTitles, this.activeStep);
 
             const scrollTop = function () {
                 if (window.ff_disable_step_scroll) {
@@ -729,6 +803,13 @@ class FluentFormSlider {
             };
 
             const animationType = $(formSteps[this.activeStep]).closest('.ff-step-container').data('animation_type');
+            const $stepContainer = $(formSteps[this.activeStep]).closest('.ff-step-container');
+            const $stepBody = $(formSteps[this.activeStep]).closest('.ff-step-body');
+            const isTabsNavigation = this.isTabsIndicator($stepContainer.data('progress_indicator'));
+
+            if (isTabsNavigation) {
+                $stepBody.css('overflow', 'hidden');
+            }
 
             // Get the current and next step elements
             const $currentStep = $(formSteps[this.activeStep]);
@@ -757,6 +838,10 @@ class FluentFormSlider {
             const progressPromise = this.animateProgressToStep(this.activeStep, completenessTotalSteps, progressDuration);
 
             const completeStepChange = function () {
+                if (isTabsNavigation) {
+                    $stepBody.css('overflow', '');
+                }
+
                 let isFormReset = goBackToStep === 0 && !isScrollTop;
                 let isFormSubmitting = self.$theForm.hasClass('ff_submitting');
 

--- a/resources/assets/public/scss/public/components.scss
+++ b/resources/assets/public/scss/public/components.scss
@@ -350,10 +350,345 @@
 
       &-container {
         overflow: hidden;
+
+        &[data-progress_indicator="tabs"][data-progress_layout="left"],
+        &[data-progress_indicator="steps_with_nav"][data-progress_layout="left"] {
+          display: flex;
+          align-items: stretch;
+          gap: 12px;
+
+          .ff-step-header {
+            flex: 0 0 30%;
+            align-self: stretch;
+            margin-bottom: 0;
+          }
+
+          .ff-step-body {
+            flex: 1 1 auto;
+            min-width: 0;
+          }
+        }
       }
 
       &-header {
         margin-bottom: 20px;
+
+        &--tabs-left {
+          display: flex;
+          flex-direction: column;
+          margin-bottom: 0;
+        }
+
+        &--tabs {
+          display: flex;
+          flex-direction: column;
+          padding: 16px;
+          border-radius: 8px;
+          background: #f5f8ff;
+
+          &-top {
+            .ff-step-titles {
+              justify-content: center;
+
+              &.ff-step-titles--overflowing {
+                justify-content: flex-start;
+              }
+            }
+
+            .ff-step-titles li .ff-step-title-text {
+              width: auto;
+              max-width: 100%;
+              flex: 0 1 auto;
+              margin: 0 auto;
+            }
+          }
+
+          .ff-step-progress-wrap--tabs {
+            margin-top: 16px;
+
+            .ff-el-progress {
+              height: 8px;
+              border-radius: 999px;
+              background: #dce7f6;
+            }
+
+            .ff-el-progress-bar {
+              border-radius: inherit;
+            }
+
+            .ff-el-progress-bar span {
+              display: none;
+            }
+
+            .ff-el-progress-status {
+              margin: 8px 0 0;
+              text-align: right;
+              font-size: 14px;
+              font-weight: 600;
+              color: #5f6f89;
+            }
+          }
+
+          .ff-step-titles {
+            counter-reset: none;
+            display: flex;
+            flex-wrap: nowrap;
+            width: 100%;
+            gap: 12px;
+            margin: 0;
+            padding: 0;
+            overflow-x: auto;
+            overflow-y: hidden;
+            scrollbar-width: thin;
+
+            &.ff-step-titles-navs {
+              cursor: default;
+            }
+
+            li {
+              flex: 0 0 160px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              gap: 8px;
+              min-height: 48px;
+              margin: 0;
+              padding: 12px 14px;
+              border: 1px solid #d6dee8;
+              border-radius: 14px;
+              background: #ffffff;
+              color: #4b5563;
+              font-size: 14px;
+              font-weight: 600;
+              line-height: 1.3;
+              text-align: center;
+
+              &:before,
+              &:after {
+                display: none;
+              }
+
+              .ff-step-title-icon {
+                flex: 0 0 auto;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 16px;
+                height: 16px;
+                font-size: 16px;
+                line-height: 1;
+                color: inherit;
+              }
+
+              .ff-step-title-text {
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 100%;
+                flex: 1 1 auto;
+                gap: 8px;
+                min-width: 0;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+
+                i,
+                span[class*="dashicons"],
+                svg {
+                  flex: 0 0 auto;
+                  display: inline-flex;
+                  align-items: center;
+                  justify-content: center;
+                  line-height: 1;
+                }
+
+                svg {
+                  width: 16px;
+                  height: 16px;
+                }
+              }
+
+              &:first-child,
+              &:last-child {
+                padding-left: 14px;
+                padding-right: 14px;
+              }
+
+              &:hover,
+              &:focus-visible {
+                color: #007bff;
+                border-color: #b8d4fb;
+                background: #f8fbff;
+              }
+
+              &.ff_completed {
+                color: #007bff;
+                background: #f8fbff;
+                border-color: #c8dcfb;
+              }
+
+              &.ff_active {
+                color: #007bff;
+                background: #f2f8ff;
+                border-color: #007bff;
+              }
+            }
+          }
+        }
+
+        &--tabs-left {
+          padding: 16px;
+          border-radius: 12px;
+          background: #f5f8ff;
+
+          .ff-step-titles {
+            counter-reset: step;
+            display: block;
+            flex: 1 1 auto;
+            min-height: 0;
+            padding: 0;
+            border: 0;
+            border-radius: 0;
+            background: transparent;
+            max-height: 240px;
+            margin-bottom: 0;
+            overflow-x: hidden;
+            overflow-y: auto;
+            scrollbar-width: thin;
+
+            li {
+              position: relative;
+              display: flex;
+              align-items: center;
+              justify-content: flex-start;
+              min-height: 48px;
+              margin: 0 0 16px;
+              padding: 12px 14px 12px 48px;
+              border: 1px solid #d6dee8;
+              border-radius: 8px;
+              background: #ffffff;
+              color: #4b5563;
+              font-size: 14px;
+              font-weight: 600;
+              text-align: left;
+              box-sizing: border-box;
+              overflow: hidden;
+
+              &:before {
+                content: counter(step);
+                counter-increment: step;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                width: 28px;
+                height: 28px;
+                margin: 0;
+                position: absolute;
+                left: 12px;
+                top: 50%;
+                transform: translateY(-50%);
+                border: 1px solid #c8d1dc;
+                border-radius: 8px;
+                background: #ffffff;
+                color: #4b5563;
+                font-size: 13px;
+                font-weight: 700;
+                line-height: 1;
+                z-index: 2;
+              }
+
+              &:after {
+                content: '';
+                position: absolute;
+                left: 34px;
+                top: calc(100% + 1px);
+                width: 2px;
+                height: 10px;
+                background: #d9e0e8;
+              }
+
+              .ff-step-title-text {
+                display: block;
+                width: auto;
+                flex: 1 1 auto;
+                min-width: 0;
+                padding-left: 4px;
+                line-height: 1.3;
+                overflow: hidden;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+              }
+
+              .ff-step-title-text {
+                justify-content: flex-start;
+
+                i,
+                span[class*="dashicons"],
+                svg {
+                  flex: 0 0 auto;
+                  display: inline-flex;
+                  align-items: center;
+                  justify-content: center;
+                  line-height: 1;
+                }
+
+                svg {
+                  width: 16px;
+                  height: 16px;
+                }
+              }
+
+              &:hover,
+              &:focus-visible {
+                color: #007bff;
+                border-color: #b8d4fb;
+                background: #f8fbff;
+              }
+
+              &.ff_completed {
+                color: #007bff;
+                border-color: #c8dcfb;
+                background: #f8fbff;
+
+                &:before {
+                  border-color: #007bff;
+                  background: #ffffff;
+                  color: #007bff;
+                }
+
+                &:after {
+                  background: #9ec5fe;
+                }
+              }
+
+              &.ff_active {
+                color: #007bff;
+                border-color: #007bff;
+                background: #f2f8ff;
+
+                &:before {
+                  border-color: #007bff;
+                  background: #007bff;
+                  color: #ffffff;
+                }
+              }
+
+              &:first-child {
+                padding-left: 48px;
+              }
+
+              &:last-child {
+                padding-left: 48px;
+                padding-right: 14px;
+                margin-bottom: 0;
+
+                &:after {
+                  display: none;
+                }
+              }
+            }
+          }
+        }
       }
 
       &-titles {
@@ -371,6 +706,12 @@
         counter-reset: step;
         &-navs {
           cursor: pointer;
+        }
+
+        &--clickable {
+          li {
+            cursor: pointer;
+          }
         }
 
         li {
@@ -449,12 +790,62 @@
         }
       }
 
+      &-container[data-progress_indicator="tabs"][data-progress_layout="left"] &-titles,
+      &-container[data-progress_indicator="steps_with_nav"][data-progress_layout="left"] &-titles {
+        margin-bottom: 0;
+      }
+
       &-body {
         @extend .clearfix;
         margin-bottom: 15px;
         position: relative;
         left: 0;
         top: 0;
+      }
+    }
+
+    @media (max-width: 767px) {
+      &-step {
+        &-container[data-progress_indicator="tabs"][data-progress_layout="left"],
+        &-container[data-progress_indicator="steps_with_nav"][data-progress_layout="left"] {
+          display: block;
+
+          .ff-step-header {
+            flex: unset;
+            margin-bottom: 20px;
+          }
+        }
+
+        &-container[data-progress_indicator="tabs"][data-progress_layout="left"] .ff-step-header--tabs-left .ff-step-titles,
+        &-container[data-progress_indicator="steps_with_nav"][data-progress_layout="left"] .ff-step-header--tabs-left .ff-step-titles {
+          display: flex;
+          gap: 10px;
+          padding: 0;
+          border: 0;
+          border-radius: 0;
+          background: transparent;
+          max-height: none;
+          overflow-x: auto;
+          overflow-y: hidden;
+
+          li {
+            min-height: 56px;
+            margin: 0;
+            padding: 14px 12px;
+            border-radius: 12px;
+            text-align: center;
+            justify-content: center;
+
+            &:before,
+            &:after {
+              display: none;
+            }
+
+            .ff-step-title-text {
+              justify-content: center;
+            }
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## What does this PR do and why?

This PR adds a new Tabs progress indicator for multi-step forms without changing the existing Steps or Progress Bar flows. It introduces editor controls and free-plugin runtime behavior needed for clickable top/left tab navigation, while keeping mixed free/pro updates compatible so legacy steps_with_nav forms do not break when Pro is updated first.

**Related Issue:** https://lounge.authlab.io/projects#/boards/16/tasks/21069-Feature---Step-Form-Tab-Progre

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — `app/Services/FormBuilder/ElementCustomization.php`: adds the new `Tabs` progress indicator option plus tabs-specific settings for layout and inline progress visibility.
- [x] PHP — `app/Services/FormBuilder/ElementSettingsPlacement.php`: places the new tabs settings under the step-start settings group.
- [x] PHP — `app/Hooks/actions.php` and `app/Modules/Registerer/Menu.php`: backfill defaults for existing saved forms so older step forms load with the new settings shape in the editor.
- [x] PHP — `app/Services/Form/Updater.php`: sanitizes and normalizes `progress_layout` and `tabs_show_progress_bar` on save.
- [x] PHP — `app/Modules/Component/Component.php`: exposes the tabs progress status text for frontend updates.
- [x] JS/Vue — `resources/assets/admin/editor_app.js` and `resources/assets/admin/components/editor-field-settings/templates/customStepTitles.vue`: hydrate default tab settings and keep step-title inputs aligned with the actual step count while preserving the existing secure title sanitization behavior.
- [x] JS — `resources/assets/public/Pro/slider.js`: adds clickable tab navigation for tabs mode only, skips backward-step validation, keeps forward validation intact, ignores active-tab clicks, handles top-tab overflow state, and limits step animation effects to the step body.
- [x] SCSS — `resources/assets/public/scss/public/components.scss`: adds dedicated top/left tabs styling, scrolling behavior, progress placement, and tabs-only layout refinements without affecting existing Steps styling.

## How to test

1. Create or open a multi-step form in the builder.
2. In the step start settings, set `Progress Indicator` to `Tabs`.
3. Switch `Tab Position` between `Top` and `Left` and save the form.
4. Verify the frontend updates to the selected layout and that the existing `Steps` and `Progress Bar` modes still render unchanged.
5. Enable `Show Progress Bar Under Tabs`, save, and verify the compact progress bar appears below the tabs; disable it and verify it disappears.
6. Click forward tabs and confirm validation still blocks invalid steps; click backward tabs and confirm it navigates without re-validating prior steps.
7. Click the active tab and confirm the current step is not re-rendered.
8. For a form using legacy `steps_with_nav`, verify navigation still works when paired with updated Pro and when Free/Pro versions are temporarily mixed.
9. Save a form with an invalid or custom `progress_layout` value in stored data and confirm it normalizes back to `top` safely.

## Anything the reviewer should know?

- This PR intentionally keeps step titles restricted to plain text plus `<br>` rendering.
- Existing `Steps` behavior is preserved; the new interactions only apply to `Tabs` and legacy `steps_with_nav` compatibility handling.
- Reciprocal Pro PR: https://github.com/fluentform/fluentformpro/pull/166