### PR TITLE
FIX: Sort entries by submission date instead of insertion order

### DIFF
--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -253,7 +253,22 @@ class Submission extends Model
 
         $query = $this->customQuery($attributes);
 
-        $submission = $query->select($columns)->where('id', $operator, $entryId)->first();
+        // Adjacency must match customQuery's sort order. Compare on the same
+        // (sortColumn, id) row-tuple the listing orders by, so Next/Prev walk
+        // in display order regardless of which sort column the filter selects.
+        // When sortColumn is id the tuple degenerates to a simple id compare.
+        $sortColumn = self::getSortColumn();
+        $current = static::select(['id', $sortColumn])->find($entryId);
+        if (!$current) {
+            return apply_filters('fluentform/next_submission', null, $entryId, $attributes);
+        }
+
+        $submission = $query->select($columns)
+            ->whereRaw(
+                "(fluentform_submissions.{$sortColumn}, fluentform_submissions.id) {$operator} (?, ?)",
+                [$current->{$sortColumn}, $entryId]
+            )
+            ->first();
 
         return apply_filters('fluentform/next_submission', $submission, $entryId, $attributes);
     }

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -258,6 +258,10 @@ class Submission extends Model
         // in display order regardless of which sort column the filter selects.
         // When sortColumn is id the tuple degenerates to a simple id compare.
         $sortColumn = self::getSortColumn();
+        // Re-assert whitelist; $sortColumn is interpolated into whereRaw below.
+        if (!in_array($sortColumn, ['id', 'created_at'], true)) {
+            $sortColumn = 'created_at';
+        }
         $current = static::select(['id', $sortColumn])->find($entryId);
         if (!$current) {
             return apply_filters('fluentform/next_submission', null, $entryId, $attributes);

--- a/app/Models/Submission.php
+++ b/app/Models/Submission.php
@@ -96,6 +96,20 @@ class Submission extends Model
         return $this->hasMany(OrderItem::class, 'submission_id', 'id');
     }
 
+    /**
+     * Returns the column the entries listing should be sorted by.
+     * Defaults to created_at so imported entries respect their original
+     * submission date. Site owners can switch back to legacy id-based
+     * ordering via the fluentform/entries_default_sort_column filter.
+     */
+    public static function getSortColumn()
+    {
+        $column = apply_filters('fluentform/entries_default_sort_column', 'created_at');
+        $allowed = ['id', 'created_at'];
+
+        return in_array($column, $allowed, true) ? $column : 'created_at';
+    }
+
     public function customQuery($attributes = [], $searchExtender = null)
     {
         $entryType = Arr::get($attributes, 'entry_type');
@@ -122,7 +136,16 @@ class Submission extends Model
             $wheres[] = ['payment_status', $paymentStatuses];
         }
 
-        $query = $this->orderBy('fluentform_submissions.id', $sortBy)
+        // Sort by submission date so imported entries (which get new auto-increment ids
+        // but carry their original created_at) interleave correctly with native ones.
+        // Tie-break on id to keep pagination stable for rows sharing a timestamp.
+        // Filter lets site owners revert to legacy id-based ordering if needed.
+        $sortColumn = self::getSortColumn();
+        $query = $this->orderBy('fluentform_submissions.' . $sortColumn, $sortBy);
+        if ('id' !== $sortColumn) {
+            $query = $query->orderBy('fluentform_submissions.id', $sortBy);
+        }
+        $query = $query
             ->when($formId, function ($q) use ($formId) {
                 return $q->where('fluentform_submissions.form_id', $formId);
             })

--- a/resources/assets/admin/views/Entries.vue
+++ b/resources/assets/admin/views/Entries.vue
@@ -355,7 +355,6 @@
                                     trigger="hover"
                                     :open-delay="150"
                                     :popper-options="entryCellPopoverOptions"
-                                    :width="420"
                                 >
                                     <div
                                         class="ff_entry_table_popover_content"


### PR DESCRIPTION
## What does this PR do and why?

Imported entries (Tools → Import → Form Entries) receive new auto-increment ids but carry their original `created_at`, so the entries listing — which sorted by `id DESC` — placed imported rows out of submission-date order (authlab #21049). This PR makes the listing sort by `created_at` with `id` as a stable tiebreaker, walks Next/Previous arrows in display order, lets the cell popover size to its content, and adds a defense-in-depth assert at the `whereRaw` call site. Forms without imported entries see zero behavior change; sites that depend on legacy id-ordering can opt out via a new `fluentform/entries_default_sort_column` filter.

## Key things done

- **`Submission::customQuery`** orders by `created_at` first, then `id` as tiebreaker. New `getSortColumn()` helper + `fluentform/entries_default_sort_column` filter (whitelisted to `id` / `created_at`).
- **`Submission::findAdjacentSubmission`** uses an SQL row-tuple comparison `(sortColumn, id) <op> (X, Y)` so Next/Previous arrows on the entry detail page walk the listing in display order.
- **`Entries.vue`** drops the hardcoded `:width="420"` on the cell popover; existing CSS already caps width at 520px and Element UI's default min-width handles short content.
- **Security:** re-asserts the `['id', 'created_at']` whitelist immediately before the `whereRaw` call so a future change to `getSortColumn()` cannot accidentally widen the surface.

## How to test

1. **Reproduce on `dev`:** export a form's entries (Tools → Export → Form Entries JSON), hand-edit `created_at` on a few rows to dates >1 year old, submit a few fresh entries through the public form, then re-import the edited JSON.
2. Open the form's Entries page → imported rows clump at the top in *reverse* date order. That's the bug.
3. **Verify the fix on this branch:** same dataset, same page → dates descend monotonically end-to-end; imports interleave by `created_at`.
4. Click the `#` column to flip ASC/DESC — both directions monotonic.
5. Open an entry near the import boundary → Next/Previous arrows walk in display order (not id order).
6. Date filter, status filter, advanced filter, search — still scope correctly.
7. Pagination — same-second rows stable across page boundaries (the id tiebreaker).
8. Hover a cell with short content → popover sizes to content (no longer 420px wide).

## Anything the reviewer should know?

- **Backward-compat:** native-only forms see no visible change because `id` and `created_at` are monotonic together. Export (JSON/CSV) and the REST endpoint now return rows in date order; sites that implicitly relied on id-order can revert via:
  ```php
  add_filter('fluentform/entries_default_sort_column', fn() => 'id');
  ```
  No hooks renamed or removed, no schema migration, trivially revertable per commit.

- **Performance:** `fluentform_submissions.created_at` has no index. Filesort cost is microseconds for forms <10k entries, becomes noticeable above ~100k. Composite index `(form_id, created_at, id)` is filed as a separate follow-up; not bundled here so the index decision can be reviewed independently.

- **Security:** SQL interpolation points (`orderBy` column, `whereRaw` row-tuple) are protected by an explicit whitelist in `getSortColumn()`; direction sanitized via `Helper::sanitizeOrderValue`; comparison operator restricted to `<`/`>` by local code; values bound with `?` placeholders. The new `SECURITY:` commit adds belt-and-suspenders re-validation at the `whereRaw` call site.

- **Out of scope (separate branch / PR):** entries listing UX polish — row click, status dot, configurable column pin, searchable form switcher, focus rings, keyboard navigation — lives in `feat/entries-page-ux-polish`.

Ref: authlab #21049