### PR TITLE
Fix: Excel export creation date format

### DIFF
--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -540,14 +540,36 @@ class TransferService
         }
         $writer->openToBrowser($fileName);
 
-        // Convert data arrays to Row objects for OpenSpout v3
-        $rows = array_map(function ($rowData) {
-            return \OpenSpout\Writer\Common\Creator\WriterEntityFactory::createRowFromArray($rowData);
-        }, $data);
+        $rows = self::getOfficeDocRows($data, $type);
 
         $writer->addRows($rows);
         $writer->close();
         die();
+    }
+
+    private static function getOfficeDocRows($data, $type)
+    {
+        if (strtolower($type) !== 'xlsx') {
+            return array_map(function ($rowData) {
+                return \OpenSpout\Writer\Common\Creator\WriterEntityFactory::createRowFromArray($rowData);
+            }, $data);
+        }
+
+        $dateStyle = (new \OpenSpout\Writer\Common\Creator\Style\StyleBuilder())
+            ->setFormat('yyyy-mm-dd hh:mm:ss')
+            ->build();
+
+        return array_map(function ($rowData) use ($dateStyle) {
+            $cells = array_map(function ($cellValue) use ($dateStyle) {
+                if ($cellValue instanceof \DateTimeInterface) {
+                    return \OpenSpout\Writer\Common\Creator\WriterEntityFactory::createCell($cellValue, $dateStyle);
+                }
+
+                return \OpenSpout\Writer\Common\Creator\WriterEntityFactory::createCell($cellValue);
+            }, $rowData);
+
+            return \OpenSpout\Writer\Common\Creator\WriterEntityFactory::createRow($cells);
+        }, $data);
     }
 
 }


### PR DESCRIPTION
## What does this PR do and why?

Fixes XLSX entry export so the submission creation date renders as a readable timestamp in Excel instead of a raw serial number like `46046.4471875`.

The export was still including `created_at`, but OpenSpout was receiving it as a DateTime object and writing it as an Excel date serial without an explicit spreadsheet date format. Excel then displayed the raw number, which made it look like the creation date was missing or broken.

Related Issue: https://lounge.authlab.io/projects#/boards/16/tasks/21137-Creation-Date-Missing-in-Excel

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — `app/Services/Transfer/TransferService.php`
- [x] Keep CSV and ODS export behavior unchanged
- [x] Apply an explicit XLSX date format for DateTime export values

## How to test

1. Go to form entries export and choose Excel format.
2. Include the default export fields so `created_at` is exported.
3. Download the XLSX file and open it in Excel or Numbers.
4. Verify the `created_at` column shows a readable date/time instead of a raw numeric serial.
5. Re-run CSV and ODS export and confirm they behave exactly as before.

## Verification

- `php -l app/Services/Transfer/TransferService.php`
- inspected the generated XLSX XML and confirmed the `created_at` cell now uses an explicit date style instead of the default general style
- confirmed CSV/ODS paths still use the existing row-building flow unchanged

## Anything the reviewer should know?

The fix is intentionally scoped to the XLSX writer path only. It does not change field selection, entry query logic, or non-spreadsheet export formats.