### PR TITLE
Fix: Preserve JSON escapes when importing form meta

### DIFF
--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -34,7 +34,31 @@ class TransferService
             return fluentform_kses_js($metaValue);
         }
 
+        $decoded = json_decode($metaValue);
+        if (is_array($decoded) || is_object($decoded)) {
+            self::sanitizeJsonNode($decoded);
+            $encoded = wp_json_encode($decoded);
+            return $encoded ?: $metaValue;
+        }
+
         return wp_kses_post($metaValue);
+    }
+
+    private static function sanitizeJsonNode(&$node)
+    {
+        if (is_array($node)) {
+            foreach ($node as &$value) {
+                self::sanitizeJsonNode($value);
+            }
+            unset($value);
+        } elseif (is_object($node)) {
+            foreach (get_object_vars($node) as $key => $value) {
+                self::sanitizeJsonNode($value);
+                $node->{$key} = $value;
+            }
+        } elseif (is_string($node)) {
+            $node = wp_kses_post($node);
+        }
     }
 
     public static function exportForms($formIds)


### PR DESCRIPTION
## What does this PR do and why?

Form import silently corrupted three meta types whenever the source contained HTML with quoted attributes — `formSettings` (confirmation messages disappeared), `notifications` (emails stopped firing, shown as disabled in the UI), and `double_optin_settings` (opt-in flow broken). The importer ran `wp_kses_post()` on the encoded JSON blob, which stripped the backslash escapes JSON uses to embed `"` inside string values; the payload then failed `json_decode()` and FluentForm fell back to defaults with no warning to the admin.

This change decodes meta values first, recursively sanitizes only string leaves, then re-encodes — preserving JSON validity and original hardening. Decoding without `assoc` keeps object-vs-array shape, so `{}` round-trips correctly.

Fixes: https://lounge.authlab.io/projects#/boards/16/tasks/21148-Form-Export/Import-Corrupts-JS
Fixes: https://support.wpmanageninja.com/#/tickets/157964/view

## Changes

- Decode JSON-encoded form meta before sanitizing, so `wp_kses_post()` runs on string leaves not the JSON envelope
- Preserve object-vs-array distinction (decode without `assoc`, walk arrays and `stdClass`)
- Keep dedicated handlers for `_custom_form_css` and `_custom_form_js`; fall back to `wp_kses_post()` for non-JSON strings

## How to test

1. On site A, edit a form. In **Settings → Confirmation Settings → Confirmation Message** paste HTML with a quoted attribute, e.g. `<a href="https://example.com">Back</a>`. Save.
2. Add an enabled notification whose body contains a quoted attribute, e.g. `<a href="mailto:hello@example.com">hello@example.com</a>`. Save.
3. **Forms → Export**, download JSON. On site B, **Forms → Import**, upload it.
4. Submit the imported form. Verify:
   - Confirmation message renders (not an empty form reload).
   - The notification email arrives.
   - `JSON_VALID(value) = 1` for `formSettings`, `notifications`, `double_optin_settings` rows in `wp_fluentform_form_meta`.
5. Round-trip a meta value of `{}` — confirm it stays `{}`, not `[]`.