### PR TITLE
Feature: support ranking field quiz

### DIFF
--- a/resources/assets/admin/components/settings/QuizInput.vue
+++ b/resources/assets/admin/components/settings/QuizInput.vue
@@ -1,20 +1,80 @@
 <template>
     <div class="quiz-field-container">
-        <div class="quiz-field">
-            <div class="quiz-field-setting">
+        <div class="quiz-field quiz-field--header">
+            <div class="quiz-field-setting quiz-field-setting--switch">
                 <el-switch v-model="input.enabled"/>
             </div>
-            <div class="quiz-field-setting">
+            <div class="quiz-field-setting quiz-field-setting--title">
                 {{ original_input.label }}
             </div>
-            <div class="quiz-field-setting"  v-if="input.enabled == true && hasOptions(input) && !is_personality_quiz" >
+            <div class="quiz-field-setting quiz-field-setting--scoring-toggle"  v-if="input.enabled == true && hasOptions(input) && !is_personality_quiz" >
                 <el-checkbox true-label="yes" false-label="no" v-model="input.has_advance_scoring">
                     {{ $t('Advance Scoring') }}
                 </el-checkbox>
             </div>
         </div>
+        <div v-if="input.enabled == true && is_personality_quiz && isRankingInput(input.element)" class="quiz-field quiz-field--ranking">
+            <div class="quiz-field-setting quiz-field-setting--ranking-order">
+                <div class="lead-title mb-2">{{ $t('Personality Score By Position') }}</div>
+                <div class="ff-ranking-quiz-order">
+                    <div
+                        v-for="(value, index) in input.correct_answer"
+                        :key="index"
+                        class="ff-ranking-quiz-order__row"
+                    >
+                        <span class="ff-ranking-quiz-order__position">{{ index + 1 }}</span>
+                        <span class="ff-ranking-quiz-order__item">{{ getRankingLabel(value) }}</span>
+                        <el-input-number
+                            size="small"
+                            v-model="input.personality_points[index]"
+                            controls-position="right"
+                            :min="0"
+                            :max="100"
+                        />
+                    </div>
+                </div>
+                <small class="text-muted mt-2">{{ $t('The personality value placed in each rank will receive that position score. Default scores are assigned from highest rank to lowest rank.') }}</small>
+            </div>
+        </div>
         <transition name="slide-down">
-            <div v-if="input.enabled == true && input.has_advance_scoring == 'no' && !is_personality_quiz" class="quiz-field">
+            <div v-if="input.enabled == true && input.has_advance_scoring == 'no' && !is_personality_quiz && isRankingInput(input.element)" class="quiz-field quiz-field--ranking">
+                <div class="quiz-field-setting">
+                    <div class="lead-title mb-2">{{ $t('Score') }}</div>
+                    <el-input-number size="small" v-model="input.points" controls-position="right" :min="1" :max="100"></el-input-number>
+                </div>
+                <div class="quiz-field-setting quiz-field-setting--ranking-order">
+                    <div class="lead-title mb-2">{{ $t('Correct Ranking') }}</div>
+                    <div class="ff-ranking-quiz-order">
+                        <div
+                            v-for="(value, index) in input.correct_answer"
+                            :key="index"
+                            class="ff-ranking-quiz-order__row"
+                        >
+                            <span class="ff-ranking-quiz-order__position">{{ index + 1 }}</span>
+                            <span class="ff-ranking-quiz-order__item">{{ getRankingLabel(value) }}</span>
+                            <div class="ff-ranking-quiz-order__actions">
+                                <el-button
+                                    size="mini"
+                                    icon="el-icon-arrow-up"
+                                    :aria-label="$t('Move up')"
+                                    :title="$t('Move up')"
+                                    @click="moveRankingItem(index, -1)"
+                                    :disabled="index === 0"
+                                />
+                                <el-button
+                                    size="mini"
+                                    icon="el-icon-arrow-down"
+                                    :aria-label="$t('Move down')"
+                                    :title="$t('Move down')"
+                                    @click="moveRankingItem(index, 1)"
+                                    :disabled="index === input.correct_answer.length - 1"
+                                />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div v-else-if="input.enabled == true && input.has_advance_scoring == 'no' && !is_personality_quiz" class="quiz-field">
                 <div class="quiz-field-setting">
                     <div class="lead-title mb-2">{{ $t('Score') }}</div>
                     <el-input-number size="small" v-model="input.points" controls-position="right" :min="1" :max="100"></el-input-number>
