### PR TITLE
Feature: Dropdown option grouping

### DIFF
--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -56,6 +56,95 @@ class Helper
         return $input;
     }
 
+    public static function isOptionGroup($option)
+    {
+        return is_array($option)
+            && ArrayHelper::get($option, 'type') === 'group'
+            && is_array(ArrayHelper::get($option, 'options'));
+    }
+
+    public static function sanitizeAdvancedOptions($options, $depth = 0)
+    {
+        if (!is_array($options)) {
+            return [];
+        }
+
+        $sanitized = [];
+
+        foreach ($options as $option) {
+            if (!is_array($option)) {
+                continue;
+            }
+
+            if (self::isOptionGroup($option)) {
+                $groupOptions = self::sanitizeAdvancedOptions(
+                    ArrayHelper::get($option, 'options', []),
+                    $depth + 1
+                );
+
+                if ($depth > 0) {
+                    $sanitized = array_merge($sanitized, $groupOptions);
+                    continue;
+                }
+
+                $sanitized[] = [
+                    'type'    => 'group',
+                    'label'   => wp_kses_post(ArrayHelper::get($option, 'label', '')),
+                    'options' => $groupOptions,
+                ];
+                continue;
+            }
+
+            $sanitized[] = [
+                'label'      => wp_kses_post(ArrayHelper::get($option, 'label', '')),
+                'value'      => sanitize_text_field(ArrayHelper::get($option, 'value', '')),
+                'image'      => sanitize_url(ArrayHelper::get($option, 'image', '')),
+                'calc_value' => sanitize_text_field(ArrayHelper::get($option, 'calc_value', '')),
+                'disabled'   => ArrayHelper::isTrue($option, 'disabled'),
+            ];
+        }
+
+        return $sanitized;
+    }
+
+    public static function flattenAdvancedOptions($options)
+    {
+        if (!is_array($options)) {
+            return [];
+        }
+
+        $flattened = [];
+
+        foreach ($options as $option) {
+            if (self::isOptionGroup($option)) {
+                $flattened = array_merge(
+                    $flattened,
+                    self::flattenAdvancedOptions(ArrayHelper::get($option, 'options', []))
+                );
+                continue;
+            }
+
+            if (!is_array($option)) {
+                continue;
+            }
+
+            $flattened[] = $option;
+        }
+
+        return $flattened;
+    }
+
+    public static function advancedOptionsValueLabelMap($options)
+    {
+        $formatted = [];
+
+        foreach (self::flattenAdvancedOptions($options) as $option) {
+            $formatted[ArrayHelper::get($option, 'value')] = ArrayHelper::get($option, 'label');
+        }
+
+        return $formatted;
+    }
+
     public static function makeMenuUrl($page = 'fluent_forms_settings', $component = null)
     {
         $baseUrl = admin_url('admin.php?page=' . $page);
@@ -1039,7 +1128,7 @@ class Helper
                     // @todo : Update all reference in form templates
                 }
 
