### PR TITLE
Fix: hide file upload interface setting for conversational forms

### DIFF
--- a/app/Services/FluentConversational/Classes/Converter/Converter.php
+++ b/app/Services/FluentConversational/Classes/Converter/Converter.php
@@ -402,6 +402,7 @@ class Converter
                 $question['dateCustomConfig'] = $dateField->getCustomConfig($field['settings']);
             } elseif (in_array($field['element'], ['input_image', 'input_file'])) {
                 $question['multiple'] = true;
+                $question['btn_text'] = ArrayHelper::get($field, 'settings.btn_text', __('Choose File', 'fluentform'));
                 
                 $maxFileCount = ArrayHelper::get($field, 'settings.validation_rules.max_file_count');
                 $maxFileSize = ArrayHelper::get($field, 'settings.validation_rules.max_file_size');

--- a/resources/assets/admin/components/editor-field-settings/FieldOptionsSettings.vue
+++ b/resources/assets/admin/components/editor-field-settings/FieldOptionsSettings.vue
@@ -297,6 +297,7 @@ export default {
             let unsupportedSettings = [
                 // 'conditional_logics',
                 'label_placement',
+                'upload_bttn_ui',
                 // 'calculation_settings',
                 'prefix_label',
                 'suffix_label',


### PR DESCRIPTION
## What does this PR do and why?

This PR removes the file upload interface mode from conversational-form editing so users cannot configure a setting that conversational rendering does not support.

Conversational forms always behave like the default file upload experience, but the editor was still exposing the Upload Button Interface option. That created a mismatch between what the editor allowed and what conversational forms actually rendered.

**Related issue:** https://lounge.authlab.io/projects#/boards/16/tasks/9022-Issue-with-File-Upload-Button-

## Scope

- [x] Free plugin
- [ ] Pro plugin

## Changes

- [x] PHP — `app/Services/FluentConversational/Classes/Converter/Converter.php`
  Keeps conversational file-upload questions on the supported default behavior by not forwarding the upload interface mode.
- [x] Vue — `resources/assets/admin/components/editor-field-settings/FieldOptionsSettings.vue`
  Hides the `upload_bttn_ui` setting when the current form is conversational.

## How to test

1. Open a regular form in the editor.
2. Edit a File Upload or Image Upload field.
3. Verify the Upload Button Interface setting is still visible.
4. Open a conversational form in the editor.
5. Edit a File Upload or Image Upload field.
6. Verify the Upload Button Interface setting is not shown.
7. Save the conversational form and preview it.
8. Verify the file upload field still renders and works normally.

## Anything the reviewer should know?

This change intentionally avoids changing conversational frontend rendering behavior. It only removes an unsupported editor option and keeps the converter aligned with that restriction.