@@ -71,9 +131,53 @@
                 </div>
             </div>
         </transition>
-        <transition v-if="input.has_advance_scoring == 'yes'">
+        <transition v-if="input.enabled == true && input.has_advance_scoring == 'yes' && !is_personality_quiz">
             <div>
-                <span v-for="(item, key) in original_input.options" class="quiz-field" :key="key">
+                <div
+                    v-if="input.enabled == true && !is_personality_quiz && isRankingInput(input.element)"
+                    class="quiz-field quiz-field--ranking"
+                >
+                    <div class="quiz-field-setting quiz-field-setting--ranking-order">
+                        <div class="lead-title mb-2">{{ $t('Scored Ranking') }}</div>
+                        <div class="ff-ranking-quiz-order">
+                            <div
+                                v-for="(value, index) in input.correct_answer"
+                                :key="index"
+                                class="ff-ranking-quiz-order__row"
+                            >
+                                <span class="ff-ranking-quiz-order__position">{{ index + 1 }}</span>
+                                <span class="ff-ranking-quiz-order__item">{{ getRankingLabel(value) }}</span>
+                                <el-input-number
+                                    size="small"
+                                    v-model="input.advance_points[value]"
+                                    controls-position="right"
+                                    :min="0"
+                                    :max="100"
+                                />
+                                <div class="ff-ranking-quiz-order__actions">
+                                    <el-button
+                                        size="mini"
+                                        icon="el-icon-arrow-up"
+                                        :aria-label="$t('Move up')"
+                                        :title="$t('Move up')"
+                                        @click="moveRankingItem(index, -1)"
+                                        :disabled="index === 0"
+                                    />
+                                    <el-button
+                                        size="mini"
+                                        icon="el-icon-arrow-down"
+                                        :aria-label="$t('Move down')"
+                                        :title="$t('Move down')"
+                                        @click="moveRankingItem(index, 1)"
+                                        :disabled="index === input.correct_answer.length - 1"
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                        <small class="text-muted mt-2">{{ $t('Points are awarded when the option is placed in the configured position.') }}</small>
+                    </div>
+                </div>
+                <span v-else v-for="(item, key) in original_input.options" class="quiz-field" :key="key">
                     <div  class="quiz-field-setting">
                        <el-input-number
                             size="small"
@@ -92,6 +196,16 @@
 </template>
 
 <script>
+const rankingQuizStrings = [
+    'Personality Score By Position',
+    'The personality value placed in each rank will receive that position score. Default scores are assigned from highest rank to lowest rank.',
+    'Correct Ranking',
+    'Move up',
+    'Move down',
+    'Scored Ranking',
+    'Points are awarded when the option is placed in the configured position.'
+];
+
 export default {
     name: "QuizInput",
     props: {
@@ -115,38 +229,144 @@ export default {
             },
         }
     },
