### PR TITLE
Fix: preserve multilingual export filenames

### DIFF
--- a/app/Services/Transfer/TransferService.php
+++ b/app/Services/Transfer/TransferService.php
@@ -299,7 +299,7 @@ class TransferService
         $data = array_merge([array_values($inputLabels)], $exportData);
         
         $data = apply_filters('fluentform/export_data', $data, $form, $exportData, $inputLabels);
-        $fileName = sanitize_title($form->title, 'export', 'view') . '-' . date('Y-m-d');
+        $fileName = self::getReadableExportFileName($form->title);
         self::downloadOfficeDoc($data, $type, $fileName);
     }
 
@@ -461,10 +461,33 @@ class TransferService
         foreach ($submissions as $submission) {
             $submission->response = json_decode($submission->response, true);
         }
-        header('Content-disposition: attachment; filename=' . sanitize_title($form->title, 'export', 'view') . '-' . date('Y-m-d') . '.json');
-        header('Content-type: application/json');
+        self::sendDownloadHeaders('application/json', self::getReadableExportFileName($form->title) . '.json');
         echo json_encode($submissions); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $submissions is escaped before being passed in.
         exit();
+    }
+
+    private static function getReadableExportFileName($formTitle)
+    {
+        $sanitizedTitle = sanitize_file_name(wp_strip_all_tags((string) $formTitle));
+
+        if (!$sanitizedTitle) {
+            $sanitizedTitle = 'export';
+        }
+
+        return $sanitizedTitle . '-' . date('Y-m-d');
+    }
+
+    private static function sendDownloadHeaders($contentType, $fileName)
+    {
+        $safeFileName = basename((string) $fileName);
+        $encodedFileName = rawurlencode($safeFileName);
+
+        header('Content-Type: ' . $contentType);
+        header(
+            'Content-Disposition: attachment; ' .
+            'filename="' . $encodedFileName . '"; ' .
+            'filename*=UTF-8\'\'' . $encodedFileName
+        );
     }
 
     private static function getSubmissions($args)


### PR DESCRIPTION
## What does this PR do and why?

This fixes entry export filenames when a form title contains Japanese or other non-Latin characters.

The bug was caused by using `sanitize_title()` when building export filenames. That slugifies multilingual titles into percent-encoded strings like `%e5%96...`, so downloaded CSV/XLSX/ODS filenames appear garbled instead of readable.

This PR switches entry export filename generation to `sanitize_file_name()` on the original form title, which keeps readable multilingual characters while still stripping unsafe filename characters.

It also fixes the JSON entry export header so it uses an RFC 6266-compatible `Content-Disposition` format with both `filename` and `filename*`, matching the UTF-8-safe download behavior used by the spreadsheet export path.

**Related Issue:** https://lounge.authlab.io/projects#/boards/16/tasks/21142-CSV-export-filename-URL-encode

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — `app/Services/Transfer/TransferService.php`: replace `sanitize_title()`-based entry export filenames with readable filename sanitization using `sanitize_file_name()`
- [x] PHP — `app/Services/Transfer/TransferService.php`: add a shared download header helper for JSON exports so non-ASCII filenames are sent with `filename` and `filename*`

## How to test

1. Create or use a form with a multilingual title such as `営業担当者シート`
2. Go to the Entries screen for that form
3. Export entries as CSV, XLSX, ODS, and JSON
4. Verify the downloaded filename is readable, for example `営業担当者シート-YYYY-MM-DD.csv`, instead of a percent-encoded slug
5. Confirm ASCII titles still download normally and unsafe filename characters are stripped safely

## Verification

- `php -l app/Services/Transfer/TransferService.php`
- Verified filename generation locally for multilingual titles and unsafe-character cases
- Confirmed the old path produced `%e5%96...` while the new path produces readable filenames like `営業担当者シート-2026-05-05.csv`

## Anything the reviewer should know?

This change only affects entry export download filenames and JSON export headers. It does not change the export data content itself.