### PR TITLE
FIX: Hide collapsed settings submenu artifacts on Submenu Collapse

### DIFF
--- a/resources/assets/admin/styles/_globals.scss
+++ b/resources/assets/admin/styles/_globals.scss
@@ -1035,11 +1035,6 @@ label.el-radio, label.el-checkbox {
       overflow: visible;
     }
 
-    .ff_list_button_item.has_sub_menu {
-      height: 40px;
-      overflow: hidden;
-    }
-
     .ff_settings_menu_icon {
       display: inline-flex;
       margin-right: 0;

--- a/resources/assets/admin/styles/_globals.scss
+++ b/resources/assets/admin/styles/_globals.scss
@@ -1035,15 +1035,27 @@ label.el-radio, label.el-checkbox {
       overflow: visible;
     }
 
+    .ff_list_button_item.has_sub_menu {
+      height: 40px;
+      overflow: hidden;
+    }
+
     .ff_settings_menu_icon {
       display: inline-flex;
       margin-right: 0;
     }
 
+    .has_sub_menu .ff_list_button_link::after,
+    .ff_list_submenu::after,
+    .ff_list_submenu li::before,
+    .ff_list_submenu li::after {
+      display: none;
+    }
+
     .ff_list_submenu,
     .ff_settings_menu_label,
     .ff_sidebar_toggle_text {
-      display: none;
+      display: none !important;
     }
 
     .ff_sidebar_toggle {

--- a/resources/assets/admin/styles/_globals.scss
+++ b/resources/assets/admin/styles/_globals.scss
@@ -1022,7 +1022,6 @@ label.el-radio, label.el-checkbox {
     .ff_layout_section_sidebar {
       width: 56px;
       padding: 12px 8px;
-      overflow: hidden;
     }
 
     .ff_list_button_link {


### PR DESCRIPTION
## What does this PR do and why?

Hides submenu connector artifacts in the collapsed form settings sidebar so the icon-only settings menu stays clean. The settings menu collapse feature already renders icons from the existing FluentForm icon font; this patch only prevents the nested submenu rail and curve pseudo-elements from bleeding into collapsed mode.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [ ] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [x] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

## How to test

1. Open a Fluent Forms form settings page in wp-admin.
2. Collapse the settings sidebar.
3. Confirm the collapsed menu shows only the icon rail and bottom expand control, without submenu connector lines or curve artifacts.

## Screenshots

Before: collapsed settings sidebar could show submenu tree connector artifacts under the settings icon.
After: collapsed settings sidebar shows a clean icon-only menu.

## Anything the reviewer should know?

This reuses the existing FluentForm icon font. No new icon assets or libraries are added.
