### PR TITLE
SECURITY: Bump dompurify and postcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "chroma-js": "^2.4.2",
                 "clipboard": "^2.0.11",
-                "dompurify": "^3.3.2",
+                "dompurify": "^3.4.3",
                 "echarts": "^5.6.0",
                 "element-theme-chalk": "^2.15.9",
                 "element-ui": "^2.15.9",
@@ -39,6 +39,7 @@
                 "laravel-mix": "^6.0.49",
                 "less": "^4.1.2",
                 "less-loader": "^10.2.0",
+                "postcss": "^8.5.14",
                 "promise-polyfill": "^8.2.3",
                 "resolve-url-loader": "^5.0.0",
                 "rtlcss": "^3.5.0",
@@ -5601,13 +5602,10 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.2.tgz",
-            "integrity": "sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.3.tgz",
+            "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
             "license": "(MPL-2.0 OR Apache-2.0)",
-            "engines": {
-                "node": ">=20"
-            },
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -9039,9 +9037,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "funding": [
                 {
                     "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dependencies": {
         "chroma-js": "^2.4.2",
         "clipboard": "^2.0.11",
-        "dompurify": "^3.3.2",
+        "dompurify": "^3.4.3",
         "echarts": "^5.6.0",
         "element-theme-chalk": "^2.15.9",
         "element-ui": "^2.15.9",
@@ -42,6 +42,7 @@
         "laravel-mix": "^6.0.49",
         "less": "^4.1.2",
         "less-loader": "^10.2.0",
+        "postcss": "^8.5.14",
         "promise-polyfill": "^8.2.3",
         "resolve-url-loader": "^5.0.0",
         "rtlcss": "^3.5.0",


### PR DESCRIPTION
## What does this PR do and why?

Bumps DOMPurify and PostCSS to patched versions so npm audit no longer reports those security advisories while keeping the existing Vue 2 dependency chain untouched.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [ ] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [x] Build/config (Vite, composer, CI)

## How to test

1. Run npm audit --omit=dev and confirm only the existing Vue 2 chain remains.
2. Run npm run production and confirm Laravel Mix compiles successfully.

## Screenshots

N/A

## Anything the reviewer should know?

Vue, Element UI, and Vuex were intentionally left unchanged because npm audit reports that fixing the Vue 2 advisory requires breaking changes.