+    computed: {
+        rankingOptions() {
+            return this.original_input.options || {};
+        }
+    },
     methods: {
         isRadioInput(key) {
             let selectAbleFields = ['input_radio'];
             return selectAbleFields.includes(key) ? true : false;
+        },
+        isRankingInput(key) {
+            return key === 'input_ranking';
         },
         ifNeedsCondition(key) {
             let textInput = ['input_text', 'input_date', 'rangeslider', 'input_number', 'select', 'input_checkbox'];
             return textInput.includes(key) ? true : false;
         },
         resetValue(input) {
-            this.$refs.resetInput.selectedLabel = '';
+            if (this.$refs.resetInput && this.$refs.resetInput.selectedLabel !== undefined) {
+                this.$refs.resetInput.selectedLabel = '';
+            }
             input.correct_answer = null;
         },
         isMultiple(item) {
             return item.condition == 'equal' ? false : true;
         },
-        setDefaultPoints(){
-            let isEmpty = Object.keys(this.input.advance_points).length === 0;
-            if (isEmpty){
-                this.input.advance_points = this.original_input.advance_points
+        moveRankingItem(index, direction) {
+            if (!this.isRankingInput(this.input.element)) {
+                return;
             }
+
+            const targetIndex = index + direction;
+            if (targetIndex < 0 || targetIndex >= this.input.correct_answer.length) {
+                return;
+            }
+
+            const correctAnswer = [...this.input.correct_answer];
+            const currentValue = correctAnswer[index];
+            correctAnswer.splice(index, 1);
+            correctAnswer.splice(targetIndex, 0, currentValue);
+            this.$set(this.input, 'correct_answer', correctAnswer);
+        },
+        getRankingLabel(value) {
+            return this.rankingOptions[value] || value;
+        },
+        getRankingOptionKey(value) {
+            return String(value);
+        },
+        setDefaultPoints(){
+            const defaultPoints = this.original_input.advance_points || {};
+            const currentPoints = this.input.advance_points || {};
+            const formattedPoints = {};
+
+            Object.keys(defaultPoints).forEach(key => {
+                formattedPoints[key] = currentPoints[key] !== undefined ? currentPoints[key] : defaultPoints[key];
+            });
+
+            this.$set(this.input, 'advance_points', formattedPoints);
+        },
+        setDefaultPersonalityPoints() {
+            if (!this.isRankingInput(this.input.element)) {
+                return;
+            }
+
+            const optionCount = Object.keys(this.rankingOptions).length;
+            const currentPoints = this.input.personality_points || {};
+            const formattedPoints = {};
+
+            for (let index = 0; index < optionCount; index++) {
+                const fallbackScore = Math.max(optionCount - index, 0);
+                formattedPoints[index] = currentPoints[index] !== undefined ? currentPoints[index] : fallbackScore;
+            }
+
+            this.$set(this.input, 'personality_points', formattedPoints);
+        },
+        syncRankingAnswer() {
+            if (!this.isRankingInput(this.input.element)) {
+                return;
+            }
+
+            const optionKeys = Object.keys(this.rankingOptions);
+            const optionKeySet = new Set(optionKeys);
+            const currentAnswer = Array.isArray(this.input.correct_answer)
+                ? this.input.correct_answer.map(value => this.getRankingOptionKey(value))
+                : [];
+            const normalizedAnswer = [];
+            const usedValues = new Set();
+
+            currentAnswer.forEach(value => {
+                if (!optionKeySet.has(value) || usedValues.has(value)) {
+                    return;
+                }
+
+                usedValues.add(value);
+                normalizedAnswer.push(value);
+            });
+
+            optionKeys.forEach(key => {
+                if (usedValues.has(key)) {
+                    return;
+                }
+
+                usedValues.add(key);
+                normalizedAnswer.push(key);
+            });
+
+            const hasChanged = normalizedAnswer.length !== currentAnswer.length ||
+                normalizedAnswer.some((value, index) => currentAnswer[index] !== value);
+
+            if (hasChanged || !Array.isArray(this.input.correct_answer)) {
+                this.$set(this.input, 'correct_answer', normalizedAnswer);
+            }
+
+            this.$set(this.input, 'condition', 'list_match');
         },
         hasOptions(item){
-           return Object.keys(this.input.advance_points).length !== 0;
+           return Object.keys(item.options || this.rankingOptions || this.input.advance_points || {}).length !== 0;
         }
 
+    },
+    watch: {
+        'original_input.options': {
+            handler() {
+                this.setDefaultPoints();
+                this.setDefaultPersonalityPoints();
+                this.syncRankingAnswer();
+            },
+            deep: true
+        }
     },
     mounted() {
         if (!this.input.has_advance_scoring){
             this.$set(this.input, 'has_advance_scoring', 'no');
         }
+        rankingQuizStrings.forEach(string => this.$t(string));
         this.setDefaultPoints();
+        this.setDefaultPersonalityPoints();
+        this.syncRankingAnswer();
     }
 }
 </script>

--- a/resources/assets/admin/components/settings/QuizSettings.vue
+++ b/resources/assets/admin/components/settings/QuizSettings.vue
@@ -60,10 +60,41 @@
                                     </table>
                                 </el-form-item>
                                 <el-form-item :label="$t('Quiz Questions')" class="quiz-questions ff-form-item">
-                                    <p v-if="resultType == 'personality'">{{ $t('Personality quiz has no right or wrong answer, just enable the questions. Make sure the answers value match with the personality options values. That is all.') }}</p>
+                                    <p v-if="resultType == 'personality'">{{ $t('Personality quiz has no right or wrong answer. Enable the questions and make sure the answer values match the personality option values. Ranking questions use position-based scores, so the value placed higher can contribute more to the final result.') }}</p>
                                     <template v-if="quizFields">
-                                        <div v-for="(input, key) in quizFields" :key="key">
-                                            <quiz-input :input="getInput(key)" :original_input="quizFields[key]" :is_personality_quiz="resultType =='personality'"></quiz-input>
+                                        <div v-if="regularQuizFieldEntries.length" class="quiz-question-section">
+                                            <div class="quiz-question-section__title">{{ $t('Standard Questions') }}</div>
+                                            <div
+                                                v-for="([key, input]) in regularQuizFieldEntries"
+                                                :key="key"
+                                                class="quiz-question-section__item"
+                                            >
+                                                <quiz-input
+                                                    :input="getInput(key)"
+                                                    :original_input="input"
+                                                    :is_personality_quiz="resultType =='personality'"
+                                                ></quiz-input>
+                                            </div>
+                                        </div>
+                                        <div v-if="rankingQuizFieldEntries.length" class="quiz-question-section quiz-question-section--ranking">
+                                            <div class="quiz-question-section__title">{{ $t('Ranking Questions') }}</div>
+                                            <p class="quiz-question-section__description" v-if="resultType == 'personality'">
+                                                {{ $t('Ranking questions award the configured position score to the personality value placed in each rank. Higher ranks can contribute more points by default, and you can adjust each position score if needed.') }}
+                                            </p>
+                                            <p class="quiz-question-section__description" v-else>
+                                                {{ $t('Ranking questions use an ordered answer. Normal scoring requires the full order to match, and advanced scoring awards points only when an option is placed in its configured position.') }}
+                                            </p>
+                                            <div
+                                                v-for="([key, input]) in rankingQuizFieldEntries"
+                                                :key="key"
+                                                class="quiz-question-section__item quiz-question-section__item--ranking"
+                                            >
+                                                <quiz-input
+                                                    :input="getInput(key)"
+                                                    :original_input="input"
+                                                    :is_personality_quiz="resultType =='personality'"
+                                                ></quiz-input>
+                                            </div>
                                         </div>
                                     </template>
                                 </el-form-item>
@@ -135,14 +166,38 @@
                 deleting: false,
                 settings: false,
                 loading: false,
-                resultType: '',
                 settingsFields: [],
                 quizFields: {},
                 errors: new Errors()
             }
         },
