### PR TITLE
Add: Adds short Entry ID shortcode {submission.entry_uid}

### DIFF
--- a/app/Services/FormBuilder/EditorShortCode.php
+++ b/app/Services/FormBuilder/EditorShortCode.php
@@ -86,7 +86,7 @@ class EditorShortCode
             '{submission.status}'         => __('Submission Status', 'fluentform'),
             '{submission.created_at}'     => __('Submission Create Date', 'fluentform'),
             '{submission.admin_view_url}' => __('Submission Admin View URL', 'fluentform'),
-            '{submission.entry_uid}'      => __('Entry ID', 'fluentform'),
+            '{submission.entry_uid}'      => __('Entry Unique ID', 'fluentform'),
         ];
 
         if ($form) {

--- a/app/Services/FormBuilder/EditorShortCode.php
+++ b/app/Services/FormBuilder/EditorShortCode.php
@@ -86,6 +86,7 @@ class EditorShortCode
             '{submission.status}'         => __('Submission Status', 'fluentform'),
             '{submission.created_at}'     => __('Submission Create Date', 'fluentform'),
             '{submission.admin_view_url}' => __('Submission Admin View URL', 'fluentform'),
+            '{submission.entry_uid}'      => __('Entry ID', 'fluentform'),
         ];
 
         if ($form) {

--- a/app/Services/FormBuilder/ShortCodeParser.php
+++ b/app/Services/FormBuilder/ShortCodeParser.php
@@ -380,8 +380,7 @@ class ShortCodeParser
         if ('admin_view_url' == $key) {
             return admin_url('admin.php?page=fluent_forms&route=entries&form_id=' . $entry->form_id . '#/entries/' . $entry->id);
         } elseif ('entry_uid' == $key) {
-            $meta = SubmissionMeta::retrieve('_entry_uid_hash', $entry->id);
-            return $meta ? substr($meta, 0, 12) : '';
+            return static::getShortEntryUid($entry);
         } elseif ('entry_uid_link' == $key) {
             return static::getEntryUidLink($entry);
         } elseif (false !== strpos($key, 'meta.')) {
@@ -657,6 +656,22 @@ class ShortCodeParser
 
         // Generate the link
         return site_url('?ff_entry=1&hash=' . $meta->value);
+    }
+
+    protected static function getShortEntryUid($entry)
+    {
+        if (empty($entry->id)) {
+            return '';
+        }
+
+        $entryId = strtoupper(base_convert((string) absint($entry->id), 10, 36));
+        $entryHash = SubmissionMeta::retrieve('_entry_uid_hash', $entry->id);
+
+        if (!$entryHash) {
+            return $entryId;
+        }
+
+        return $entryId . '-' . strtoupper(substr($entryHash, 0, 4));
     }
 
     public static function resetData()

--- a/app/Services/FormBuilder/ShortCodeParser.php
+++ b/app/Services/FormBuilder/ShortCodeParser.php
@@ -379,6 +379,9 @@ class ShortCodeParser
         }
         if ('admin_view_url' == $key) {
             return admin_url('admin.php?page=fluent_forms&route=entries&form_id=' . $entry->form_id . '#/entries/' . $entry->id);
+        } elseif ('entry_uid' == $key) {
+            $meta = SubmissionMeta::retrieve('_entry_uid_hash', $entry->id);
+            return $meta ? substr($meta, 0, 12) : '';
         } elseif ('entry_uid_link' == $key) {
             return static::getEntryUidLink($entry);
         } elseif (false !== strpos($key, 'meta.')) {


### PR DESCRIPTION
 Introduces a compact, user-friendly Entry ID shortcode
  for emails, SMS, and webhooks. The value is generated
  from the submission’s database ID in Base36 with a short
  hash suffix, giving a stable reference format such as
  3FK-7224 without adding schema changes.

  - Add {submission.entry_uid} shortcode for compact entry
  references
  - Use Base36 submission ID plus a short stored-hash
  suffix for stable output
  - No DB schema changes; remains backward compatible with
  existing entry UID hash storage