### PR TITLE
Fix: Preserve custom CSS and JS during form import

### DIFF
--- a/app/Modules/Form/Transfer.php
+++ b/app/Modules/Form/Transfer.php
@@ -3,6 +3,7 @@
 namespace FluentForm\App\Modules\Form;
 
 use FluentForm\App\Helpers\Helper;
+use FluentForm\App\Services\Transfer\TransferService;
 use FluentForm\Framework\Foundation\Application;
 use FluentForm\Framework\Helpers\ArrayHelper;
 use FluentForm\Framework\Http\Request\File;
@@ -113,10 +114,14 @@ class Transfer
 
                     if (isset($formItem['metas'])) {
                         foreach ($formItem['metas'] as $metaData) {
+                            $metaKey = sanitize_text_field(ArrayHelper::get($metaData, 'meta_key'));
                             $settings = [
                                 'form_id'  => $formId,
-                                'meta_key' => $metaData['meta_key'],
-                                'value'    => $metaData['value'],
+                                'meta_key' => $metaKey,
+                                'value'    => TransferService::sanitizeImportedMetaValue(
+                                    $metaKey,
+                                    ArrayHelper::get($metaData, 'value')
+                                ),
                             ];
                             wpFluent()->table('fluentform_form_meta')->insert($settings);
                         }

--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -20,6 +20,23 @@ use FluentForm\Framework\Support\Arr;
 
 class TransferService
 {
+    public static function sanitizeImportedMetaValue($metaKey, $metaValue)
+    {
+        if (!is_string($metaValue)) {
+            return $metaValue;
+        }
+
+        if ($metaKey === '_custom_form_css') {
+            return fluentformSanitizeCSS($metaValue);
+        }
+
+        if ($metaKey === '_custom_form_js') {
+            return fluentform_kses_js($metaValue);
+        }
+
+        return wp_kses_post($metaValue);
+    }
+
     public static function exportForms($formIds)
     {
         $result = Form::with(['formMeta'])
@@ -98,9 +115,7 @@ class TransferService
                             if ("ffc_form_settings_generated_css" == $metaKey || "ffc_form_settings_meta" == $metaKey) {
                                 $metaValue = str_replace('ff_conv_app_' . Arr::get($formItem, 'id'), 'ff_conv_app_' . $formId, $metaValue);
                             }
-                            if (is_string($metaValue)) {
-                                $metaValue = wp_kses_post($metaValue);
-                            }
+                            $metaValue = static::sanitizeImportedMetaValue($metaKey, $metaValue);
                             $settings = [
                                 'form_id'  => $formId,
                                 'meta_key' => $metaKey,


### PR DESCRIPTION
## What does this PR do and why?

Fixes a form import regression where Custom CSS and Custom JS meta can be corrupted during import.

The current importer applies `wp_kses_post()` to all string form meta values. That hardening is reasonable for generic HTML-like meta, but it is too broad for `_custom_form_css` and `_custom_form_js`, which already have dedicated sanitizers. As a result, importing a form can mutate code content, including replacing or stripping characters such as `>` inside CSS selectors and JavaScript expressions.

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/21108-Import-problem-%3A-the-%22%3E%22-char-

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Conversational repo

## Changes

- Adds a shared import-time meta sanitizer in `app/Services/Transfer/TransferService.php`.
- Uses `fluentformSanitizeCSS()` for `_custom_form_css`.
- Uses `fluentform_kses_js()` for `_custom_form_js`.
- Keeps `wp_kses_post()` for other imported string meta values.
- Mirrors the same behavior in the deprecated importer at `app/Modules/Form/Transfer.php` so both import paths remain consistent.

## How to test

1. Export a form that contains Custom CSS and Custom JS.
2. Make sure the CSS or JS contains characters such as `>`.
3. Import the form on Fluent Forms `6.2.2`.
4. Open the imported form's `Custom CSS & JS` settings.
5. Verify the CSS and JS content matches the exported file exactly.

Additional verified repro cases:

1. Imported `/Users/dhrupo/Downloads/fluentform-export-forms-1-27-04-2026--.json` through the real `TransferService::importForms()` path.
2. Before this fix:
   - CSS `>` characters were stored as `&gt;`
   - JS `>` characters were stored as `&gt;`
3. After this fix:
   - CSS imports unchanged
   - JS imports unchanged

And also:

1. Imported `/Users/dhrupo/Downloads/fluentform-export-forms-1-29-04-2026.json` exported from Fluent Forms `6.2.2`.
2. Before this fix:
   - CSS in that file happened to stay unchanged because it did not contain `>`
   - JS `console.log('<', '>');` was corrupted to `console.log('');`
3. After this fix:
   - CSS imports unchanged
   - JS imports unchanged

## Anything the reviewer should know?

- This keeps the import hardening for generic meta intact.
- The fix only narrows handling for the two code-based meta keys that already have dedicated sanitization paths.
- No asset rebuild is required.