-        computed: {},
+        computed: {
+            resultType() {
+                return this.settings ? this.settings.result_type : '';
+            },
+            regularQuizFieldEntries() {
+                if (!this.quizFields) {
+                    return [];
+                }
+
+                return Object.entries(this.quizFields).filter(([, input]) => {
+                    return !this.isRankingField(input);
+                });
+            },
+            rankingQuizFieldEntries() {
+                if (!this.quizFields) {
+                    return [];
+                }
+
+                return Object.entries(this.quizFields).filter(([, input]) => {
+                    return this.isRankingField(input);
+                });
+            }
+        },
         methods: {
+            isRankingField(input) {
+                return input && input.element === 'input_ranking';
+            },
             getInput(key) {
                 if (this.settings.saved_quiz_fields[key]) {
                     return this.settings.saved_quiz_fields[key];
@@ -160,7 +215,6 @@
                         this.settings = response.data.settings;
                         this.quizFields = response.data.quiz_fields;
                         this.settingsFields = response.data.settings_fields;
-                        this.resultType = response.data.settings.result_type;
                     })
                     .fail(error => {
                     })

--- a/resources/assets/admin/css/settings_global.scss
+++ b/resources/assets/admin/css/settings_global.scss
@@ -829,30 +829,173 @@ ul.fcc_inline_social {
 }
 
 .ff-quiz-settings-wrapper {
-  .quiz-field {
-    display: flex;
-    margin-bottom: 15px;
-    align-items: center;
-    &-setting {
-      padding-right: 10px;
-      display: flex;
-      flex-direction: column;
+  .quiz-questions {
+    > p {
+      margin: 0 0 16px;
+      color: #606266;
+      line-height: 1.6;
     }
   }
-  .quiz-questions > div {
-    .quiz-field-container {
-      border: 1px solid #efefef;
-      border-bottom: none;
-      padding: 10px;
+
+  .quiz-question-section {
+    padding: 18px 20px 20px;
+    border: 1px solid #ebeef5;
+    border-radius: 10px;
+    background: #fff;
+
+    & + .quiz-question-section {
+      margin-top: 20px;
     }
-    > div {
-      &:last-child {
-        .quiz-field-container {
-          border-bottom: 1px solid #efefef;
+
+    &__title {
+      margin-bottom: 6px;
+      color: #303133;
+      font-size: 16px;
+      font-weight: 700;
+    }
+
+    &__description {
+      margin: 0 0 16px;
+      color: #606266;
+      line-height: 1.5;
+    }
+
+    &--ranking {
+      background: #fcfdff;
+      border-color: #dfe8f7;
+    }
+  }
+
+  .quiz-field {
+    display: flex;
+    margin-bottom: 16px;
+    align-items: center;
+    gap: 12px;
+
+    &--header {
+      margin-bottom: 12px;
+      padding-bottom: 12px;
+      border-bottom: 1px solid #f2f4f7;
+    }
+
+    &--ranking {
+      align-items: flex-start;
+    }
+
+    &-setting {
+      display: flex;
+      flex-direction: column;
+
+      &--switch {
+        flex: 0 0 auto;
+      }
+
+      &--title {
+        flex: 0 1 auto;
+        color: #303133;
+        font-size: 15px;
+        font-weight: 600;
+      }
+
+      &--scoring-toggle {
+        flex: 0 0 auto;
+      }
+
+      &--ranking-order {
+        min-width: 0;
+        flex: 1 1 420px;
+      }
+    }
+  }
+
+  .ff-ranking-quiz-order {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+
+    &__row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      border: 1px solid #ebeef5;
+      border-radius: 8px;
+      background: #fff;
+    }
+
+    &__position {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: #f2f6fc;
+      color: #606266;
+      font-weight: 600;
+      flex: 0 0 28px;
+    }
+
+    &__item {
+      flex: 1 1 auto;
+      min-width: 180px;
+      color: #303133;
+      font-weight: 500;
+      line-height: 1.4;
+    }
+
+    &__actions {
+      display: inline-flex;
+      gap: 8px;
+      margin-left: auto;
+    }
+  }
+
+  @media (max-width: 960px) {
+    .quiz-field {
+      &--header,
+      &--ranking {
+        flex-wrap: wrap;
+      }
+
+      &-setting {
+        &--ranking-order,
+        &--scoring-toggle {
+          width: 100%;
         }
       }
     }
 
+    .ff-ranking-quiz-order {
+      &__row {
+        flex-wrap: wrap;
+      }
+
+      &__item {
+        min-width: 0;
+      }
+
+      &__actions {
+        width: 100%;
+        margin-left: 0;
+        justify-content: flex-end;
+      }
+    }
+  }
+
+  .quiz-questions > div {
+    .quiz-field-container {
+      border: 1px solid #eef1f6;
+      border-bottom: none;
+      padding: 14px 16px;
+      background: #fff;
+    }
+
+    .quiz-question-section__item:last-child {
+      .quiz-field-container {
+        border-bottom: 1px solid #eef1f6;
+      }
+    }
   }
 }
 

--- a/resources/assets/admin/views/EntryEditor/RankingField.vue
+++ b/resources/assets/admin/views/EntryEditor/RankingField.vue
@@ -55,6 +55,33 @@ export default {
         }
     },
     methods: {
+        parseCurrentValue() {
+            if (Array.isArray(this.value)) {
+                return {
+                    values: this.value.map(String),
+                    shouldSync: true
+                };
+            }
+
+            if (typeof this.value === 'string' && this.value) {
+                try {
+                    const parsedValue = JSON.parse(this.value);
+                    if (Array.isArray(parsedValue)) {
+                        return {
+                            values: parsedValue.map(String),
+                            shouldSync: true
+                        };
+                    }
+                } catch (e) {
+                    // Ignore invalid string payloads and avoid rewriting them on open.
+                }
+            }
+
+            return {
+                values: [],
+                shouldSync: false
+            };
+        },
         flattenOptions(options) {
             const flattened = [];
 
@@ -80,29 +107,47 @@ export default {
                 (((this.field || {}).raw || {}).settings || {}).advanced_options || []
             );
             const options = optionItems.reduce((formatted, option) => {
-                formatted[option.value] = option.label || option.value;
+                formatted[String(option.value)] = option.label || option.value;
                 return formatted;
             }, {});
-            const currentValue = Array.isArray(this.value) ? this.value.slice() : [];
-            const items = [];
+            const optionValues = Object.keys(options);
+            const optionValueSet = new Set(optionValues);
+            const currentValueState = this.parseCurrentValue();
+            const currentValue = currentValueState.values;
+            const normalizedValues = [];
+            const usedValues = new Set();
 
             currentValue.forEach(value => {
-                items.push({
-                    value,
-                    label: options[value] || value
-                });
-            });
-
-            Object.keys(options).forEach(value => {
-                if (!currentValue.includes(value)) {
-                    items.push({
-                        value,
-                        label: options[value] || value
-                    });
+                if (!optionValueSet.has(value) || usedValues.has(value)) {
+                    return;
                 }
+
+                usedValues.add(value);
+                normalizedValues.push(value);
             });
 
-            this.orderedItems = items;
+            const displayValues = normalizedValues.slice();
+
+            optionValues.forEach(value => {
+                if (usedValues.has(value)) {
+                    return;
+                }
+
+                usedValues.add(value);
+                displayValues.push(value);
+            });
+
+            this.orderedItems = displayValues.map(value => ({
+                value,
+                label: options[value] || value
+            }));
+
+            const hasChanged = normalizedValues.length !== currentValue.length ||
+                normalizedValues.some((value, index) => currentValue[index] !== value);
+
+            if (currentValueState.shouldSync && currentValue.length && hasChanged) {
+                this.$emit('input', normalizedValues);
+            }
         },
         move(index, delta) {
             const targetIndex = index + delta;


### PR DESCRIPTION
## What does this PR do and why?

This stacked PR adds ranking-field quiz support in the free plugin builder layer. It introduces ranking-specific quiz settings UI, improves ranking answer normalization in quiz settings, and hardens the ranking entry editor behavior so existing saved values are not silently rewritten.

Related issue: N/A

Parent PR: https://github.com/fluentform/fluentform/pull/912
Reciprocal PR: https://github.com/fluentform/fluentformpro/pull/172

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] Vue — QuizInput.vue: add ranking-specific quiz and personality position scoring UI
- [x] Vue — QuizSettings.vue: group ranking quiz questions and update ranking quiz copy
- [x] SCSS — settings_global.scss: improve ranking quiz settings layout and responsive behavior
- [x] Vue — EntryEditor/RankingField.vue: preserve existing ranking entry values and avoid silent rewrites

## How to test

1. Open quiz settings for a form containing a ranking field.
2. Verify normal quiz mode shows ranking-specific correct-order and advanced scoring controls.
3. Verify personality quiz mode shows position-based ranking score inputs.
4. Save and reopen quiz settings with numeric-valued ranking options and confirm the configured order persists.
5. Open an entry with an existing ranking value and confirm the editor does not rewrite the saved order on open.

## Anything the reviewer should know?

This is a stacked PR on top of the main ranking field branch and only contains the follow-up free-side quiz/editor changes.