-                $options = array_column($formattedOptions, 'value');
+                $options = array_column(self::flattenAdvancedOptions($formattedOptions), 'value');
                 
                 // Add field-specific __ff_other__ to options if "Other" option is enabled
                 if (in_array($fieldType, ['input_checkbox', 'input_radio']) &&

--- a/app/Hooks/actions.php
+++ b/app/Hooks/actions.php
@@ -297,6 +297,10 @@ $app->addAction('fluentform/loading_editor_assets', function ($form) {
                 $element['settings']['values_visible'] = false;
             }
 
+            if ('select' == $upgradeElement && !isset($element['settings']['enable_option_groups'])) {
+                $element['settings']['enable_option_groups'] = 'no';
+            }
+
       
 
             return $element;

--- a/app/Hooks/filters.php
+++ b/app/Hooks/filters.php
@@ -213,10 +213,9 @@ foreach ($fluentformElements as $fluentformElement) {
 
         if ($response && ($isHtml || defined('FLUENTFORM_RENDERING_ENTRIES')) && in_array($element, ['select', 'input_radio']) && !is_array($response)) {
             if (!isset($field['options'])) {
-                $field['options'] = [];
-                foreach (\FluentForm\Framework\Helpers\ArrayHelper::get($field, 'raw.settings.advanced_options', []) as $option) {
-                    $field['options'][$option['value']] = $option['label'];
-                }
+                $field['options'] = \FluentForm\App\Helpers\Helper::advancedOptionsValueLabelMap(
+                    \FluentForm\Framework\Helpers\ArrayHelper::get($field, 'raw.settings.advanced_options', [])
+                );
             }
             if (isset($field['options'][$response])) {
                 return $field['options'][$response];

--- a/app/Modules/Form/FormDataParser.php
+++ b/app/Modules/Form/FormDataParser.php
@@ -328,7 +328,7 @@ class FormDataParser
                 $values && is_array($values) &&
                 $options = ArrayHelper::get($field, 'raw.settings.advanced_options', [])
             ) {
-                $options = array_column($options, 'label', 'value');
+                $options = \FluentForm\App\Helpers\Helper::advancedOptionsValueLabelMap($options);
                 foreach ($values as &$value) {
                     if ($label = ArrayHelper::get($options, $value)) {
                         $value = $label;
@@ -347,10 +347,9 @@ class FormDataParser
         }
 
         if (!isset($field['options'])) {
-            $field['options'] = [];
-            foreach (ArrayHelper::get($field, 'raw.settings.advanced_options', []) as $option) {
-                $field['options'][$option['value']] = $option['label'];
-            }
+            $field['options'] = \FluentForm\App\Helpers\Helper::advancedOptionsValueLabelMap(
+                ArrayHelper::get($field, 'raw.settings.advanced_options', [])
+            );
         }
 
         $html = '<ul style="white-space: normal;">';

--- a/app/Services/FluentConversational/Classes/Converter/Converter.php
+++ b/app/Services/FluentConversational/Classes/Converter/Converter.php
@@ -1216,10 +1216,20 @@ class Converter
     private static function getAdvancedOptions($field, $form)
     {
         $options = ArrayHelper::get($field, 'settings.advanced_options', []);
-        
+
         foreach ($options as &$option) {
+            if (\FluentForm\App\Helpers\Helper::isOptionGroup($option)) {
+                foreach ($option['options'] as &$groupOption) {
+                    $groupOption['label'] = self::getComponent()->replaceEditorSmartCodes($groupOption['label'], $form);
+                }
+                unset($groupOption);
+                $option['label'] = self::getComponent()->replaceEditorSmartCodes($option['label'], $form);
+                continue;
+            }
+
             $option['label'] = self::getComponent()->replaceEditorSmartCodes($option['label'], $form);
         }
+        unset($option);
         
         if ($options && 'yes' == ArrayHelper::get($field, 'settings.randomize_options')) {
             shuffle($options);

--- a/app/Services/FormBuilder/Components/Select.php
+++ b/app/Services/FormBuilder/Components/Select.php
@@ -128,6 +128,30 @@ class Select extends BaseComponent
             $opts .= '<option value="">' . wp_strip_all_tags($data['attributes']['placeholder']) . '</option>';
         }
         foreach ($formattedOptions as $option) {
+            if (Helper::isOptionGroup($option)) {
+                $groupLabel = wp_strip_all_tags(ArrayHelper::get($option, 'label', ''));
+                $groupOptions = $this->buildOptionMarkup(
+                    ArrayHelper::get($option, 'options', []),
+                    $defaultValues
+                );
+
+                if ($groupOptions) {
+                    $opts .= '<optgroup label="' . esc_attr($groupLabel) . '">' . $groupOptions . '</optgroup>';
+                }
+                continue;
+            }
+
+            $opts .= $this->buildOptionMarkup([$option], $defaultValues);
+        }
+
+        return $opts;
+    }
+
+    protected function buildOptionMarkup($formattedOptions, $defaultValues)
+    {
+        $opts = '';
+
+        foreach ($formattedOptions as $option) {
             if (in_array($option['value'], $defaultValues)) {
                 $selected = 'selected';
             } else {

--- a/app/Services/FormBuilder/DefaultElements.php
+++ b/app/Services/FormBuilder/DefaultElements.php
@@ -848,6 +848,7 @@ $fluentformDefaultElements = [
                 'calc_value_status'  => false,
                 'enable_image_input' => false,
                 'values_visible'     => false,
+                'enable_option_groups' => 'no',
                 'enable_select_2'    => 'no',
                 'validation_rules'   => [
                     'required' => [
@@ -1017,6 +1018,7 @@ $fluentformDefaultElements = [
                 ],
                 'calc_value_status'  => false,
                 'enable_image_input' => false,
+                'enable_option_groups' => 'no',
                 'randomize_options'  => 'no',
                 'validation_rules'   => [
                     'required' => [

--- a/app/Services/FormBuilder/ElementCustomization.php
+++ b/app/Services/FormBuilder/ElementCustomization.php
@@ -135,6 +135,11 @@ $fluentformElementCustomizationSettings = [
         'label'     => __('Options', 'fluentform'),
         'help_text' => __('Create visual options for the field and checkmark them for default selection.', 'fluentform'),
     ],
+    'enable_option_groups' => [
+        'template'  => 'inputYesNoCheckBox',
+        'label'     => __('Enable Option Grouping', 'fluentform'),
+        'help_text' => __('Turn this on to organize dropdown and multiselect options under group labels.', 'fluentform'),
+    ],
     'enable_select_2' => [
         'template'  => 'inputYesNoCheckBox',
         'label'     => __('Enable Searchable Smart Options', 'fluentform'),

--- a/app/Services/Parser/Extractor.php
+++ b/app/Services/Parser/Extractor.php
@@ -257,10 +257,12 @@ class Extractor
     protected function setOptions()
     {
         if (in_array('options', $this->with)) {
-            $options = Arr::get($this->field, 'options', []);
+                $options = Arr::get($this->field, 'options', []);
 
-            if(!$options) {
-                $newOptions = Arr::get($this->field, 'settings.advanced_options', []);
+                if(!$options) {
+                    $newOptions = \FluentForm\App\Helpers\Helper::flattenAdvancedOptions(
+                        Arr::get($this->field, 'settings.advanced_options', [])
+                    );
 
                 if(
                     !$newOptions

--- a/boot/globals.php
+++ b/boot/globals.php
@@ -319,23 +319,7 @@ function fluentFormPrintUnescapedInternalString($string)
 
 function fluentform_options_sanitize($options)
 {
-    $maps = [
-        'label'      => 'wp_kses_post',
-        'value'      => 'sanitize_text_field',
-        'image'      => 'sanitize_url',
-        'calc_value' => 'sanitize_text_field',
-    ];
-
-    $mapKeys = array_keys($maps);
-
-    foreach ($options as $optionIndex => $option) {
-        $attributes = array_filter(ArrayHelper::only($option, $mapKeys));
-        foreach ($attributes as $key => $value) {
-            $options[$optionIndex][$key] = call_user_func($maps[$key], $value);
-        }
-    }
-
-    return $options;
+    return \FluentForm\App\Helpers\Helper::sanitizeAdvancedOptions($options);
 }
 
 function fluentform_iframe_srcdoc_sanitize($value)

--- a/resources/assets/admin/components/editor-field-settings/templates/advanced-options.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/advanced-options.vue
@@ -1,7 +1,23 @@
 <template>
-    <el-form-item>
-        <div class="clearfix">
-            <div class="pull-right top-check-action">
+    <el-form-item class="ff_advanced_options_form_item">
+        <elLabel slot="label" :label="listItem.label" :helpText="listItem.help_text"></elLabel>
+
+        <div class="ff_advanced_options_toolbar">
+            <div v-if="supportsGrouping" class="ff_advanced_options_toolbar__grouping">
+                <div class="ff_advanced_options_toolbar__grouping-copy">
+                    <span class="ff_advanced_options_toolbar__grouping-title">{{ $t('Enable Option Grouping') }}</span>
+                    <small class="ff_advanced_options_toolbar__grouping-help">{{ $t('Create labeled option sections for this field') }}</small>
+                </div>
+                <el-switch
+                    v-model="groupingEnabled"
+                    class="ff-switch-sm"
+                    active-color="#409EFF"
+                    inactive-color="#dcdfe6"
+                    @change="handleGroupingModeChange"
+                ></el-switch>
+            </div>
+
+            <div class="top-check-action">
                 <el-checkbox v-model="valuesVisible">{{ $t('Show Values') }}</el-checkbox>
                 <el-checkbox v-if="hasCalValue" v-model="editItem.settings.calc_value_status">{{ $t('Calc Values') }}</el-checkbox>
                 <template v-if="has_pro">
@@ -11,45 +27,173 @@
                     <el-checkbox v-model="pro_mock" @change="showProMessage()">{{ $t('Photo') }}</el-checkbox>
                 </template>
             </div>
-            <elLabel slot="label" :label="listItem.label" :helpText="listItem.help_text"></elLabel>
         </div>
 
-        <vddl-list :drop="handleDrop" v-if="optionsToRender.length" class="vddl-list__handle ff_advnced_options_wrap" :list="editItem.settings.advanced_options" :horizontal="false">
-            <vddl-draggable :moved="handleMoved" class="optionsToRender" v-for="(option, index) in editItem.settings.advanced_options" :key="option.id"
-                            :draggable="option"
-                            :index="index"
-                            :wrapper="editItem.settings.advanced_options"
-                            effect-allowed="move">
+        <vddl-list
+            v-if="groupingEnabled"
+            class="ff_option_groups_wrap"
+            :list="editItem.settings.advanced_options"
+            :horizontal="false"
+            :drop="handleDrop"
+        >
+            <vddl-draggable
+                v-for="(group, groupIndex) in groupedOptions"
+                :key="group.id || `group-${groupIndex}`"
+                :draggable="group"
+                :index="groupIndex"
+                :wrapper="editItem.settings.advanced_options"
+                :moved="handleMoved"
+                effect-allowed="move"
+                class="ff_option_group_drag"
+            >
+                <vddl-nodrag class="ff_option_group mb-3">
+                    <div class="ff_option_group__head">
+                        <div class="ff_option_group__head-main">
+                            <vddl-handle
+                                :handle-left="20"
+                                :handle-top="20"
+                                class="handle ff_option_group__handle"
+                            >
+                                <i class="el-icon-rank"></i>
+                            </vddl-handle>
+
+                            <button
+                                type="button"
+                                class="ff_option_group__toggle"
+                                @click.prevent="toggleGroup(group)"
+                            >
+                                <i :class="group.is_open === false ? 'el-icon-arrow-right' : 'el-icon-arrow-down'"></i>
+                            </button>
+
+                            <el-input
+                                :placeholder="$t('Group label')"
+                                v-model="group.label"
+                                class="ff_option_group__label"
+                            ></el-input>
+                        </div>
+
+                        <div class="ff_option_group__actions">
+                            <button
+                                type="button"
+                                class="ff_option_group__icon-btn ff_option_group__icon-btn--danger"
+                                @click.prevent="removeGroup(groupIndex)"
+                                :title="$t('Remove Group')"
+                            >
+                                <i class="el-icon-delete"></i>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div v-show="group.is_open !== false" class="ff_option_group__body">
+                        <div class="ff_option_group__rail"></div>
+
+                        <div class="ff_option_group__rows">
+                            <div
+                                v-for="(option, optionIndex) in group.options"
+                                :key="`group-${groupIndex}-option-${optionIndex}`"
+                                class="ff_option_group__row"
+                            >
+                                <div class="checkbox ff_option_group__default">
+                                    <input
+                                        class="form-control"
+                                        :type="optionsType"
+                                        name="fluentform__default-option"
+                                        :value="option.value"
+                                        :checked="isChecked(option.value)"
+                                        @change="updateDefaultOption(option, $event)"
+                                    >
+                                </div>
+
+                                <div class="ff_option_group__field ff_option_group__field--label">
+                                    <el-input
+                                        :placeholder="$t('label')"
+                                        v-model="option.label"
+                                        @input="updateValue(option, $event)"
+                                    ></el-input>
+                                </div>
+
+                                <div v-if="valuesVisible" class="ff_option_group__field ff_option_group__field--value">
+                                    <el-input :placeholder="$t('value')" v-model="option.value"></el-input>
+                                </div>
+
+                                <div v-if="editItem.settings.calc_value_status" class="ff_option_group__field ff_option_group__field--calc">
+                                    <el-input
+                                        :placeholder="$t('calc value')"
+                                        type="number"
+                                        step="any"
+                                        v-model="option.calc_value"
+                                    ></el-input>
+                                </div>
+
+                                <action-btn>
+                                    <action-btn-add @click="addOptionToGroup(groupIndex, optionIndex)" size="mini"></action-btn-add>
+                                    <action-btn-remove @click="removeGroupOption(groupIndex, optionIndex)" size="mini"></action-btn-remove>
+                                </action-btn>
+                            </div>
+                        </div>
+                    </div>
+                </vddl-nodrag>
+            </vddl-draggable>
+
+            <button
+                type="button"
+                class="ff_option_groups_wrap__add"
+                @click.prevent="addGroup()"
+            >
+                <i class="el-icon-circle-plus-outline"></i>
+                <span>{{ $t('Create New Option Group') }}</span>
+            </button>
+        </vddl-list>
+
+        <vddl-list
+            :drop="handleDrop"
+            v-else-if="optionsToRender.length"
+            class="vddl-list__handle ff_advnced_options_wrap"
+            :list="editItem.settings.advanced_options"
+            :horizontal="false"
+        >
+            <vddl-draggable
+                :moved="handleMoved"
+                class="optionsToRender"
+                v-for="(option, index) in editItem.settings.advanced_options"
+                :key="option.id || index"
+                :draggable="option"
+                :index="index"
+                :wrapper="editItem.settings.advanced_options"
+                effect-allowed="move"
+            >
                 <vddl-nodrag class="nodrag">
                     <div class="checkbox">
-                        <input ref="defaultOptions"
-                               class="form-control"
-                               :type="optionsType"
-                               name="fluentform__default-option"
-                               :value="option.value"
-                               :checked="isChecked(option.value)"
-                               @change="updateDefaultOption(option)"
+                        <input
+                            ref="defaultOptions"
+                            class="form-control"
+                            :type="optionsType"
+                            name="fluentform__default-option"
+                            :value="option.value"
+                            :checked="isChecked(option.value)"
+                            @change="updateDefaultOption(option, $event)"
                         >
                     </div>
 
                     <vddl-handle
-                            :handle-left="20"
-                            :handle-top="20"
-                            class="handle">
+                        :handle-left="20"
+                        :handle-top="20"
+                        class="handle"
+                    >
                     </vddl-handle>
 
                     <div
-                            style="max-width: 64px; max-height: 32px; overflow: hidden;"
-                            v-if="editItem.settings.enable_image_input && hasImageSupport"
+                        style="max-width: 64px; max-height: 32px; overflow: hidden;"
+                        v-if="editItem.settings.enable_image_input && hasImageSupport"
                     >
                         <photo-widget enable_clear="yes" v-model="option.image" :for_advanced_option="true" />
                     </div>
 
                     <div>
                         <el-input
-                                :placeholder="$t('label')"
-                                v-model="option.label"
-                                @input="updateValue(option)"
+                            :placeholder="$t('label')"
+                            v-model="option.label"
+                            @input="updateValue(option, $event)"
                         ></el-input>
                     </div>
 
@@ -59,14 +203,14 @@
 
                     <div v-if="editItem.settings.calc_value_status">
                         <el-input
-                                :placeholder="$t('calc value')"
-                                type="number"
-                                step="any"
-                                v-model="option.calc_value"
+                            :placeholder="$t('calc value')"
+                            type="number"
+                            step="any"
+                            v-model="option.calc_value"
                         ></el-input>
                     </div>
 
-                    <action-btn>
+                    <action-btn v-if="!isToggleField">
                         <action-btn-add @click="increase(index)" size="mini"></action-btn-add>
                         <action-btn-remove @click="decrease(index)" size="mini"></action-btn-remove>
                     </action-btn>
@@ -75,23 +219,23 @@
         </vddl-list>
 
         <el-button
-                type="warning"
-                size="mini"
-                :disabled="!editItem.attributes.value"
-                @click.prevent="clear"
+            type="warning"
+            size="mini"
+            :disabled="!editItem.attributes.value || (Array.isArray(editItem.attributes.value) && !editItem.attributes.value.length)"
+            @click.prevent="clear"
         >{{ $t('Clear Selection') }}</el-button>
 
         <el-button
-                size="mini"
-                @click="initBulkEdit()"
-                v-if="!editItem.settings.calc_value_status && !editItem.settings.enable_image_input"
+            size="mini"
+            @click="initBulkEdit()"
+            v-if="!groupingEnabled && !isToggleField && !editItem.settings.calc_value_status && !editItem.settings.enable_image_input"
         >{{ $t('Bulk Edit / Predefined Data Sets') }} </el-button>
 
         <el-dialog
-                :append-to-body="true"
-                class="ff_backdrop"
-                :visible.sync="bulkEditVisible"
-                width="60%"
+            :append-to-body="true"
+            class="ff_backdrop"
+            :visible.sync="bulkEditVisible"
+            width="60%"
         >
             <div slot="title">
                 <h4 class="mb-2">{{$t('Edit your options')}}</h4>
@@ -102,10 +246,10 @@
                     <el-col :span="24">
                         <ul class="ff_bulk_option_groups mb-3">
                             <li
-                                    @click="setOptions(options)"
-                                    v-for="(options, optionGroup) in editor_options"
-                                    :key="optionGroup"
-                                    :class="{ 'active': options === activeClass}"
+                                @click="setOptions(options)"
+                                v-for="(options, optionGroup) in editor_options"
+                                :key="optionGroup"
+                                :class="{ 'active': options === activeClass}"
                             >{{optionGroup}}</li>
                         </ul>
                     </el-col>
@@ -120,7 +264,6 @@
                 <el-button @click="bulkEditVisible = false" type="info" class="el-button--soft">{{ $t('Cancel') }}</el-button>
             </div>
         </el-dialog>
-
     </el-form-item>
 </template>
 
@@ -173,11 +316,9 @@
                     case 'multiselect':
                     case 'checkbox':
                         return 'checkbox'
-                        break;
                     case 'select':
                     case 'radio':
                         return 'radio'
-                        break;
                     default:
                         return 'radio'
                 }
@@ -187,11 +328,28 @@
             },
             valuesVisible:{
                 get() {
-                    return this.editItem.settings.values_visible||false;
+                    return this.editItem.settings.values_visible || false;
                 },
                 set(val) {
                     this.$set(this.editItem.settings, 'values_visible', val);
                 }
+            },
+            supportsGrouping() {
+                return this.editItem.element === 'select';
+            },
+            groupingEnabled: {
+                get() {
+                    return this.editItem.settings.enable_option_groups === 'yes';
+                },
+                set(value) {
+                    this.$set(this.editItem.settings, 'enable_option_groups', value ? 'yes' : 'no');
+                }
+            },
+            groupedOptions() {
+                return this.editItem.settings.advanced_options || [];
+            },
+            isToggleField() {
+                return this.editItem && this.editItem.element === 'input_toggle';
             },
         },
         methods: {
@@ -204,26 +362,23 @@
                 const { index, list } = item;
                 list.splice(index, 1);
             },
-
-            updateValue(currentOption) {
-                if(!this.valuesVisible) {
-                    currentOption.value = event.target.value;
+            updateValue(currentOption, value) {
+                if (!this.valuesVisible) {
+                    currentOption.value = value;
                 }
             },
-
             initBulkEdit() {
                 let astext = '';
-                each(this.editItem.settings.advanced_options, (item) => {
-					let label = item.label;
-					let value = item.value;
+                each(this.editItem.settings.advanced_options, item => {
+                    let label = item.label;
+                    let value = item.value;
 
-	                // Convert label, value ':' to escaped colons '\:'
-	                if (label.includes(':')) {
-		                label = label.replace(/:/g, '\\:');
-	                }
-					if (value.includes(':')) {
-						value = value.replace(/:/g, '\\:');
-	                }
+                    if (label.includes(':')) {
+                        label = label.replace(/:/g, '\\:');
+                    }
+                    if (value.includes(':')) {
+                        value = value.replace(/:/g, '\\:');
+                    }
 
                     astext += label;
                     if (item.label && item.label != item.value) {
@@ -234,29 +389,28 @@
                 this.value_key_pair_text = astext;
                 this.bulkEditVisible = true
             },
-
             confirmBulkEdit() {
                 let lines = this.value_key_pair_text.split('\n');
                 let values = [];
-                each(lines, (line) => {
-	                // Split by ':' but ignore escaped colons '\:'
-	                let lineItem = line.split(/(?<!\\):/);
+                each(lines, line => {
+                    let lineItem = line.split(/(?<!\\):/);
 
-	                // Convert label, value escaped colons '\:' to ':'
-	                let label = lineItem[0];
-					if (label) {
-						label = label.replace(/\\:/g, ':').trim();
-					}
-	                let value = lineItem[1];
-					if (value) {
-						value = value.replace(/\\:/g, ':').trim();
-					} else {
+                    let label = lineItem[0];
+                    if (label) {
+                        label = label.replace(/\\:/g, ':').trim();
+                    }
+                    let value = lineItem[1];
+                    if (value) {
+                        value = value.replace(/\\:/g, ':').trim();
+                    } else {
                         value = label;
                     }
                     if (label && value) {
                         values.push({
                             label: label,
-                            value: value
+                            value: value,
+                            calc_value: '',
+                            image: ''
                         });
                     }
                 });
@@ -264,38 +418,17 @@
                 this.editItem.settings.advanced_options = values;
                 this.bulkEditVisible = false
             },
-
             isChecked(optVal) {
                 if (Array.isArray(this.editItem.attributes.value)) {
                     return this.editItem.attributes.value.includes(optVal);
-                } else {
-                    return this.editItem.attributes.value == optVal;
                 }
-            },
 
+                return this.editItem.attributes.value == optVal;
+            },
             increase(index) {
                 let options = this.editItem.settings.advanced_options;
-
-                let keys = options.map(opt => {
-                    let value = opt.value;
-                    value = value.toString();
-                    let nums = value.match(/\d+/g);
-                    return nums && Number(nums.pop());
-                });
-                let key = Math.max(...keys.filter(i => i != 'undefined')) + 1;
-                let optionStr = `Item ${key}`;
-                let optionKey = optionStr.toLowerCase().replace(/\s/g, '_');
-
-                let newOpt = {
-                    label: optionStr,
-                    value: optionKey,
-                    calc_value: '',
-                    image: ''
-                };
-
-                options.splice(index + 1, 0, newOpt);
+                options.splice(index + 1, 0, this.createOption());
             },
-
             decrease(index) {
                 let options = this.editItem.settings.advanced_options;
                 if (options.length > 1) {
@@ -307,12 +440,10 @@
                     });
                 }
             },
-
             setOptions(options) {
                 this.value_key_pair_text = options.join('\n');
                 this.activeClass = options;
             },
-
             clear() {
                 let attributes = this.editItem.attributes;
 
@@ -321,39 +452,210 @@
                 } else {
                     attributes.value = '';
                 }
-                this.$refs.defaultOptions.map(el => el.checked = false);
-            },
 
-            updateDefaultOption(option) {
+                let defaultOptions = this.$refs.defaultOptions || [];
+                if (!Array.isArray(defaultOptions)) {
+                    defaultOptions = [defaultOptions];
+                }
+                defaultOptions.forEach(el => {
+                    if (el) {
+                        el.checked = false;
+                    }
+                });
+            },
+            updateDefaultOption(option, event) {
                 let attributes = this.editItem.attributes;
                 if (attributes.type == 'checkbox' || attributes.multiple) {
-                    if (event.target.checked) {
+                    if (!Array.isArray(attributes.value)) {
+                        this.$set(attributes, 'value', []);
+                    }
+
+                    if (event.target.checked && !attributes.value.includes(option.value)) {
                         attributes.value.push(option.value);
-                    } else {
+                    } else if (!event.target.checked) {
                         attributes.value.splice(attributes.value.indexOf(option.value), 1);
                     }
                 } else {
-                    if (event.target.checked) {
-                        attributes.value = option.value;
-                    } else {
-                        attributes.value = '';
-                    }
+                    attributes.value = event.target.checked ? option.value : '';
                 }
             },
-
             createOptionsToRender() {
                 this.optionsToRender = this.editItem.settings.advanced_options;
             },
             showProMessage() {
                 this.$notify.error('Images with options is available in the Pro version');
                 this.pro_mock = false;
+            },
+            createOption(optionNumber = null) {
+                if (!optionNumber) {
+                    optionNumber = this.flattenAdvancedOptions(this.editItem.settings.advanced_options || []).length + 1;
+                }
+
+                const optionLabel = `Option ${optionNumber}`;
+
+                return {
+                    label: optionLabel,
+                    value: optionLabel,
+                    calc_value: '',
+                    image: ''
+                };
+            },
+            createDefaultGroupOptions() {
+                const nextOptionNumber = this.flattenAdvancedOptions(this.editItem.settings.advanced_options || []).length + 1;
+
+                return [
+                    this.createOption(nextOptionNumber),
+                    this.createOption(nextOptionNumber + 1)
+                ];
+            },
+            createGroup(options = [], groupNumber = null) {
+                if (!groupNumber) {
+                    groupNumber = (this.editItem.settings.advanced_options || []).length + 1;
+                }
+
+                return {
+                    type: 'group',
+                    label: `Group ${groupNumber}`,
+                    is_open: true,
+                    options: options.length ? options : this.createDefaultGroupOptions()
+                };
+            },
+            createInitialGroupedOptions(options = []) {
+                let normalizedOptions = this.flattenAdvancedOptions(options || []).filter(Boolean);
+
+                while (normalizedOptions.length < 4) {
+                    normalizedOptions.push(this.createOption(normalizedOptions.length + 1));
+                }
+
+                const groups = [];
+                for (let i = 0; i < normalizedOptions.length; i += 2) {
+                    groups.push(this.createGroup(normalizedOptions.slice(i, i + 2), groups.length + 1));
+                }
+
+                return groups;
+            },
+            flattenAdvancedOptions(options) {
+                let flattened = [];
+
+                each(options, option => {
+                    if (option && option.type === 'group' && Array.isArray(option.options)) {
+                        flattened = flattened.concat(this.flattenAdvancedOptions(option.options));
+                        return;
+                    }
+
+                    flattened.push(option);
+                });
+
+                return flattened;
+            },
+            hasGroupedOptions(options) {
+                return (options || []).some(option => option && option.type === 'group' && Array.isArray(option.options));
+            },
+            handleGroupingModeChange(value) {
+                this.$set(this.editItem.settings, 'enable_option_groups', value ? 'yes' : 'no');
+
+                if (value) {
+                    if (!this.hasGroupedOptions(this.editItem.settings.advanced_options)) {
+                        const flattened = this.flattenAdvancedOptions(this.editItem.settings.advanced_options || []);
+                        this.$set(
+                            this.editItem.settings,
+                            'advanced_options',
+                            this.createInitialGroupedOptions(flattened)
+                        );
+                    }
+                } else {
+                    this.$set(
+                        this.editItem.settings,
+                        'advanced_options',
+                        this.flattenAdvancedOptions(this.editItem.settings.advanced_options || [])
+                    );
+                }
+
+                this.createOptionsToRender();
+            },
+            addGroup(index = null) {
+                const groups = this.editItem.settings.advanced_options || [];
+                const newGroup = this.createGroup();
+
+                if (index === null || index === undefined) {
+                    groups.push(newGroup);
+                } else {
+                    groups.splice(index + 1, 0, newGroup);
+                }
+            },
+            removeGroup(groupIndex) {
+                const groups = this.editItem.settings.advanced_options || [];
+
+                if (groups.length > 1) {
+                    groups.splice(groupIndex, 1);
+                    return;
+                }
+
+                this.$notify.error({
+                    message: 'You have to have at least one group.',
+                    offset: 30
+                });
+            },
+            addOptionToGroup(groupIndex, optionIndex = null) {
+                const group = this.editItem.settings.advanced_options[groupIndex];
+                if (!group || !Array.isArray(group.options)) {
+                    return;
+                }
+
+                const newOption = this.createOption();
+                if (optionIndex === null || optionIndex === undefined) {
+                    group.options.push(newOption);
+                } else {
+                    group.options.splice(optionIndex + 1, 0, newOption);
+                }
+            },
+            removeGroupOption(groupIndex, optionIndex) {
+                const group = this.editItem.settings.advanced_options[groupIndex];
+                if (!group || !Array.isArray(group.options)) {
+                    return;
+                }
+
+                if (group.options.length > 1) {
+                    group.options.splice(optionIndex, 1);
+                    return;
+                }
+
+                this.$notify.error({
+                    message: 'You have to have at least one option in a group.',
+                    offset: 30
+                });
+            },
+            toggleGroup(group) {
+                this.$set(group, 'is_open', group.is_open === false);
+            },
+            normalizeGroupingState() {
+                if (!this.supportsGrouping) {
+                    return;
+                }
+
+                if (this.hasGroupedOptions(this.editItem.settings.advanced_options || [])) {
+                    this.$set(this.editItem.settings, 'enable_option_groups', 'yes');
+                return;
             }
-        },
+
+            if (!this.editItem.settings.enable_option_groups) {
+                this.$set(this.editItem.settings, 'enable_option_groups', 'no');
+            }
+            each(this.editItem.settings.advanced_options || [], group => {
+                if (group && group.type === 'group' && typeof group.is_open === 'undefined') {
+                    this.$set(group, 'is_open', true);
+                }
+            });
+        }
+    },
         mounted() {
+            this.normalizeGroupingState();
             this.createOptionsToRender();
-            this.editItem.settings.advanced_options.forEach((item,i)=>{
-                item.id = i;
-            })
+            (this.editItem.settings.advanced_options || []).forEach((item, i) => {
+                if (!item.id) {
+                    item.id = i;
+                }
+            });
         }
     }
 </script>

--- a/resources/assets/admin/components/editor-field-settings/templates/conditionalLogics.vue
+++ b/resources/assets/admin/components/editor-field-settings/templates/conditionalLogics.vue
@@ -367,7 +367,7 @@
                             } else if (['input_radio', 'select', 'input_checkbox', 'dynamic_field'].includes(formItem.element)) {
                                 let options = formItem.options ? this.formatOptions(formItem.options) : null;
                                 if (!options) {
-                                    options = formItem.settings.advanced_options;
+                                    options = this.flattenAdvancedOptions(formItem.settings.advanced_options || []);
                                 }
 								if ('text' === formItem.attributes.type) {
 									options = null
@@ -570,6 +570,20 @@
                     label: value,
                     value: key
                 }));
+
+                return options;
+            },
+            flattenAdvancedOptions(items) {
+                let options = [];
+
+                each(items, item => {
+                    if (item && item.type === 'group' && Array.isArray(item.options)) {
+                        options = options.concat(this.flattenAdvancedOptions(item.options));
+                        return;
+                    }
+
+                    options.push(item);
+                });
 
                 return options;
             }

--- a/resources/assets/admin/components/templates/select.vue
+++ b/resources/assets/admin/components/templates/select.vue
@@ -17,9 +17,24 @@ export default {
     props: ['item'],
     computed :{
         defaultVal() {
-            let option = find(this.item.settings.advanced_options, { value: this.item.attributes.value });
+            let option = find(this.flattenedOptions, { value: this.item.attributes.value });
 
             return option ? option.label : null;
+        },
+        flattenedOptions() {
+            return this.flattenOptions(this.item.settings.advanced_options || []);
+        }
+    },
+    methods: {
+        flattenOptions(options) {
+            return options.reduce((formatted, option) => {
+                if (option && option.type === 'group' && Array.isArray(option.options)) {
+                    return formatted.concat(this.flattenOptions(option.options));
+                }
+
+                formatted.push(option);
+                return formatted;
+            }, []);
         }
     },
     components: {

--- a/resources/assets/admin/styles/editor.scss
+++ b/resources/assets/admin/styles/editor.scss
@@ -147,6 +147,184 @@
       margin-bottom: 10px;
     }
 
+    .ff_option_groups_wrap {
+      max-height: 520px;
+      overflow-y: auto;
+      margin-bottom: 12px;
+
+      &__add {
+        width: 100%;
+        padding: 8px;
+        border: 2px dashed #dfe6f1;
+        border-radius: 14px;
+        background: #f9fbff;
+        color: #8a98ad;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        font-size: 14px;
+        cursor: pointer;
+        transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+
+        &:hover {
+          border-color: #b9c8dd;
+          color: #55657f;
+          background: #f5f8fd;
+        }
+
+        i {
+          font-size: 24px;
+        }
+      }
+    }
+
+    .ff_option_group_drag {
+      margin-bottom: 16px;
+    }
+
+    .ff_option_group {
+      display: block !important;
+      border: 1px solid #dfe6f1;
+      border-radius: 14px;
+      background: #fff;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(15, 23, 42, 0.04);
+
+      &__head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 8px;
+        border-bottom: 1px solid #edf2f7;
+      }
+
+      &__head-main {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      &__handle {
+        flex: 0 0 auto;
+        width: 28px;
+        height: 28px;
+        border-radius: 8px;
+        background: transparent;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        color: #8a98ad;
+        cursor: move;
+
+        &:hover {
+          background: #f5f8fd;
+          color: #42526b;
+        }
+
+        i {
+          font-size: 18px;
+          line-height: 1;
+        }
+      }
+
+      &__toggle,
+      &__icon-btn {
+        width: 24px;
+        height: 24px;
+        border: 0;
+        background: transparent;
+        color: #718096;
+        border-radius: 8px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background-color 0.2s ease, color 0.2s ease;
+
+        &:hover {
+          background: #f5f8fd;
+          color: #42526b;
+        }
+
+        i {
+          font-size: 18px;
+        }
+      }
+
+      &__icon-btn--danger:hover {
+        color: #d64545;
+        background: #fff4f4;
+      }
+
+      &__label {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      &__actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex: 0 0 auto;
+      }
+
+      &__body {
+        display: flex;
+        gap: 12px;
+        padding: 8px;
+      }
+
+      &__rail {
+        width: 2px;
+        background: #dbe7f5;
+        border-radius: 999px;
+        flex: 0 0 2px;
+      }
+
+      &__rows {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+
+      &__row {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        background: #fff;
+        border: 1px solid #edf2f7;
+        border-radius: 12px;
+        padding: 8px;
+        margin-bottom: 12px;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+      }
+
+      &__default {
+        flex: 0 0 auto;
+      }
+
+      &__field {
+        flex: 1 1 0;
+        min-width: 0;
+        margin-right: 0 !important;
+
+        &--label {
+          flex: 1.5 1 0;
+        }
+
+        &--value,
+        &--calc {
+          max-width: 220px;
+        }
+      }
+    }
+
     .ff_validation_rule_warp {
       padding: 10px;
       border-radius: 5px;
@@ -670,17 +848,63 @@ div.mce-inline-toolbar-grp.mce-arrow-up,
   }
 }
 
-.pull-right.top-check-action {
-  >label {
-    margin-right: 10px;
+.ff_advanced_options_form_item {
+  .el-form-item__content {
+    width: 100%;
+  }
+}
 
-    &:last-child {
-      margin-right: 0px;
-    }
+.ff_advanced_options_toolbar {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+  margin-bottom: 14px;
+
+  &__grouping {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 12px 14px;
+    border: 1px solid #dfe6f1;
+    border-radius: 12px;
+    background: #f9fbff;
+  }
+
+  &__grouping-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  &__grouping-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: #2f3a4c;
+    line-height: 1.3;
+  }
+
+  &__grouping-help {
+    font-size: 12px;
+    color: #7f8ca1;
+    line-height: 1.4;
+  }
+}
+
+.top-check-action {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px 16px;
+
+  > label {
+    margin-right: 0;
   }
 
   span.el-checkbox__label {
-    padding-left: 3px;
+    padding-left: 6px;
   }
 }
 
@@ -808,20 +1032,6 @@ mark {
 
 .optionsToRender {
   margin: 7px 0;
-}
-
-.pull-right.top-check-action {
-  >label {
-    margin-right: 10px;
-
-    &:last-child {
-      margin-right: 0px;
-    }
-  }
-
-  span.el-checkbox__label {
-    padding-left: 3px;
-  }
 }
 
 .item_desc textarea {

--- a/resources/assets/admin/styles/entries.scss
+++ b/resources/assets/admin/styles/entries.scss
@@ -596,6 +596,48 @@ ul.entry_item_list {
   list-style-type: disc;
 }
 
+.wpf_entry_grouped_response {
+  white-space: normal;
+  word-break: break-word;
+
+  .entry_item_list {
+    margin: 0;
+  }
+}
+
+.entry_item_group {
+  padding-left: 12px;
+  border-left: 2px solid #dbe7f5;
+  margin-bottom: 12px;
+  white-space: normal;
+  word-break: break-word;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &__label {
+    font-weight: 600;
+    color: #2f3a4c;
+    margin-bottom: 6px;
+  }
+}
+
+.wpf_entry_group_value {
+  line-height: 1.6;
+  white-space: normal;
+  word-break: break-word;
+}
+
+.wpf_entry_value {
+  .wpf_entry_grouped_response,
+  .entry_item_group,
+  .entry_item_list {
+    white-space: normal;
+    word-break: break-word;
+  }
+}
+
 .star_big {
   font-size: 20px;
   display: inline-block;

--- a/resources/assets/admin/views/EditEntry.vue
+++ b/resources/assets/admin/views/EditEntry.vue
@@ -238,12 +238,26 @@
                 let options = element.options;
                 if(!options) {
                     let formattedOptions = {};
-                    each(element.settings.advanced_options, (optionItem) => {
+                    each(this.flattenAdvancedOptions(element.settings.advanced_options || []), (optionItem) => {
                         formattedOptions[optionItem.value] = optionItem.label;
                     });
                     return formattedOptions;
                 }
                 return options;
+            },
+            flattenAdvancedOptions(options) {
+                let flattened = [];
+
+                each(options, option => {
+                    if (option && option.type === 'group' && Array.isArray(option.options)) {
+                        flattened = flattened.concat(this.flattenAdvancedOptions(option.options));
+                        return;
+                    }
+
+                    flattened.push(option);
+                });
+
+                return flattened;
             }
         }
     }

--- a/resources/assets/admin/views/Entry.vue
+++ b/resources/assets/admin/views/Entry.vue
@@ -87,7 +87,7 @@
                                                 </template>
                                                 <template
                                                     v-else-if="['input_checkbox', 'select'].indexOf(formFields[label_index]['element']) != -1">
-                                                    <div class="wpf_entry_value" v-html="maybeExtractCommaArrayInfo(entry.user_inputs[label_index], formFields[label_index]['raw'])"></div>
+                                                    <div class="wpf_entry_value" v-html="maybeExtractCommaArrayInfo(entry.user_inputs[label_index], formFields[label_index]['raw'], original_data[label_index])"></div>
                                                 </template>
                                                 <template v-else>
                                                     <div class="wpf_entry_value" v-html="entry.user_inputs[label_index]"></div>
@@ -449,7 +449,12 @@
             explodeFileUrls(value, chunkSize = 4) {
                 return value ? _ff.chunk(value.split(', '), chunkSize) : [];
             },
-            maybeExtractCommaArrayInfo(dataValue, field) {
+            maybeExtractCommaArrayInfo(dataValue, field, rawValue = null) {
+
+                const groupedHtml = this.renderGroupedEntryValue(field, rawValue, dataValue);
+                if (groupedHtml) {
+                    return groupedHtml;
+                }
 
                 if (typeof dataValue == 'string' && field.element == 'input_checkbox') {
                     return dataValue;
@@ -480,7 +485,7 @@
                     let advancedOptions = field.settings.advanced_options;
                     if(advancedOptions) {
                         options = {};
-                        each(advancedOptions, (optionItem) => {
+                        each(this.flattenAdvancedOptions(advancedOptions), (optionItem) => {
                             options[optionItem.value] = optionItem.label;
                         });
                     }
@@ -503,8 +508,158 @@
                 itemHtml += '</ul>';
                 return itemHtml;
             },
+            renderGroupedEntryValue(field, rawValue, fallbackValue) {
+                if (!this.hasGroupedAdvancedOptions(field)) {
+                    return '';
+                }
+
+                const selectedValues = this.normalizeEntryValues(rawValue, fallbackValue, field);
+
+                if (!selectedValues.length) {
+                    return '';
+                }
+
+                let groupsHtml = '';
+                let matchedStandaloneOptions = [];
+                let matchedGroupedValues = [];
+                let matchedStandaloneValues = [];
+
+                each(field.settings.advanced_options || [], optionItem => {
+                    if (!optionItem) {
+                        return;
+                    }
+
+                    if (optionItem.type !== 'group' || !Array.isArray(optionItem.options)) {
+                        if (selectedValues.includes(String(optionItem.value))) {
+                            matchedStandaloneOptions.push(optionItem.label || optionItem.value);
+                            matchedStandaloneValues.push(String(optionItem.value));
+                        }
+
+                        return;
+                    }
+
+                    let matchedOptions = [];
+
+                    each(optionItem.options, option => {
+                        if (!option) {
+                            return;
+                        }
+
+                        if (selectedValues.includes(String(option.value))) {
+                            matchedOptions.push(option.label || option.value);
+                            matchedGroupedValues.push(String(option.value));
+                        }
+                    });
+
+                    if (!matchedOptions.length) {
+                        return;
+                    }
+
+                    let matchedHtml = '';
+                    if (matchedOptions.length === 1) {
+                        matchedHtml = `<div class="wpf_entry_group_value">${this.escapeEntryHtml(matchedOptions[0])}</div>`;
+                    } else {
+                        matchedHtml = '<ul class="entry_item_list">';
+                        each(matchedOptions, optionLabel => {
+                            matchedHtml += `<li>${this.escapeEntryHtml(optionLabel)}</li>`;
+                        });
+                        matchedHtml += '</ul>';
+                    }
+
+                    groupsHtml += `
+                        <div class="entry_item_group">
+                            <div class="entry_item_group__label">${this.escapeEntryHtml(optionItem.label || 'Group')}</div>
+                            ${matchedHtml}
+                        </div>
+                    `;
+                });
+
+                const unmatchedStandaloneValues = selectedValues.filter(value => {
+                    if (matchedGroupedValues.includes(value)) {
+                        return false;
+                    }
+
+                    return !matchedStandaloneValues.includes(value);
+                });
+
+                each(unmatchedStandaloneValues, value => {
+                    matchedStandaloneOptions.push(value);
+                });
+
+                let standaloneHtml = '';
+
+                if (matchedStandaloneOptions.length === 1) {
+                    standaloneHtml = `<div class="wpf_entry_group_value">${this.escapeEntryHtml(matchedStandaloneOptions[0])}</div>`;
+                } else if (matchedStandaloneOptions.length > 1) {
+                    standaloneHtml = '<ul class="entry_item_list">';
+                    each(matchedStandaloneOptions, optionLabel => {
+                        standaloneHtml += `<li>${this.escapeEntryHtml(optionLabel)}</li>`;
+                    });
+                    standaloneHtml += '</ul>';
+                }
+
+                if (!groupsHtml && !standaloneHtml) {
+                    return '';
+                }
+
+                return `<div class="wpf_entry_grouped_response">${standaloneHtml}${groupsHtml}</div>`;
+            },
+            normalizeEntryValues(rawValue, fallbackValue, field) {
+                let values = [];
+
+                if (Array.isArray(rawValue)) {
+                    values = rawValue;
+                } else if (typeof rawValue === 'string' && rawValue) {
+                    if (field.element === 'select' && field.attributes && !field.attributes.multiple) {
+                        values = [rawValue];
+                    } else {
+                        values = rawValue.split(',');
+                    }
+                } else if (Array.isArray(fallbackValue)) {
+                    values = fallbackValue;
+                } else if (typeof fallbackValue === 'string' && fallbackValue) {
+                    if (field.element === 'select' && field.attributes && !field.attributes.multiple) {
+                        values = [fallbackValue];
+                    } else {
+                        values = fallbackValue.split(',');
+                    }
+                }
+
+                return values
+                    .map(value => String(value).trim())
+                    .filter(Boolean);
+            },
+            hasGroupedAdvancedOptions(field) {
+                const advancedOptions = field && field.settings && field.settings.advanced_options;
+
+                return Array.isArray(advancedOptions) && advancedOptions.some(option => {
+                    return option && option.type === 'group' && Array.isArray(option.options);
+                });
+            },
+            escapeEntryHtml(value) {
+                return String(value)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+            },
             dataType(data) {
                 return typeof data;
+            },
+            flattenAdvancedOptions(items) {
+                let options = [];
+
+                each(items, item => {
+                    if (item && item.type === 'group' && Array.isArray(item.options)) {
+                        options = options.concat(this.flattenAdvancedOptions(item.options));
+                        return;
+                    }
+
+                    options.push(item);
+                });
+
+                return options;
             },
             prettifyJson(entry) {
                 let data = {

--- a/resources/assets/admin/views/EntryEditor/RepeatField.vue
+++ b/resources/assets/admin/views/EntryEditor/RepeatField.vue
@@ -15,12 +15,26 @@
 			                v-if="fieldItem.attributes.type === 'select'"
 			                v-model="model[rowIndex][fieldIndex]" size="mini"
 		                >
-			                <el-option
-				                v-for="option in fieldItem.settings.advanced_options"
-				                :key="option.value"
-				                :label="option.label"
-				                :value="option.value">
-			                </el-option>
+			                <template v-for="(option, optionIndex) in fieldItem.settings.advanced_options">
+			                    <el-option-group
+				                    v-if="isOptionGroup(option)"
+				                    :key="`group-${optionIndex}`"
+				                    :label="option.label"
+			                    >
+				                    <el-option
+					                    v-for="groupOption in option.options"
+					                    :key="groupOption.value"
+					                    :label="groupOption.label"
+					                    :value="groupOption.value">
+				                    </el-option>
+			                    </el-option-group>
+			                    <el-option
+				                    v-else
+				                    :key="option.value"
+				                    :label="option.label"
+				                    :value="option.value">
+			                    </el-option>
+			                </template>
 		                </el-select>
 	                    <el-input
 		                    v-else
@@ -72,6 +86,9 @@
             },
             initNewRow() {
                 this.model = [new Array(this.field.raw.fields.length).fill('')];
+            },
+            isOptionGroup(option) {
+                return option && option.type === 'group' && Array.isArray(option.options);
             }
         },
         computed: {


### PR DESCRIPTION
## What does this PR do and why?

Adds option grouping support for `Dropdown` and `Multiselect` fields in the free plugin.

This introduces an opt-in grouped option editor flow for select-based fields, persists grouped `advanced_options`, renders grouped frontend selects with native `optgroup` markup, and keeps submission parsing, validation, conditional logic, entry rendering, and conversational conversion aligned with the grouped option shape.

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/21109-Feature%3A-Dropdown-option-group

Companion PRs:
- Pro: https://github.com/fluentform/fluentformpro/pull/168
- Conversational: https://github.com/WPManageNinja/fluent-conversational-js/pull/37

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Conversational repo

## Changes

- Adds grouped option helpers in `app/Helpers/Helper.php` for grouped option detection, sanitization, flattening, and value-label mapping.
- Adds save-time sanitization for grouped `advanced_options` through `fluentform_options_sanitize`, including flattening nested subgroup rows into the supported one-level structure.
- Adds an opt-in `Enable Option Grouping` switch for `select` and `multi_select` and updates the advanced options editor UI to manage groups and grouped child options.
- Renders grouped select options through native `optgroup` markup in `app/Services/FormBuilder/Components/Select.php`.
- Updates select-related admin preview, conditional logic option lookups, repeat entry editing, parser/extractor flows, and entry detail rendering to work with grouped options.
- Preserves grouped structure when preparing dropdown data for conversational forms and syncs the rebuilt conversational assets used by the free plugin.
- Keeps legacy flat option behavior unchanged when option grouping is disabled.

## How to test

1. Create a form with a `Dropdown` field.
2. Open field settings and enable `Enable Option Grouping`.
3. Verify the editor initializes with two groups and grouped child options.
4. Add, rename, reorder, collapse, and delete groups and child options.
5. Save the form and verify the frontend renders grouped dropdown choices under native optgroup labels.
6. Submit values from grouped dropdown and grouped multiselect fields.
7. Verify entry detail rendering shows grouped responses correctly, including mixed grouped and standalone options if present.
8. Add conditional logic against grouped dropdown values and verify the matched leaf options still resolve correctly.
9. Open the same form in conversational mode and verify grouped dropdown data is available there as well.

## Anything the reviewer should know?

- Grouping is opt-in and defaults to off.
- The persisted grouped option shape supports one visible grouping level. Any malformed nested subgroup rows are flattened during sanitization so saved data matches the current renderer support.
- This PR includes rebuilt admin and conversational assets required by the source changes.
