### PR TITLE
REFACT: Polish advanced filter UX 

### DIFF
--- a/app/Services/FormBuilder/EditorShortCode.php
+++ b/app/Services/FormBuilder/EditorShortCode.php
@@ -77,16 +77,16 @@ class EditorShortCode
     public static function getSubmissionShortcodes($form = false)
     {
         $submissionProperties = [
+            '{submission.serial_number}'  => __('#Submission Serial Number', 'fluentform'),
             '{submission.id}'             => __('Submission ID', 'fluentform'),
-            '{submission.serial_number}'  => __('Submission Serial Number', 'fluentform'),
-            '{submission.source_url}'     => __('Source URL', 'fluentform'),
             '{submission.user_id}'        => __('User Id', 'fluentform'),
+            '{submission.entry_uid}'      => __('Entry Unique ID', 'fluentform'),
+            '{submission.source_url}'     => __('Source URL', 'fluentform'),
             '{submission.browser}'        => __('Submitter Browser', 'fluentform'),
             '{submission.device}'         => __('Submitter Device', 'fluentform'),
             '{submission.status}'         => __('Submission Status', 'fluentform'),
             '{submission.created_at}'     => __('Submission Create Date', 'fluentform'),
             '{submission.admin_view_url}' => __('Submission Admin View URL', 'fluentform'),
-            '{submission.entry_uid}'      => __('Entry Unique ID', 'fluentform'),
         ];
 
         if ($form) {

--- a/resources/assets/admin/styles/entries.scss
+++ b/resources/assets/admin/styles/entries.scss
@@ -889,13 +889,19 @@ span.ff_tag {
   border-radius: 8px;
   box-shadow: 0px 1px 3px rgba(30, 31, 33, 0.08);
   margin-bottom: 20px;
-  padding: 5px 10px 5px;
+  padding: 12px;
 
   .ff_rich_filters{
     padding: 10px;
     background: #fdfdfd;
-    border: 1px solid #efefef;
-    border-radius: 4px;
+    border: 1px solid #e4e7ed;
+    border-radius: 6px;
+    transition: border-color 0.15s ease;
+
+    &:hover {
+      border-color: #c6d4e1;
+    }
+
     .ff_table{
       background: #f0f3f7;
       border: 1px solid #dedcdc;
@@ -906,6 +912,7 @@ span.ff_tag {
     }
   }
   .ff_cond_or {
+    // Legacy "OR" used elsewhere; keep minimal so it doesn't break other contexts
     border-bottom: 1px dashed #d5dce1;
     margin: 0 0 15px;
     color: gray;
@@ -921,5 +928,178 @@ span.ff_tag {
       position: relative;
       top: 9px;
     }
+  }
+
+  .ff_filter_group_wrap {
+    position: relative;
+    margin-bottom: 4px;
+
+    &:last-of-type {
+      margin-bottom: 12px;
+    }
+  }
+
+  .fc_rich_filter {
+    position: relative;
+  }
+
+  .ff_filter_group_actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding: 6px 8px 2px;
+    border-top: 1px dashed #e4e7ed;
+    margin-top: 4px;
+
+    .el-button {
+      font-size: 12px;
+    }
+  }
+
+  .ff_filter_modified_dot {
+    margin-left: 6px;
+    font-size: 9px;
+    color: #ffd54f;
+    line-height: 1;
+    vertical-align: middle;
+  }
+
+  // OR separator drawn between two existing filter groups (non-clickable)
+  .ff_or_separator {
+    position: relative;
+    text-align: center;
+    height: 1px;
+    background: #e4e7ed;
+    margin: 14px 0;
+
+    span {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #fff;
+      padding: 2px 12px;
+      color: #1565C9;
+      font-weight: 700;
+      font-size: 12px;
+      letter-spacing: 0.5px;
+    }
+  }
+
+  .ff_cond_or_wrap {
+    display: flex;
+    justify-content: center;
+    margin: 8px 0 4px;
+  }
+
+  .ff_add_or_group_btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    background: #fff;
+    color: #1565C9;
+    border: 1px dashed #1565C9;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+
+    &:hover {
+      background: #E8F2FF;
+      border-style: solid;
+    }
+
+    .el-icon-plus {
+      font-size: 13px;
+      font-weight: 700;
+    }
+  }
+
+  // Soft blue Add button used in empty filter group state
+  .el-button.blue-soft {
+    background-color: #E8F2FF;
+    border-color: #E8F2FF;
+    color: #1565C9;
+
+    &:hover,
+    &:focus {
+      background-color: #1565C9;
+      border-color: #1565C9;
+      color: #fff;
+    }
+  }
+}
+
+// Applied filters summary chips above the entries table
+.ff_applied_filters_summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #f4f8fb;
+  border: 1px solid #dfe6ef;
+  border-left: 3px solid #1565C9;
+  border-radius: 4px;
+  margin-bottom: 16px;
+
+  .ff_applied_filters_label {
+    font-weight: 600;
+    color: #303133;
+    margin-right: 4px;
+
+    .el-icon-search {
+      margin-right: 4px;
+      color: #1565C9;
+    }
+  }
+
+  .ff_filter_chip {
+    margin-right: 4px;
+
+    .ff_filter_item_text {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+
+      em {
+        font-style: normal;
+        font-weight: 500;
+        color: #1565C9;
+      }
+    }
+  }
+
+  .ff_filter_or_separator {
+    font-weight: 700;
+    color: #1565C9;
+    font-size: 12px;
+    padding: 0 4px;
+  }
+
+  .ff_filter_and_separator {
+    color: #909399;
+    font-weight: 500;
+    font-size: 11px;
+  }
+
+  .ff_clear_all_filters {
+    margin-left: auto;
+  }
+}
+
+.ff_advanced_filter_badge {
+  margin-left: 6px;
+
+  .el-badge__content {
+    background-color: #fff;
+    color: #1565C9;
+    border: none;
+    height: 16px;
+    line-height: 16px;
+    padding: 0 6px;
+    font-size: 11px;
   }
 }

--- a/resources/assets/admin/styles/entries.scss
+++ b/resources/assets/admin/styles/entries.scss
@@ -891,6 +891,30 @@ span.ff_tag {
   margin-bottom: 20px;
   padding: 12px;
 
+  // Subtle help banner explaining AND-within-group / OR-between-groups
+  .ff_filter_help_bar {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    margin-bottom: 10px;
+    background: #f4f8fb;
+    border: 1px solid #dfe6ef;
+    border-radius: 4px;
+    font-size: 12px;
+    color: #606266;
+
+    .el-icon-info {
+      color: #1565C9;
+      font-size: 14px;
+    }
+
+    strong {
+      color: #1565C9;
+      font-weight: 700;
+    }
+  }
+
   .ff_rich_filters{
     padding: 10px;
     background: #fdfdfd;
@@ -908,6 +932,32 @@ span.ff_tag {
       box-shadow:none;
       .filter_name{
         font-weight: 500;
+
+        .ff_filter_field_btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          padding: 2px 6px;
+          border-radius: 4px;
+          cursor: pointer;
+          transition: background-color 0.15s ease;
+
+          &:hover {
+            background: #E8F2FF;
+
+            .ff_filter_field_edit_icon {
+              opacity: 1;
+            }
+          }
+        }
+
+        .ff_filter_field_edit_icon {
+          margin-left: 4px;
+          font-size: 13px;
+          color: #1565C9;
+          opacity: 0.4;
+          transition: opacity 0.15s ease;
+        }
       }
     }
   }

