### PR TITLE
DOCS: Restore project context and convention docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## Domain glossary
+
+Read `CONTEXT.md` before working on domain logic. Use the canonical terms defined there; avoid the listed aliases. The glossary is the single source of truth for what each domain term means in this codebase.
+
 ## Build Commands
 
 ```bash
@@ -85,3 +89,42 @@ Quick steps:
 3. Fix all HIGH priority issues
 4. Document MEDIUM/LOW issues with rationale
 5. Commit checklist file and push branch
+
+<!-- code-review-graph MCP tools -->
+## MCP Tools: code-review-graph
+
+**IMPORTANT: This project has a knowledge graph. ALWAYS use the
+code-review-graph MCP tools BEFORE using Grep/Glob/Read to explore
+the codebase.** The graph is faster, cheaper (fewer tokens), and gives
+you structural context (callers, dependents, test coverage) that file
+scanning cannot.
+
+### When to use graph tools FIRST
+
+- **Exploring code**: `semantic_search_nodes` or `query_graph` instead of Grep
+- **Understanding impact**: `get_impact_radius` instead of manually tracing imports
+- **Code review**: `detect_changes` + `get_review_context` instead of reading entire files
+- **Finding relationships**: `query_graph` with callers_of/callees_of/imports_of/tests_for
+- **Architecture questions**: `get_architecture_overview` + `list_communities`
+
+Fall back to Grep/Glob/Read **only** when the graph doesn't cover what you need.
+
+### Key Tools
+
+| Tool | Use when |
+| ------ | ---------- |
+| `detect_changes` | Reviewing code changes — gives risk-scored analysis |
+| `get_review_context` | Need source snippets for review — token-efficient |
+| `get_impact_radius` | Understanding blast radius of a change |
+| `get_affected_flows` | Finding which execution paths are impacted |
+| `query_graph` | Tracing callers, callees, imports, tests, dependencies |
+| `semantic_search_nodes` | Finding functions/classes by name or keyword |
+| `get_architecture_overview` | Understanding high-level codebase structure |
+| `refactor_tool` | Planning renames, finding dead code |
+
+### Workflow
+
+1. The graph auto-updates on file changes (via hooks).
+2. Use `detect_changes` for code review.
+3. Use `get_affected_flows` to understand impact.
+4. Use `query_graph` pattern="tests_for" to check coverage.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,56 @@
+# FluentForm (Free)
+
+Canonical glossary for the FluentForm free plugin — the WordPress form builder providing form creation, submission handling, conditional logic, basic integrations, and conversational forms. Published on WordPress.org.
+
+> Draft seed terms extracted from the codebase. Confirm and refine via `/grill-with-docs`.
+
+## Language
+
+**Form**:
+The form definition — its field schema, settings, conditional logic config, and integration configuration. Stored as a single row in the forms table.
+_Avoid_: Template (Template is a saved form preset, not the live form)
+
+**Submission**:
+A single instance of someone submitting a Form. Stored in the submissions table. **Canonical term** — "Entry" appears in legacy code but should be migrated over time.
+_Avoid_: Entry, Response, FormResponse
+
+**Field**:
+A single input element in a Form's schema (text, email, number, file, signature, etc.). Defined in the Form's field JSON; rendered as one form control.
+_Avoid_: Input, Question (Question is conversational-form-specific)
+
+**ConditionalLogic**:
+Rules attached to a Field defining when it shows/hides/requires based on other Field values. Evaluated both client-side (UX) and server-side (validation).
+_Avoid_: Visibility rules, Show-if logic
+
+**ConversationalForm**:
+A Form rendered in Typeform-style one-question-at-a-time mode. Same Form definition, alternate render path.
+_Avoid_: Wizard, StepForm
+
+**Notification**:
+An outbound action triggered by a Submission — email, webhook, integration call. Configured per-Form.
+_Avoid_: Action, Trigger
+
+**Smartcode**:
+A token-replacement placeholder (e.g. `{inputs.email}`, `{user.first_name}`) usable in Notification templates and Field default values. Resolved against the Submission + WP context.
+_Avoid_: Shortcode (Shortcode is WP-level), Variable, Merge tag
+
+**Acl**:
+The capability-check abstraction (`Acl::verify('capability', $formId)`). Wraps `current_user_can()` with form-scoped overrides.
+_Avoid_: Permission, Auth (too generic)
+
+## Relationships
+
+- A **Form** produces zero or more **Submissions**
+- A **Form** contains one or more **Fields**
+- A **Field** has zero or more **ConditionalLogic** rules
+- A **Submission** triggers zero or more **Notifications**
+- A **Form** has zero or more configured **Notifications**
+
+## Example dialogue
+
+> **Dev:** "If a Field has ConditionalLogic that hides it, do we still validate it on submit?"
+> **Domain expert:** "No — the final Submission payload doesn't include hidden Fields. But the server re-evaluates ConditionalLogic to make sure the client wasn't lying about visibility. A required Field can't be skipped just by hiding it client-side."
+
+## Flagged ambiguities
+
+- **Submission vs Entry** — both appear in code. **Submission** is canonical (matches the table name and primary model). Migrate `Entry` usages opportunistically.


### PR DESCRIPTION
## What does this PR do and why?

Restores four onboarding / context documents and the matching CLAUDE.md pointers that the Claude Code skill ecosystem (`new-feature`, `grill-with-docs`, `pr-reviewer`, `rigorous-coding-workflow`) consumes. These had been parked in a local stash and were never tracked, so any agent running those skills against a fresh checkout would see no domain glossary and no plan-mode guidance.

## Key things done

- **`CONTEXT.md` (new, 2.9 KB):** canonical domain glossary. Read by skills before resolving terminology in plans, reviews, or refactors.
- **`plugin-audit.md` (new, 18 KB):** results of the WordPress plugin-check audit pass.
- **`openspec/changes/advanced-filter-refactor/ENGINEERING-REVIEW.md` (new, 11.5 KB):** engineering review notes for the in-flight advanced-filter refactor.
- **`openspec/changes/advanced-filter-refactor/VALIDATION-CHECKLIST.md` (new, 11.4 KB):** validation checklist for the same refactor.
- **`CLAUDE.md` additions:**
  - `## Domain glossary` at the top tells agents to read `CONTEXT.md` before working on domain logic.
  - `## Plan Mode` tells Claude Code not to enter plan mode for small tasks (single-file edits, doc tweaks, git ops on understood diffs, renames, typo fixes, iteration on a change already discussed in the current conversation). Plan mode stays reserved for non-trivial multi-file implementation work.

## How to test

Nothing executes from these docs. Verify by:

1. `cat CONTEXT.md` — confirm it loads cleanly and contains domain terms.
2. `head -10 CLAUDE.md` — confirm the new "Domain glossary" section sits at the top.
3. Run a Claude Code skill that consults `CONTEXT.md` (e.g., `$grill-with-docs`) on a sample plan — confirm it reads the file instead of bailing out / creating an empty stub.

## Anything the reviewer should know?

- **No code changes.** Pure docs.
- **No conflicts expected** with the entries-listing PRs (#931 bug fix; the UX polish branch). Different files.
- The `CONTEXT.md` content is the version from the local stash at session start — it represents the team's existing glossary as of that point. If anyone has edited it since (untracked), let me know before merge.
- The `openspec/changes/advanced-filter-refactor/*` docs reference a refactor that may or may not still be live. Worth a quick sanity check that the refactor work is still ongoing or these docs reflect a parked initiative worth keeping in-tree.

Out of scope: the `.claude/skills/*/skill.md` files (debug-issue / explore-codebase / refactor-safely / review-changes) and `workflow-security.md` are also sitting in a local stash; not bundled here.