--- a/resources/assets/admin/styles/entries.scss
+++ b/resources/assets/admin/styles/entries.scss
@@ -961,6 +961,36 @@ span.ff_tag {
       }
     }
   }
+
+  // Cascader panel inside the field-change popover and the empty
+  // filter group's add picker
+  .ff_filter_field_picker {
+    width: 100%;
+  }
+
+  // Layout columns inside a filter row
+  .ff_table {
+    width: 100%;
+
+    .filter_name {
+      width: 210px;
+      line-height: 110%;
+    }
+
+    .fc_filter_operator {
+      width: 190px;
+    }
+
+    .fc_filter_actions {
+      width: 50px;
+      text-align: right;
+    }
+  }
+
+  // Delete button in an empty filter group (right-aligned alongside the Add)
+  .ff_filter_empty_remove {
+    float: right;
+  }
   .ff_cond_or {
     // Legacy "OR" used elsewhere; keep minimal so it doesn't break other contexts
     border-bottom: 1px dashed #d5dce1;

--- a/resources/assets/admin/styles/entries.scss
+++ b/resources/assets/admin/styles/entries.scss
@@ -1164,10 +1164,6 @@ span.ff_tag {
     font-weight: 500;
     font-size: 11px;
   }
-
-  .ff_clear_all_filters {
-    margin-left: auto;
-  }
 }
 
 .ff_advanced_filter_badge {

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -274,7 +274,6 @@
 	    </template>
 
         <applied-filter-summary
-            v-if="advanced_filter_active"
             :filters="advanced_filter"
             @clear-group="clearFilterGroup" />
 
@@ -797,10 +796,15 @@
 
             /**
              * Whether any advanced filters are currently applied. Used for
-             * the count badge on the Advanced Filter toggle button.
+             * the chip summary, the count badge on the Advanced Filter
+             * toggle, and to gate sending the filter to the server. The
+             * panel's visibility (advanced_filter_active) is intentionally
+             * NOT part of this check — once a filter is applied to the
+             * query, hiding the editing panel must not silently make the
+             * indicators disappear, otherwise admins can be looking at
+             * filtered data while believing it's unfiltered.
              */
             hasAppliedFilters() {
-                if (!this.advanced_filter_active) return false;
                 if (!Array.isArray(this.advanced_filter)) return false;
                 return this.advanced_filter.some(group => Array.isArray(group) && group.length > 0);
             },
@@ -951,9 +955,15 @@
 	            if (this.basicFilter) {
 		            this.basicFilter = false;
 	            }
-	            if (this.advanced_filter_active) {
+                // Send the advanced filter whenever it has data, regardless
+                // of whether the editing panel is currently visible. Gating
+                // by advanced_filter_active would let the user collapse the
+                // panel and silently get unfiltered results back from the
+                // server while the chips and badge still claim a filter is
+                // applied.
+                if (this.hasAppliedFilters) {
                     data.advanced_filter = this.advanced_filter;
-	            }
+                }
 
                 this.loading = true;
 
@@ -1238,7 +1248,7 @@
                     data.date_range = this.filter_date_range;
                     data.is_favourite = this.show_favorites;
                 }
-				if (this.advanced_filter_active) {
+				if (this.hasAppliedFilters) {
 					data.advanced_filter = this.advanced_filter;
 				}
 	            location.href = ajaxurl + '?' + jQuery.param(data);

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -145,11 +145,18 @@
             <section-head-content>
                 <btn-group class="ff_entries_report_wrap" as="div">
                     <btn-group-item as="div">
-                        <label for="search_bar">
-                           <b> {{ $t('Advanced Filter') }}</b>
-                        </label>
-                        <el-switch inactive-color="#afb3ba" class="el-switch-sm " v-model="advanced_filter_active" />
-
+                        <el-button
+                            :type="advanced_filter_active ? 'primary' : 'default'"
+                            :plain="!advanced_filter_active"
+                            icon="el-icon-s-operation"
+                            @click="advanced_filter_active = !advanced_filter_active"
+                            :title="$t('Toggle advanced filter panel')">
+                            {{ advanced_filter_active ? $t('Hide Filters') : $t('Advanced Filter') }}
+                            <el-badge
+                                v-if="hasAppliedFilters"
+                                :value="appliedFiltersSummary.length"
+                                class="ff_advanced_filter_badge" />
+                        </el-button>
                     </btn-group-item>
                     <btn-group-item as="div">
                         <label for="search_bar" class="screen-reader-text">
@@ -1475,52 +1482,3 @@
     };
 </script>
 
-<style>
-.ff_applied_filters_summary {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 8px;
-    padding: 12px 16px;
-    background: #f4f8fb;
-    border: 1px solid #dfe6ef;
-    border-left: 3px solid #0077cc;
-    border-radius: 4px;
-}
-.ff_applied_filters_label {
-    font-weight: 600;
-    color: #303133;
-    margin-right: 4px;
-}
-.ff_applied_filters_label .el-icon-search {
-    margin-right: 4px;
-    color: #0077cc;
-}
-.ff_filter_chip {
-    margin-right: 4px;
-}
-.ff_filter_chip .ff_filter_item_text {
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-}
-.ff_filter_chip .ff_filter_item_text em {
-    font-style: normal;
-    font-weight: 500;
-    color: #0077cc;
-}
-.ff_filter_or_separator {
-    font-weight: 700;
-    color: #0077cc;
-    font-size: 12px;
-    padding: 0 4px;
-}
-.ff_filter_and_separator {
-    color: #909399;
-    font-weight: 500;
-    font-size: 11px;
-}
-.ff_clear_all_filters {
-    margin-left: auto;
-}
-</style>

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -276,8 +276,7 @@
         <applied-filter-summary
             v-if="advanced_filter_active"
             :filters="advanced_filter"
-            @clear-group="clearFilterGroup"
-            @clear-all="clearAllAdvancedFilters" />
+            @clear-group="clearFilterGroup" />
 
         <div style="min-height: 300px;" class="entries_table">
             <div class="ff_table">

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -266,6 +266,41 @@
 			    </notice>
 	    </template>
 
+        <div v-if="hasAppliedFilters" class="ff_applied_filters_summary mb-4">
+            <span class="ff_applied_filters_label">
+                <i class="el-icon-search"></i>
+                {{ $t('Active Filters:') }}
+            </span>
+            <template v-for="(group, groupIndex) in appliedFiltersSummary">
+                <span v-if="groupIndex > 0" :key="'or_' + groupIndex" class="ff_filter_or_separator">{{ $t('OR') }}</span>
+                <el-tag
+                    :key="'filter_group_' + groupIndex"
+                    closable
+                    type="info"
+                    size="small"
+                    class="ff_filter_chip"
+                    @close="clearFilterGroup(groupIndex)">
+                    <template v-for="(item, itemIndex) in group">
+                        <span v-if="itemIndex > 0" :key="'and_' + itemIndex" class="ff_filter_and_separator"> {{ $t('AND') }} </span>
+                        <span :key="'item_' + itemIndex" class="ff_filter_item_text">
+                            <strong>{{ item.fieldLabel }}</strong>
+                            {{ item.operatorLabel }}
+                            <em>{{ item.displayValue }}</em>
+                        </span>
+                    </template>
+                </el-tag>
+            </template>
+            <el-button
+                @click="clearAllAdvancedFilters"
+                size="mini"
+                plain
+                type="danger"
+                icon="el-icon-close"
+                class="ff_clear_all_filters">
+                {{ $t('Clear All') }}
+            </el-button>
+        </div>
+
         <div style="min-height: 300px;" class="entries_table">
             <div class="ff_table">
                 <el-skeleton :loading="loading" animated :rows="6">
@@ -782,6 +817,46 @@
             },
 
             /**
+             * Whether any advanced filters are currently applied
+             * @return {Boolean}
+             */
+            hasAppliedFilters() {
+                if (!this.advanced_filter_active) return false;
+                if (!Array.isArray(this.advanced_filter)) return false;
+                if (!this.advanced_filter.length) return false;
+                return this.advanced_filter.some(group => Array.isArray(group) && group.length > 0);
+            },
+
+            /**
+             * Format applied filters for human-readable summary display
+             * @return {Array} Array of filter groups with formatted labels
+             */
+            appliedFiltersSummary() {
+                if (!this.hasAppliedFilters) return [];
+
+                const filterOptions = window.fluent_form_entries_vars && window.fluent_form_entries_vars.advanced_filters || [];
+                const operators = window.fluent_form_entries_vars && window.fluent_form_entries_vars.advanced_filters_operators || {};
+
+                return this.advanced_filter
+                    .filter(group => Array.isArray(group) && group.length > 0)
+                    .map(group => {
+                        return group.map(item => {
+                            const fieldLabel = this.lookupFieldLabel(item.source, filterOptions);
+                            const operatorLabel = operators[item.operator] || item.operator;
+                            const displayValue = this.formatFilterValue(item.value);
+                            return {
+                                source: item.source,
+                                operator: item.operator,
+                                value: item.value,
+                                fieldLabel,
+                                operatorLabel,
+                                displayValue
+                            };
+                        });
+                    });
+            },
+
+            /**
              * Compute columns order
              * @return {Array}
              */
@@ -874,6 +949,63 @@
             },
             runAdvanceSearch(query){
                 this.advanced_filter = query
+                this.getData();
+            },
+
+            /**
+             * Look up the human-readable field label from filter options
+             * @param {Array} source - [provider, fieldName]
+             * @param {Array} filterOptions - The available filter options
+             * @return {String} Field label
+             */
+            lookupFieldLabel(source, filterOptions) {
+                if (!Array.isArray(source) || source.length < 2) return '';
+                const [provider, fieldName] = source;
+
+                const providerGroup = filterOptions.find(opt => opt.value === provider);
+                if (!providerGroup || !providerGroup.children) return fieldName;
+
+                const field = providerGroup.children.find(child => child.value === fieldName);
+                return field ? `${providerGroup.label} / ${field.label}` : fieldName;
+            },
+
+            /**
+             * Format filter value for display
+             * @param {*} value
+             * @return {String}
+             */
+            formatFilterValue(value) {
+                if (value === null || value === undefined || value === '') {
+                    return '(empty)';
+                }
+                if (Array.isArray(value)) {
+                    return value.join(', ');
+                }
+                return String(value);
+            },
+
+            /**
+             * Remove a single filter group by index and re-run search
+             * @param {Number} groupIndex
+             */
+            clearFilterGroup(groupIndex) {
+                if (!Array.isArray(this.advanced_filter)) return;
+                const updatedFilters = this.advanced_filter.filter((_, idx) => idx !== groupIndex);
+
+                if (updatedFilters.length === 0) {
+                    this.clearAllAdvancedFilters();
+                    return;
+                }
+
+                this.advanced_filter = updatedFilters;
+                this.getData();
+            },
+
+            /**
+             * Clear all advanced filters and re-run search
+             */
+            clearAllAdvancedFilters() {
+                this.advanced_filter = [[]];
                 this.getData();
             },
             getData() {
@@ -1342,3 +1474,53 @@
 	    }
     };
 </script>
+
+<style>
+.ff_applied_filters_summary {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    padding: 12px 16px;
+    background: #f4f8fb;
+    border: 1px solid #dfe6ef;
+    border-left: 3px solid #0077cc;
+    border-radius: 4px;
+}
+.ff_applied_filters_label {
+    font-weight: 600;
+    color: #303133;
+    margin-right: 4px;
+}
+.ff_applied_filters_label .el-icon-search {
+    margin-right: 4px;
+    color: #0077cc;
+}
+.ff_filter_chip {
+    margin-right: 4px;
+}
+.ff_filter_chip .ff_filter_item_text {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.ff_filter_chip .ff_filter_item_text em {
+    font-style: normal;
+    font-weight: 500;
+    color: #0077cc;
+}
+.ff_filter_or_separator {
+    font-weight: 700;
+    color: #0077cc;
+    font-size: 12px;
+    padding: 0 4px;
+}
+.ff_filter_and_separator {
+    color: #909399;
+    font-weight: 500;
+    font-size: 11px;
+}
+.ff_clear_all_filters {
+    margin-left: auto;
+}
+</style>

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -274,6 +274,7 @@
 	    </template>
 
         <applied-filter-summary
+            v-if="advanced_filter_active"
             :filters="advanced_filter"
             @clear-group="clearFilterGroup"
             @clear-all="clearAllAdvancedFilters" />

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -154,7 +154,7 @@
                             {{ advanced_filter_active ? $t('Hide Filters') : $t('Advanced Filter') }}
                             <el-badge
                                 v-if="hasAppliedFilters"
-                                :value="appliedFiltersSummary.length"
+                                :value="appliedFilterGroupCount"
                                 class="ff_advanced_filter_badge" />
                         </el-button>
                     </btn-group-item>
@@ -273,40 +273,10 @@
 			    </notice>
 	    </template>
 
-        <div v-if="hasAppliedFilters" class="ff_applied_filters_summary mb-4">
-            <span class="ff_applied_filters_label">
-                <i class="el-icon-search"></i>
-                {{ $t('Active Filters:') }}
-            </span>
-            <template v-for="(group, groupIndex) in appliedFiltersSummary">
-                <span v-if="groupIndex > 0" :key="'or_' + groupIndex" class="ff_filter_or_separator">{{ $t('OR') }}</span>
-                <el-tag
-                    :key="'filter_group_' + groupIndex"
-                    closable
-                    type="info"
-                    size="small"
-                    class="ff_filter_chip"
-                    @close="clearFilterGroup(groupIndex)">
-                    <template v-for="(item, itemIndex) in group">
-                        <span v-if="itemIndex > 0" :key="'and_' + itemIndex" class="ff_filter_and_separator"> {{ $t('AND') }} </span>
-                        <span :key="'item_' + itemIndex" class="ff_filter_item_text">
-                            <strong>{{ item.fieldLabel }}</strong>
-                            {{ item.operatorLabel }}
-                            <em>{{ item.displayValue }}</em>
-                        </span>
-                    </template>
-                </el-tag>
-            </template>
-            <el-button
-                @click="clearAllAdvancedFilters"
-                size="mini"
-                plain
-                type="danger"
-                icon="el-icon-close"
-                class="ff_clear_all_filters">
-                {{ $t('Clear All') }}
-            </el-button>
-        </div>
+        <applied-filter-summary
+            :filters="advanced_filter"
+            @clear-group="clearFilterGroup"
+            @clear-all="clearAllAdvancedFilters" />
 
         <div style="min-height: 300px;" class="entries_table">
             <div class="ff_table">
@@ -620,6 +590,7 @@
     import SectionHeadContent from '@/admin/components/SectionHead/SectionHeadContent.vue';
     import ImportEntriesModal from "@/admin/components/modals/ImportEntriesModal.vue";
     import AdvancedSearch from "@/admin/views/_AdvancedSearch";
+    import AppliedFilterSummary from "@/admin/views/_AppliedFilterSummary";
     import Notice from '@/admin/components/Notice/Notice.vue'
 
     export default {
@@ -627,6 +598,7 @@
         props: ['form_id', 'has_pdf'],
         components: {
             AdvancedSearch,
+            AppliedFilterSummary,
             Confirm,
             EmailResend,
             ColumnDragAndDrop,
@@ -824,43 +796,21 @@
             },
 
             /**
-             * Whether any advanced filters are currently applied
-             * @return {Boolean}
+             * Whether any advanced filters are currently applied. Used for
+             * the count badge on the Advanced Filter toggle button.
              */
             hasAppliedFilters() {
                 if (!this.advanced_filter_active) return false;
                 if (!Array.isArray(this.advanced_filter)) return false;
-                if (!this.advanced_filter.length) return false;
                 return this.advanced_filter.some(group => Array.isArray(group) && group.length > 0);
             },
 
             /**
-             * Format applied filters for human-readable summary display
-             * @return {Array} Array of filter groups with formatted labels
+             * Number of populated filter groups, used for the badge count.
              */
-            appliedFiltersSummary() {
-                if (!this.hasAppliedFilters) return [];
-
-                const filterOptions = window.fluent_form_entries_vars && window.fluent_form_entries_vars.advanced_filters || [];
-                const operators = window.fluent_form_entries_vars && window.fluent_form_entries_vars.advanced_filters_operators || {};
-
-                return this.advanced_filter
-                    .filter(group => Array.isArray(group) && group.length > 0)
-                    .map(group => {
-                        return group.map(item => {
-                            const fieldLabel = this.lookupFieldLabel(item.source, filterOptions);
-                            const operatorLabel = operators[item.operator] || item.operator;
-                            const displayValue = this.formatFilterValue(item.value);
-                            return {
-                                source: item.source,
-                                operator: item.operator,
-                                value: item.value,
-                                fieldLabel,
-                                operatorLabel,
-                                displayValue
-                            };
-                        });
-                    });
+            appliedFilterGroupCount() {
+                if (!Array.isArray(this.advanced_filter)) return 0;
+                return this.advanced_filter.filter(group => Array.isArray(group) && group.length > 0).length;
             },
 
             /**
@@ -957,38 +907,6 @@
             runAdvanceSearch(query){
                 this.advanced_filter = query
                 this.getData();
-            },
-
-            /**
-             * Look up the human-readable field label from filter options
-             * @param {Array} source - [provider, fieldName]
-             * @param {Array} filterOptions - The available filter options
-             * @return {String} Field label
-             */
-            lookupFieldLabel(source, filterOptions) {
-                if (!Array.isArray(source) || source.length < 2) return '';
-                const [provider, fieldName] = source;
-
-                const providerGroup = filterOptions.find(opt => opt.value === provider);
-                if (!providerGroup || !providerGroup.children) return fieldName;
-
-                const field = providerGroup.children.find(child => child.value === fieldName);
-                return field ? `${providerGroup.label} / ${field.label}` : fieldName;
-            },
-
-            /**
-             * Format filter value for display
-             * @param {*} value
-             * @return {String}
-             */
-            formatFilterValue(value) {
-                if (value === null || value === undefined || value === '') {
-                    return '(empty)';
-                }
-                if (Array.isArray(value)) {
-                    return value.join(', ');
-                }
-                return String(value);
             },
 
             /**

--- a/resources/assets/admin/views/EntryFilters/Filters.vue
+++ b/resources/assets/admin/views/EntryFilters/Filters.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="ff_rich_filters">
-        <table v-if="items.length && !working" style="width: 100%;" class="ff_table">
+        <table v-if="items.length && !working" class="ff_table">
             <tbody>
             <filter-item v-for="(item, itemKey) in items" :view_only="view_only" @removeItem="removeItem(itemKey)"
                          :key="itemKey"
@@ -19,7 +19,7 @@
                 v-model="addVisible"
                 trigger="click">
                 <el-cascader-panel @change="maybeSelected"
-                                   style="width: 100%"
+                                   class="ff_filter_field_picker"
                                    :options="filterOptions"
                                    v-model="new_item"/>
                 <el-button slot="reference"  size="small" class="blue-soft" icon="el-icon-plus">
@@ -27,7 +27,7 @@
                 </el-button>
             </el-popover>
             {{ $t(add_label) }}
-            <el-button v-if="canRemove" style="float: right;" @click="$emit('maybeRemove')" size="mini" type="danger"
+            <el-button v-if="canRemove" class="ff_filter_empty_remove" @click="$emit('maybeRemove')" size="mini" type="danger"
                        icon="el-icon-delete"></el-button>
         </div>
 
@@ -38,7 +38,7 @@
                 v-model="addVisible"
                 trigger="click">
                 <el-cascader-panel @change="maybeSelected"
-                                   style="width: 100%"
+                                   class="ff_filter_field_picker"
                                    :options="filterOptions"
                                    v-model="new_item"/>
               <el-button slot="reference"  size="small" class="blue-soft" icon="el-icon-plus">

--- a/resources/assets/admin/views/EntryFilters/Filters.vue
+++ b/resources/assets/admin/views/EntryFilters/Filters.vue
@@ -4,7 +4,9 @@
             <tbody>
             <filter-item v-for="(item, itemKey) in items" :view_only="view_only" @removeItem="removeItem(itemKey)"
                          :key="itemKey"
-                         :filterLabels="filterLabels" :item="item"/>
+                         :filterLabels="filterLabels"
+                         :filterOptions="filterOptions"
+                         :item="item"/>
             </tbody>
         </table>
 

--- a/resources/assets/admin/views/EntryFilters/Filters.vue
+++ b/resources/assets/admin/views/EntryFilters/Filters.vue
@@ -20,12 +20,12 @@
                                    style="width: 100%"
                                    :options="filterOptions"
                                    v-model="new_item"/>
-                <el-button slot="reference"  size="small" icon="el-icon-plus">
+                <el-button slot="reference"  size="small" class="blue-soft" icon="el-icon-plus">
                     {{ $t('Add') }}
                 </el-button>
             </el-popover>
             {{ $t(add_label) }}
-            <el-button style="float: right;" @click="$emit('maybeRemove')" size="mini" type="danger"
+            <el-button v-if="canRemove" style="float: right;" @click="$emit('maybeRemove')" size="mini" type="danger"
                        icon="el-icon-delete"></el-button>
         </div>
 
@@ -39,9 +39,9 @@
                                    style="width: 100%"
                                    :options="filterOptions"
                                    v-model="new_item"/>
-                <el-button slot="reference" size="small" icon="el-icon-plus">
-                    {{ $t('Add') }}
-                </el-button>
+              <el-button slot="reference"  size="small" class="blue-soft" icon="el-icon-plus">
+                {{ $t('Add') }}
+              </el-button>
             </el-popover>
             {{ $t(add_label) }}
         </div>
@@ -78,6 +78,10 @@ export default {
             default() {
                 return false;
             }
+        },
+        canRemove: {
+            type: Boolean,
+            default: false
         }
     },
     data() {

--- a/resources/assets/admin/views/EntryFilters/_FilterItem.vue
+++ b/resources/assets/admin/views/EntryFilters/_FilterItem.vue
@@ -1,6 +1,6 @@
 <template>
     <tr>
-        <td style="width: 210px; line-height: 110%;" class="filter_name">
+        <td class="filter_name">
             <el-popover
                 v-if="!view_only && filterOptions && filterOptions.length"
                 placement="bottom-start"
@@ -8,7 +8,7 @@
                 trigger="click"
                 v-model="changeFieldOpen">
                 <el-cascader-panel
-                    style="width: 100%"
+                    class="ff_filter_field_picker"
                     :options="filterOptions"
                     v-model="changeFieldSelection"
                     @change="maybeChangeField" />
@@ -31,7 +31,7 @@
                 </el-tooltip>
             </span>
         </td>
-        <td style="width: 190px" class="fc_filter_operator">
+        <td class="fc_filter_operator">
             <el-select :disabled="view_only" size="mini" :placeholder="$t('Select Operator')"
                        @visible-change="maybeOperatorSelected"
                        v-model="item.operator">
@@ -114,7 +114,7 @@
 	                      type="text" v-model="item.value"/>
             </template>
         </td>
-        <td v-if="!view_only" style="width: 50px; text-align: right;">
+        <td v-if="!view_only" class="fc_filter_actions">
             <el-button
                 plain
                 icon="el-icon-delete"

--- a/resources/assets/admin/views/EntryFilters/_FilterItem.vue
+++ b/resources/assets/admin/views/EntryFilters/_FilterItem.vue
@@ -1,8 +1,29 @@
 <template>
     <tr>
         <td style="width: 210px; line-height: 110%;" class="filter_name">
-            {{ itemConfig.provider|ucFirst }} <span class="fs_provider_separator">/</span>
-            {{ itemConfig.label }}
+            <el-popover
+                v-if="!view_only && filterOptions && filterOptions.length"
+                placement="bottom-start"
+                width="450"
+                trigger="click"
+                v-model="changeFieldOpen">
+                <el-cascader-panel
+                    style="width: 100%"
+                    :options="filterOptions"
+                    v-model="changeFieldSelection"
+                    @change="maybeChangeField" />
+                <span slot="reference" class="ff_filter_field_btn" :title="$t('Click to change field')">
+                    {{ itemConfig.provider | ucFirst }}
+                    <span class="fs_provider_separator">/</span>
+                    {{ itemConfig.label }}
+                    <i class="el-icon-edit-outline ff_filter_field_edit_icon"></i>
+                </span>
+            </el-popover>
+            <span v-else>
+                {{ itemConfig.provider | ucFirst }}
+                <span class="fs_provider_separator">/</span>
+                {{ itemConfig.label }}
+            </span>
             <span v-if="itemConfig.help">
                 <el-tooltip class="item" effect="dark" placement="top-start">
                     <i class="el-icon el-icon-info"></i>
@@ -15,7 +36,7 @@
                        @visible-change="maybeOperatorSelected"
                        v-model="item.operator">
                 <el-option v-for="(optionLabel, option) in operators" :key="option" :value="option"
-                           :label="optionLabel"></el-option>
+                           :label="optionLabel" :title="operatorHelp[option] || ''"></el-option>
             </el-select>
         </td>
         <td class="fc_filter_value">
@@ -23,8 +44,10 @@
                 --
             </template>
             <template v-else>
-                <el-input size="mini" v-if="isNumericType" type="number"
-                          :placeholder="$t('Condition Value')"
+                <el-input size="mini"
+                          v-if="isNumericType"
+                          :type="isMultiValueOperator ? 'text' : 'number'"
+                          :placeholder="isMultiValueOperator ? $t('Comma-separated values, e.g. 1,5,10') : $t('Condition Value')"
                           v-model="item.value"/>
                 <template v-else-if="itemConfig.type == 'dates'">
 	                <el-date-picker :type="dateType"
@@ -109,17 +132,49 @@ import isArray from 'lodash/isArray';
 
 export default {
     name: 'RichFilterItem',
-    props: ['item', 'filterLabels', 'view_only'],
+    props: {
+        item: { type: Object, required: true },
+        filterLabels: { type: Object, default: () => ({}) },
+        filterOptions: { type: Array, default: () => [] },
+        view_only: { type: Boolean, default: false }
+    },
     components: {
 
     },
     data() {
         return {
 			all_operator : window.fluent_form_entries_vars.advanced_filters_operators || {},
-			all_columns : window.fluent_form_entries_vars.advanced_filters_columns || {}
+			all_columns : window.fluent_form_entries_vars.advanced_filters_columns || {},
+            changeFieldOpen: false,
+            changeFieldSelection: []
         }
     },
     computed: {
+        /**
+         * Short, plain-language descriptions for each operator. Shown as a
+         * native title tooltip when the user hovers an option in the
+         * operator dropdown.
+         */
+        operatorHelp() {
+            return {
+                '=': this.$t('Field value is exactly equal to the input'),
+                '!=': this.$t('Field value is anything other than the input'),
+                '>': this.$t('Field value is greater than the input'),
+                '<': this.$t('Field value is less than the input'),
+                '>=': this.$t('Field value is greater than or equal to the input'),
+                '<=': this.$t('Field value is less than or equal to the input'),
+                'IN': this.$t('Field value matches any item in the comma-separated list'),
+                'NOT IN': this.$t('Field value does not match any item in the comma-separated list'),
+                'BETWEEN': this.$t('Field value falls between two values (inclusive)'),
+                'NOT BETWEEN': this.$t('Field value falls outside the two values'),
+                'contains': this.$t('Field value contains this text anywhere'),
+                'doNotContains': this.$t('Field value does not contain this text'),
+                'startsWith': this.$t('Field value begins with this text'),
+                'endsWith': this.$t('Field value ends with this text'),
+                'is_null': this.$t('Field has no value'),
+                'not_null': this.$t('Field has any value')
+            };
+        },
 	    operators() {
 		    let operators = { ...this.all_operator };
 		    const type = this.itemConfig.type;
@@ -138,7 +193,7 @@ export default {
 				    allow_operators = ['=', '!='];
 			    }
 		    } else if (this.isNumericType) {
-			    allow_operators = ['>', '<', '>=', '<=', '=', '!='];
+			    allow_operators = ['>', '<', '>=', '<=', '=', '!=', 'IN', 'NOT IN'];
 		    } else {
 				allow_operators = ['=', '!=', 'IN', 'NOT IN', 'contains', 'doNotContains', 'startsWith', 'endsWith'];
 		    }
@@ -152,6 +207,14 @@ export default {
 	    isNumericType(){
 			return this.itemConfig.type == 'numeric' || this.all_columns.numeric.includes(this.item.source.join('.'));
 	    },
+        /**
+         * Operators that accept a comma-separated list of values. The input
+         * for these must be plain text so users can type commas — a
+         * native number input strips them.
+         */
+        isMultiValueOperator() {
+            return ['IN', 'NOT IN'].includes(this.item.operator);
+        },
 	    dateType() {
 		    if (['BETWEEN', 'NOT BETWEEN'].includes(this.item.operator)) {
 			    return this.itemConfig.date_type + 'range';
@@ -174,6 +237,21 @@ export default {
         }
     },
     methods: {
+        /**
+         * Replace the field source for this filter row with the cascader's
+         * new selection. Resets the operator and value because the new field
+         * may not support the previously selected operator/value type.
+         */
+        maybeChangeField(newSource) {
+            if (!Array.isArray(newSource) || newSource.length !== 2) {
+                return;
+            }
+            this.item.source = [...newSource];
+            this.item.operator = '';
+            this.item.value = '';
+            this.changeFieldOpen = false;
+            this.changeFieldSelection = [];
+        },
         closingSource(status) {
             if (!status) {
                 setTimeout(() => {

--- a/resources/assets/admin/views/_AdvancedSearch.vue
+++ b/resources/assets/admin/views/_AdvancedSearch.vue
@@ -1,5 +1,14 @@
 <template>
-    <div class="ff_as_container" v-show="advanced_filter">
+    <div class="ff_as_container" v-show="advanced_filter" @keyup.enter="handleEnterKey">
+        <div class="ff_filter_help_bar">
+            <i class="el-icon-info"></i>
+            <span>
+                {{ $t('Conditions inside a group are joined with') }}
+                <strong>{{ $t('AND') }}</strong>.
+                {{ $t('Multiple groups are joined with') }}
+                <strong>{{ $t('OR') }}</strong>.
+            </span>
+        </div>
         <div v-for="(rich_filter, filterIndex) in advanced_filters" :key="filterIndex" class="ff_filter_group_wrap">
             <div class="fc_rich_filter">
                 <rich-filter
@@ -45,7 +54,8 @@
             </div>
             <div
                 v-else-if="filterIndex < advanced_filters.length - 1"
-                class="ff_or_separator">
+                class="ff_or_separator"
+                :title="$t('Entries matching either group are returned')">
                 <span>{{ $t('OR') }}</span>
             </div>
 
@@ -134,6 +144,25 @@
             runSearch(){
                 this.lastAppliedFilters = JSON.stringify(this.advanced_filters);
                 this.$emit("runSearch", this.advanced_filters);
+            },
+            /**
+             * Trigger the filter when the user presses Enter from any input
+             * inside the panel. We blur the active element so the user gets
+             * an obvious "I just submitted" feedback (collapsed cursor) and
+             * any open Element UI popovers (cascader, select) aren't
+             * inadvertently submitted by their internal Enter handlers.
+             */
+            handleEnterKey(event) {
+                // Skip when an Element UI dropdown/cascader is open: its
+                // own Enter handler should win (selecting an option).
+                const target = event && event.target;
+                if (target && target.closest && target.closest('.el-select-dropdown, .el-cascader-panel, .el-popover')) {
+                    return;
+                }
+                if (target && typeof target.blur === 'function') {
+                    target.blur();
+                }
+                this.runSearch();
             },
             addConditionGroup() {
                 this.advanced_filters.push([]);

--- a/resources/assets/admin/views/_AdvancedSearch.vue
+++ b/resources/assets/admin/views/_AdvancedSearch.vue
@@ -1,8 +1,28 @@
 <template>
     <div class="ff_as_container" v-show="advanced_filter">
-        <div v-for="(rich_filter, filterIndex) in advanced_filters" :key="filterIndex">
+        <div v-for="(rich_filter, filterIndex) in advanced_filters" :key="filterIndex" class="ff_filter_group_wrap">
             <div class="fc_rich_filter">
                 <rich-filter :filterOptions="editorShortcodes" :add_label="filterLabel" @maybeRemove="maybeRemoveGroup(filterIndex)" :items="rich_filter"/>
+
+                <div v-if="rich_filter.length > 0" class="ff_filter_group_actions">
+                    <el-button
+                        @click="duplicateGroup(filterIndex)"
+                        size="mini"
+                        plain
+                        icon="el-icon-document-copy"
+                        :title="$t('Duplicate this group with all conditions')">
+                        {{ $t('Duplicate Group') }}
+                    </el-button>
+                    <el-button
+                        v-if="advanced_filters.length > 1"
+                        @click="maybeRemoveGroup(filterIndex)"
+                        size="mini"
+                        plain
+                        type="danger"
+                        icon="el-icon-delete"
+                        :title="$t('Remove this filter group')">
+                    </el-button>
+                </div>
             </div>
 
 
@@ -63,6 +83,19 @@
                     this.advanced_filters.splice(index, 1);
                 }
             },
+            /**
+             * Duplicate a filter group with all its conditions.
+             * Inserts the clone immediately after the source group so the
+             * user can quickly tweak the duplicate's values.
+             */
+            duplicateGroup(index) {
+                const sourceGroup = this.advanced_filters[index];
+                if (!sourceGroup || !sourceGroup.length) {
+                    return;
+                }
+                const clonedGroup = JSON.parse(JSON.stringify(sourceGroup));
+                this.advanced_filters.splice(index + 1, 0, clonedGroup);
+            },
             runSearch(){
                 this.$emit("runSearch", this.advanced_filters);
             },
@@ -75,3 +108,23 @@
         }
     }
 </script>
+
+<style>
+.ff_as_container .ff_filter_group_wrap {
+    position: relative;
+}
+.ff_as_container .fc_rich_filter {
+    position: relative;
+}
+.ff_as_container .ff_filter_group_actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+    padding: 8px 12px 4px;
+    border-top: 1px dashed #e4e7ed;
+    margin-top: 4px;
+}
+.ff_as_container .ff_filter_group_actions .el-button {
+    font-size: 12px;
+}
+</style>

--- a/resources/assets/admin/views/_AdvancedSearch.vue
+++ b/resources/assets/admin/views/_AdvancedSearch.vue
@@ -88,11 +88,36 @@
     export default {
         name: 'AdvancedSearch',
         props: {
-            advanced_filter: {},
-
+            advanced_filter: {
+                type: [Array, Object],
+                default: () => ([[]])
+            }
         },
         components: {
             RichFilter,
+        },
+        watch: {
+            /**
+             * Keep the panel's internal editor state in sync with the
+             * parent's filter prop. When the parent removes a group via a
+             * chip click, this fires and the panel reflects the new state
+             * the next time the user opens it (otherwise reopening would
+             * show a stale group and clicking Filter would silently
+             * re-apply the removed filter).
+             */
+            advanced_filter: {
+                handler(newVal) {
+                    if (!Array.isArray(newVal)) return;
+                    const incoming = JSON.stringify(newVal);
+                    if (incoming === JSON.stringify(this.advanced_filters)) return;
+                    this.advanced_filters = JSON.parse(incoming);
+                    // The parent already considers this state "applied"
+                    // (it just ran getData with it), so align the
+                    // unsaved-changes baseline accordingly.
+                    this.lastAppliedFilters = incoming;
+                },
+                deep: true
+            }
         },
         data() {
             return {
@@ -170,6 +195,12 @@
         },
         mounted() {
             this.fetchAllEditorShortcodes();
+            // Hydrate from the parent prop on first mount in case the
+            // parent already has a filter to display (e.g. opening the
+            // page with an applied filter from a remembered state).
+            if (Array.isArray(this.advanced_filter) && this.advanced_filter.length) {
+                this.advanced_filters = JSON.parse(JSON.stringify(this.advanced_filter));
+            }
             this.lastAppliedFilters = JSON.stringify(this.advanced_filters);
         }
     }

--- a/resources/assets/admin/views/_AdvancedSearch.vue
+++ b/resources/assets/admin/views/_AdvancedSearch.vue
@@ -2,7 +2,12 @@
     <div class="ff_as_container" v-show="advanced_filter">
         <div v-for="(rich_filter, filterIndex) in advanced_filters" :key="filterIndex" class="ff_filter_group_wrap">
             <div class="fc_rich_filter">
-                <rich-filter :filterOptions="editorShortcodes" :add_label="filterLabel" @maybeRemove="maybeRemoveGroup(filterIndex)" :items="rich_filter"/>
+                <rich-filter
+                    :filterOptions="editorShortcodes"
+                    :add_label="filterLabel"
+                    :items="rich_filter"
+                    :can-remove="advanced_filters.length > 1"
+                    @maybeRemove="maybeRemoveGroup(filterIndex)" />
 
                 <div v-if="rich_filter.length > 0" class="ff_filter_group_actions">
                     <el-button
@@ -26,17 +31,36 @@
             </div>
 
 
-            <div class="ff_cond_or">
-                <em @click="addConditionGroup()"
-                    style="cursor: pointer; color: rgb(0, 119, 204); font-weight: bold;"><i
-                        class="el-icon-plus"></i> {{ $t('OR') }}</em>
+            <div
+                v-if="rich_filter.length > 0 && filterIndex === advanced_filters.length - 1"
+                class="ff_cond_or_wrap">
+                <button
+                    type="button"
+                    class="ff_add_or_group_btn"
+                    @click="addConditionGroup()"
+                    :title="$t('Add another filter group combined with OR')">
+                    <i class="el-icon-plus"></i>
+                    <span>{{ $t('Add OR Group') }}</span>
+                </button>
+            </div>
+            <div
+                v-else-if="filterIndex < advanced_filters.length - 1"
+                class="ff_or_separator">
+                <span>{{ $t('OR') }}</span>
             </div>
 
 
         </div>
         <el-row :gutter="20">
             <el-col :md="12" :xs="24">
-                <el-button type="primary" size="small" @click="runSearch">{{ $t('Filter') }}</el-button>
+                <el-button
+                    type="primary"
+                    size="small"
+                    @click="runSearch"
+                    :class="{'ff_filter_btn_modified': hasUnappliedChanges}"
+                    :title="hasUnappliedChanges ? $t('You have unapplied filter changes') : ''">
+                    {{ $t('Filter') }}<span v-if="hasUnappliedChanges" class="ff_filter_modified_dot">●</span>
+                </el-button>
             </el-col>
             <el-col :md="12" :xs="24">
                 <div class="text-right">
@@ -72,7 +96,18 @@
                 },
                 editorShortcodes: [],
                 advanced_filters: [[]],
-                filterLabel: this.$t('Filters Info'),}
+                lastAppliedFilters: '[[]]',
+                filterLabel: this.$t('Add your filters here'),}
+        },
+        computed: {
+            /**
+             * True when the current filter state differs from the last applied
+             * filter snapshot. Used to show a subtle "unsaved changes" hint
+             * on the Filter button.
+             */
+            hasUnappliedChanges() {
+                return JSON.stringify(this.advanced_filters) !== this.lastAppliedFilters;
+            }
         },
         methods: {
             fetchAllEditorShortcodes() {
@@ -97,6 +132,7 @@
                 this.advanced_filters.splice(index + 1, 0, clonedGroup);
             },
             runSearch(){
+                this.lastAppliedFilters = JSON.stringify(this.advanced_filters);
                 this.$emit("runSearch", this.advanced_filters);
             },
             addConditionGroup() {
@@ -105,26 +141,8 @@
         },
         mounted() {
             this.fetchAllEditorShortcodes();
+            this.lastAppliedFilters = JSON.stringify(this.advanced_filters);
         }
     }
 </script>
 
-<style>
-.ff_as_container .ff_filter_group_wrap {
-    position: relative;
-}
-.ff_as_container .fc_rich_filter {
-    position: relative;
-}
-.ff_as_container .ff_filter_group_actions {
-    display: flex;
-    gap: 8px;
-    justify-content: flex-end;
-    padding: 8px 12px 4px;
-    border-top: 1px dashed #e4e7ed;
-    margin-top: 4px;
-}
-.ff_as_container .ff_filter_group_actions .el-button {
-    font-size: 12px;
-}
-</style>

--- a/resources/assets/admin/views/_AppliedFilterSummary.vue
+++ b/resources/assets/admin/views/_AppliedFilterSummary.vue
@@ -1,0 +1,109 @@
+<template>
+    <div v-if="hasFilters" class="ff_applied_filters_summary">
+        <span class="ff_applied_filters_label">
+            <i class="el-icon-search"></i>
+            {{ $t('Active Filters:') }}
+        </span>
+        <template v-for="(group, gi) in summary">
+            <span
+                v-if="gi > 0"
+                :key="'or_' + gi"
+                class="ff_filter_or_separator">
+                {{ $t('OR') }}
+            </span>
+            <el-tag
+                :key="'group_' + gi"
+                closable
+                type="info"
+                size="small"
+                class="ff_filter_chip"
+                @close="$emit('clear-group', gi)">
+                <template v-for="(item, ii) in group">
+                    <span
+                        v-if="ii > 0"
+                        :key="'and_' + ii"
+                        class="ff_filter_and_separator">
+                        {{ $t('AND') }}
+                    </span>
+                    <span :key="'item_' + ii" class="ff_filter_item_text">
+                        <strong>{{ item.fieldLabel }}</strong>
+                        {{ item.operatorLabel }}
+                        <em>{{ item.displayValue }}</em>
+                    </span>
+                </template>
+            </el-tag>
+        </template>
+        <el-button
+            size="mini"
+            plain
+            type="danger"
+            icon="el-icon-close"
+            class="ff_clear_all_filters"
+            @click="$emit('clear-all')">
+            {{ $t('Clear All') }}
+        </el-button>
+    </div>
+</template>
+
+<script>
+/**
+ * Renders the active advanced filters above the entries table as a row of
+ * removable chips. Receives the raw filter array and looks up
+ * human-readable labels (field names, operator labels) from the global
+ * fluent_form_entries_vars provided by the backend.
+ *
+ * Emits:
+ *  - clear-group(index): user closed a chip; parent should drop that group
+ *  - clear-all: user clicked "Clear All"; parent should reset filters
+ */
+export default {
+    name: 'AppliedFilterSummary',
+    props: {
+        filters: {
+            type: Array,
+            default: () => []
+        }
+    },
+    computed: {
+        hasFilters() {
+            if (!Array.isArray(this.filters)) return false;
+            return this.filters.some(group => Array.isArray(group) && group.length > 0);
+        },
+        filterOptions() {
+            return (window.fluent_form_entries_vars
+                && window.fluent_form_entries_vars.advanced_filters) || [];
+        },
+        operators() {
+            return (window.fluent_form_entries_vars
+                && window.fluent_form_entries_vars.advanced_filters_operators) || {};
+        },
+        summary() {
+            if (!this.hasFilters) return [];
+            return this.filters
+                .filter(group => Array.isArray(group) && group.length > 0)
+                .map(group => group.map(item => ({
+                    fieldLabel: this.lookupFieldLabel(item.source),
+                    operatorLabel: this.operators[item.operator] || item.operator,
+                    displayValue: this.formatValue(item.value)
+                })));
+        }
+    },
+    methods: {
+        lookupFieldLabel(source) {
+            if (!Array.isArray(source) || source.length < 2) return '';
+            const [provider, fieldName] = source;
+            const providerGroup = this.filterOptions.find(opt => opt.value === provider);
+            if (!providerGroup || !providerGroup.children) return fieldName;
+            const field = providerGroup.children.find(child => child.value === fieldName);
+            return field ? `${providerGroup.label} / ${field.label}` : fieldName;
+        },
+        formatValue(value) {
+            if (value === null || value === undefined || value === '') {
+                return this.$t('(empty)');
+            }
+            if (Array.isArray(value)) return value.join(', ');
+            return String(value);
+        }
+    }
+};
+</script>

--- a/resources/assets/admin/views/_AppliedFilterSummary.vue
+++ b/resources/assets/admin/views/_AppliedFilterSummary.vue
@@ -4,21 +4,21 @@
             <i class="el-icon-search"></i>
             {{ $t('Active Filters:') }}
         </span>
-        <template v-for="(group, gi) in summary">
+        <template v-for="(group, displayIndex) in summary">
             <span
-                v-if="gi > 0"
-                :key="'or_' + gi"
+                v-if="displayIndex > 0"
+                :key="'or_' + group.originalIndex"
                 class="ff_filter_or_separator">
                 {{ $t('OR') }}
             </span>
             <el-tag
-                :key="'group_' + gi"
+                :key="'group_' + group.originalIndex"
                 closable
                 type="info"
                 size="small"
                 class="ff_filter_chip"
-                @close="$emit('clear-group', gi)">
-                <template v-for="(item, ii) in group">
+                @close="$emit('clear-group', group.originalIndex)">
+                <template v-for="(item, ii) in group.items">
                     <span
                         v-if="ii > 0"
                         :key="'and_' + ii"
@@ -71,13 +71,24 @@ export default {
         },
         summary() {
             if (!this.hasFilters) return [];
-            return this.filters
-                .filter(group => Array.isArray(group) && group.length > 0)
-                .map(group => group.map(item => ({
-                    fieldLabel: this.lookupFieldLabel(item.source),
-                    operatorLabel: this.operators[item.operator] || item.operator,
-                    displayValue: this.formatValue(item.value)
-                })));
+            // Preserve the original index in the parent's advanced_filter
+            // array so the chip-close handler can target the correct group
+            // even when there are empty groups before populated ones.
+            // Emitting the compacted (post-filter) index would point the
+            // parent at the wrong group and silently delete the wrong filter.
+            const result = [];
+            this.filters.forEach((group, originalIndex) => {
+                if (!Array.isArray(group) || group.length === 0) return;
+                result.push({
+                    originalIndex,
+                    items: group.map(item => ({
+                        fieldLabel: this.lookupFieldLabel(item.source),
+                        operatorLabel: this.operators[item.operator] || item.operator,
+                        displayValue: this.formatValue(item.value)
+                    }))
+                });
+            });
+            return result;
         }
     },
     methods: {

--- a/resources/assets/admin/views/_AppliedFilterSummary.vue
+++ b/resources/assets/admin/views/_AppliedFilterSummary.vue
@@ -33,15 +33,6 @@
                 </template>
             </el-tag>
         </template>
-        <el-button
-            size="mini"
-            plain
-            type="danger"
-            icon="el-icon-close"
-            class="ff_clear_all_filters"
-            @click="$emit('clear-all')">
-            {{ $t('Clear All') }}
-        </el-button>
     </div>
 </template>
 
@@ -53,8 +44,9 @@
  * fluent_form_entries_vars provided by the backend.
  *
  * Emits:
- *  - clear-group(index): user closed a chip; parent should drop that group
- *  - clear-all: user clicked "Clear All"; parent should reset filters
+ *  - clear-group(index): user closed a chip; parent should drop that group.
+ *    For bulk clear, parent provides "Clear Filters" inside the filter
+ *    panel itself, so we don't duplicate that affordance here.
  */
 export default {
     name: 'AppliedFilterSummary',


### PR DESCRIPTION
## What does this PR do and why?

  The advanced filter UI in the entries screen was hard to understand and easy to get out of sync with the actual applied
  query, especially when users hid the panel, removed groups, or tried to build multi-group conditions. This PR improves the
  advanced-filter experience by making active filters visible, keeping the panel state aligned with the parent view, and adding
  clearer editing and grouping controls. The scope is limited to the entries admin filter UX plus the smartcode ordering used
  to populate filter choices.

  ## Changes

  - [ ] PHP (backend logic, models, services, hooks)
  - [x] Vue/React (admin UI, block editor)
  - [x] CSS/Tailwind (styling)
  - [ ] Database (migrations, schema changes)
  - [ ] REST API (new or changed endpoints)
  - [ ] Build/config (Vite, composer, CI)

  ## How to test

  1. Open a form’s Entries screen and enable Advanced Filter.
  2. Add one or more filter groups and verify the panel now shows inline guidance for `AND` within a group and `OR` between
  groups.
  3. Duplicate a group, remove a group, and edit a field/operator/value in place. Confirm the UI stays in sync and the applied
  results update correctly after clicking `Filter`.
  4. Apply filters, collapse the panel, and confirm the active filters remain visible as chips. Remove a chip and verify the
  results refresh and the panel reflects the updated state when reopened.
  5. For a numeric field, verify `IN` and `NOT IN` are available and accept comma-separated values.
  6. Press `Enter` from inside the filter panel and confirm it triggers filtering without needing to click the button.
  ##Screnshots
  
<img width="1312" height="723" alt="image" src="https://github.com/user-attachments/assets/a2feedc2-35ea-4330-bbaf-c5cecffc582d" />

  ## Anything the reviewer should know?

  This branch is focused on admin-side advanced-filter UX only. It adds a new applied-filter summary component and adjusts the
  available filter metadata to make entry attributes easier to discover in the picker.