### PR TITLE
Fix: Global Settings sidebar collapse toggle on desktop

### DIFF
--- a/app/Views/admin/globalSettings/menu.php
+++ b/app/Views/admin/globalSettings/menu.php
@@ -35,17 +35,17 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                 );
                 do_action('fluentform/before_global_settings_wrapper');
             ?>
-            <div class="ff_settings_sidebar_wrap">
-                <span class="ff_sidebar_toggle" title="Toggle Setting">
-                    <i class="ff-icon ff-icon-arrow-right"></i>
-                </span>
+            <div class="ff_settings_sidebar_wrap" id="ff_global_settings_sidebar">
                 <div class="ff_settings_sidebar ff_layout_section_sidebar">
                     <ul class="ff_settings_list ff_list_button">
                         <li class="ff_list_button_item has_sub_menu ">
                             <a
                                 class="ff_list_button_link"
+                                title="<?php echo esc_attr(__('General', 'fluentform')); ?>"
+                                aria-label="<?php echo esc_attr(__('General', 'fluentform')); ?>"
                                 href="#">
-                                <?php esc_html_e('General','fluentform'); ?>
+                                <i class="ff_settings_menu_icon ff-icon ff-icon-setting" aria-hidden="true"></i>
+                                <span class="ff_settings_menu_label"><?php esc_html_e('General','fluentform'); ?></span>
                             </a>
                             <ul class="ff_list_submenu" >
                                 <li >
@@ -114,8 +114,12 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                         <?php if (ArrayHelper::exists($components, 'payment_settings')) : ?>
                             <?php if (Helper::isPaymentCompatible()) : ?>
                                 <li class="ff_list_button_item has_sub_menu">
-                                    <a class="ff_list_button_link" href="#">
-                                        <?php echo esc_html(ArrayHelper::get($components, 'payment_settings.title', '')); ?>
+                                    <a class="ff_list_button_link"
+                                        title="<?php echo esc_attr(ArrayHelper::get($components, 'payment_settings.title', '')); ?>"
+                                        aria-label="<?php echo esc_attr(ArrayHelper::get($components, 'payment_settings.title', '')); ?>"
+                                        href="#">
+                                        <i class="ff_settings_menu_icon ff-icon ff-icon-payment" aria-hidden="true"></i>
+                                        <span class="ff_settings_menu_label"><?php echo esc_html(ArrayHelper::get($components, 'payment_settings.title', '')); ?></span>
                                     </a>
                                     <?php if (ArrayHelper::get($components, 'payment_settings.sub_menu')) : ?>
                                         <ul class="ff_list_submenu">
@@ -142,8 +146,11 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                                     <a
                                             class="ff_list_button_link ff-payment-settings-root"
                                             data-hash="payment_settings"
+                                            title="<?php echo esc_attr(__('Payment', 'fluentform')); ?>"
+                                            aria-label="<?php echo esc_attr(__('Payment', 'fluentform')); ?>"
                                             href="#">
-                                        <?php esc_html_e('Payment', 'fluentform'); ?>
+                                        <i class="ff_settings_menu_icon ff-icon ff-icon-payment" aria-hidden="true"></i>
+                                        <span class="ff_settings_menu_label"><?php esc_html_e('Payment', 'fluentform'); ?></span>
                                     </a>
                                     <?php if (ArrayHelper::get($components, 'payment_settings.sub_menu')) : ?>
                                         <ul class="ff_list_submenu">
@@ -173,8 +180,12 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                         <?php endif; ?>
 
                         <li class="ff_list_button_item has_sub_menu">
-                            <a class="ff_list_button_link" href="#">
-                                <?php esc_html_e('Security', 'fluentform'); ?>
+                            <a class="ff_list_button_link"
+                                title="<?php echo esc_attr(__('Security', 'fluentform')); ?>"
+                                aria-label="<?php echo esc_attr(__('Security', 'fluentform')); ?>"
+                                href="#">
+                                <i class="ff_settings_menu_icon ff-icon ff-icon-lock" aria-hidden="true"></i>
+                                <span class="ff_settings_menu_label"><?php esc_html_e('Security', 'fluentform'); ?></span>
                             </a>
                             <ul class="ff_list_submenu">
                                 <?php foreach ($components as $componentName => $component): ?>
@@ -206,10 +217,13 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                             <a
                                     class="ff_list_button_link"
                                     data-hash="managers"
+                                    title="<?php echo esc_attr(__('Permissions', 'fluentform')); ?>"
+                                    aria-label="<?php echo esc_attr(__('Permissions', 'fluentform')); ?>"
                                     href="<?php echo esc_url(Helper::makeMenuUrl('fluent_forms_settings', [
                                         'hash' => 'permissions'
                                     ])); ?>">
-                                <?php esc_html_e('Permissions','fluentform'); ?>
+                                <i class="ff_settings_menu_icon ff-icon ff-icon-user" aria-hidden="true"></i>
+                                <span class="ff_settings_menu_label"><?php esc_html_e('Permissions','fluentform'); ?></span>
                             </a>
                         </li>
                         <?php if ( ArrayHelper::get($components, 'admin_approval')) :?>
@@ -220,10 +234,13 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                                         data-hash="admin_approval"
                                         data-settings_key="ff_admin_approval"
                                         data-component="general-integration-settings"
+                                        title="<?php echo esc_attr(__('Admin approval', 'fluentform')); ?>"
+                                        aria-label="<?php echo esc_attr(__('Admin approval', 'fluentform')); ?>"
                                         href="<?php echo esc_url(Helper::makeMenuUrl('fluent_forms_settings', [
                                             'hash' => 'admin_approval'
                                         ])); ?>">
-                                    <?php esc_html_e('Admin approval', 'fluentform'); ?>
+                                    <i class="ff_settings_menu_icon ff-icon ff-icon-checkmark-square" aria-hidden="true"></i>
+                                    <span class="ff_settings_menu_label"><?php esc_html_e('Admin approval', 'fluentform'); ?></span>
                                 </a>
                             </li>
                         <?php endif; ?>
@@ -231,10 +248,13 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                             <a
                                     class="ff_list_button_link"
                                     data-hash="double_optin_settings"
+                                    title="<?php echo esc_attr(__('Double Opt-in', 'fluentform')); ?>"
+                                    aria-label="<?php echo esc_attr(__('Double Opt-in', 'fluentform')); ?>"
                                     href="<?php echo esc_url(Helper::makeMenuUrl('fluent_forms_settings', [
                                         'hash' => 'double_optin_settings'
                                     ])); ?>">
-                                <?php esc_html_e('Double Opt-in', 'fluentform'); ?>
+                                <i class="ff_settings_menu_icon ff-icon ff-icon-email" aria-hidden="true"></i>
+                                <span class="ff_settings_menu_label"><?php esc_html_e('Double Opt-in', 'fluentform'); ?></span>
                             </a>
                         </li>
                         <?php
@@ -243,19 +263,25 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                                 <a
                                         class="ff_list_button_link"
                                         data-hash="inventory_manager"
+                                        title="<?php echo esc_attr(__('Inventory Manager', 'fluentform')); ?>"
+                                        aria-label="<?php echo esc_attr(__('Inventory Manager', 'fluentform')); ?>"
                                         href="<?php
                                         echo esc_url(Helper::makeMenuUrl('fluent_forms_settings', [
                                             'hash' => 'inventory_manager'
                                         ])); ?>">
-                                    <?php
-                                    esc_html_e('Inventory Manager', 'fluentform'); ?>
+                                    <i class="ff_settings_menu_icon ff-icon ff-icon-layers" aria-hidden="true"></i>
+                                    <span class="ff_settings_menu_label"><?php esc_html_e('Inventory Manager', 'fluentform'); ?></span>
                                 </a>
                             </li>
                         <?php } ?>
 
                         <li class="ff_list_button_item has_sub_menu">
-                            <a class="ff_list_button_link" href="#">
-                                <?php esc_html_e('Configure Integrations', 'fluentform'); ?>
+                            <a class="ff_list_button_link"
+                                title="<?php echo esc_attr(__('Configure Integrations', 'fluentform')); ?>"
+                                aria-label="<?php echo esc_attr(__('Configure Integrations', 'fluentform')); ?>"
+                                href="#">
+                                <i class="ff_settings_menu_icon ff-icon ff-icon-puzzle" aria-hidden="true"></i>
+                                <span class="ff_settings_menu_label"><?php esc_html_e('Configure Integrations', 'fluentform'); ?></span>
                             </a>
                             <ul class="ff_list_submenu">
                                 <?php foreach ($components as $componentName => $component): ?>
@@ -294,9 +320,12 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                                 <a
                                         class="ff_list_button_link"
                                         data-component="<?php echo esc_attr(ArrayHelper::get($licensePage, 'query.component', '')); ?>"
+                                        title="<?php echo esc_attr($licensePage['title']); ?>"
+                                        aria-label="<?php echo esc_attr($licensePage['title']); ?>"
                                         href="<?php echo esc_url(Helper::makeMenuUrl('fluent_forms_settings', $licensePage)); ?>"
                                 >
-                                    <?php echo esc_attr($licensePage['title']); ?>
+                                    <i class="ff_settings_menu_icon ff-icon ff-icon-handshake" aria-hidden="true"></i>
+                                    <span class="ff_settings_menu_label"><?php echo esc_attr($licensePage['title']); ?></span>
                                 </a>
                             </li>
                         <?php endif ?>
@@ -306,8 +335,12 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                             <?php foreach ($customLinks as $customLink): ?>
                                 <?php if($subLinks = ArrayHelper::get($customLink, 'sub_links')) :?>
                                     <li class="ff_list_button_item has_sub_menu">
-                                        <a class="ff_list_button_link" href="#">
-                                            <?php echo esc_html(ArrayHelper::get($customLink, 'title', '')); ?>
+                                        <a class="ff_list_button_link"
+                                            title="<?php echo esc_attr(ArrayHelper::get($customLink, 'title', '')); ?>"
+                                            aria-label="<?php echo esc_attr(ArrayHelper::get($customLink, 'title', '')); ?>"
+                                            href="#">
+                                            <i class="ff_settings_menu_icon ff-icon <?php echo esc_attr(ArrayHelper::get($customLink, 'icon', 'ff-icon-link')); ?>" aria-hidden="true"></i>
+                                            <span class="ff_settings_menu_label"><?php echo esc_html(ArrayHelper::get($customLink, 'title', '')); ?></span>
                                         </a>
                                         <ul class="ff_list_submenu">
                                             <?php foreach ($subLinks as $customSubLink): ?>
@@ -339,11 +372,14 @@ use FluentForm\Framework\Helpers\ArrayHelper;
                                                 data-settings_key="custom_component"
                                                 data-component="custom_component"
                                                 data-component_name="<?php echo esc_attr(ArrayHelper::get($customLink, 'component', '')); ?>"
+                                                title="<?php echo esc_attr(ArrayHelper::get($customLink, 'title', '')); ?>"
+                                                aria-label="<?php echo esc_attr(ArrayHelper::get($customLink, 'title', '')); ?>"
                                                 href="<?php echo esc_url(Helper::makeMenuUrl('fluent_forms_settings', [
                                                     'hash' => esc_attr(ArrayHelper::get($customLink, 'hash', 'custom_component')),
                                                 ])); ?>"
                                         >
-                                            <?php echo esc_attr(ArrayHelper::get($customLink, 'title', '')); ?>
+                                            <i class="ff_settings_menu_icon ff-icon <?php echo esc_attr(ArrayHelper::get($customLink, 'icon', 'ff-icon-link')); ?>" aria-hidden="true"></i>
+                                            <span class="ff_settings_menu_label"><?php echo esc_attr(ArrayHelper::get($customLink, 'title', '')); ?></span>
                                         </a>
                                     </li>
                                 <?php endif ?>
@@ -353,6 +389,10 @@ use FluentForm\Framework\Helpers\ArrayHelper;
 
                     </ul>
                 </div>
+                <button type="button" class="ff_sidebar_toggle" title="<?php echo esc_attr(__('Collapse settings menu', 'fluentform')); ?>" aria-label="<?php echo esc_attr(__('Collapse settings menu', 'fluentform')); ?>" aria-controls="ff_global_settings_sidebar" aria-expanded="true" data-collapse-label="<?php echo esc_attr(__('Collapse settings menu', 'fluentform')); ?>" data-expand-label="<?php echo esc_attr(__('Expand settings menu', 'fluentform')); ?>">
+                    <i class="ff-icon ff-icon-arrow-right" aria-hidden="true"></i>
+                    <span class="ff_sidebar_toggle_text"><?php echo esc_html(__('Collapse menu', 'fluentform')); ?></span>
+                </button>
             </div>
 
             <div class="ff_settings_container ff_layout_section_container" id="ff_settings_container">

--- a/app/Views/admin/global_menu.php
+++ b/app/Views/admin/global_menu.php
@@ -129,16 +129,60 @@ $page = sanitize_text_field($_GET['page']);
         $globalSearchButtonClickScript
 
         // for setting sidebar
-        let globalSettingSidebarElem = jQuery('.ff_settings_sidebar_wrap');
+        let globalSettingSidebarElem = jQuery('#ff_global_settings_sidebar');
         let globalOverlayElem = jQuery('#global-overlay');
+        let globalSettingSidebarStateKey = 'fluentform_global_settings_sidebar_collapsed';
+        let globalSettingSidebarToggle = globalSettingSidebarElem.find('.ff_sidebar_toggle');
+        let isGlobalSettingDesktop = function() {
+            return window.matchMedia('(min-width: 769px)').matches;
+        };
+        let syncGlobalSettingSidebarMode = function() {
+            if (isGlobalSettingDesktop() && window.localStorage.getItem(globalSettingSidebarStateKey) === 'yes') {
+                globalSettingSidebarElem.addClass('ff_settings_sidebar_collapsed');
+            } else if (!isGlobalSettingDesktop()) {
+                globalSettingSidebarElem.removeClass('ff_settings_sidebar_collapsed');
+            }
+        };
+        let updateGlobalSettingToggleState = function() {
+            let collapseLabel = globalSettingSidebarToggle.data('collapse-label') || 'Collapse settings menu';
+            let expandLabel = globalSettingSidebarToggle.data('expand-label') || 'Expand settings menu';
+            let isExpanded = isGlobalSettingDesktop()
+                ? !globalSettingSidebarElem.hasClass('ff_settings_sidebar_collapsed')
+                : globalSettingSidebarElem.hasClass('active');
 
-        jQuery('.ff_sidebar_toggle').on('click', function() {
+            globalSettingSidebarToggle
+                .attr('aria-expanded', isExpanded ? 'true' : 'false')
+                .attr('aria-label', isExpanded ? collapseLabel : expandLabel)
+                .attr('title', isExpanded ? collapseLabel : expandLabel);
+        };
+
+        syncGlobalSettingSidebarMode();
+
+        globalSettingSidebarToggle.on('click', function() {
+            if (isGlobalSettingDesktop()) {
+                globalSettingSidebarElem.toggleClass('ff_settings_sidebar_collapsed');
+                window.localStorage.setItem(
+                    globalSettingSidebarStateKey,
+                    globalSettingSidebarElem.hasClass('ff_settings_sidebar_collapsed') ? 'yes' : 'no'
+                );
+                updateGlobalSettingToggleState();
+                return;
+            }
+
             jQuery(globalSettingSidebarElem).add(globalOverlayElem).toggleClass('active');
+            updateGlobalSettingToggleState();
         });
-        
+
         jQuery(globalOverlayElem).on('click', function() {
             jQuery(globalOverlayElem).add(globalSettingSidebarElem).removeClass('active');
+            updateGlobalSettingToggleState();
         });
+
+        jQuery(window).on('resize', function() {
+            syncGlobalSettingSidebarMode();
+            updateGlobalSettingToggleState();
+        });
+        updateGlobalSettingToggleState();
 
     ");
     ?>


### PR DESCRIPTION
PR: Fix Global Settings sidebar collapse toggle on desktop

## What does this PR do and why?

The Global Settings page rendered a legacy sidebar toggle whose click handler only flipped a no-op .active class on desktop. PR #935 (improve share and access settings) introduced .ff_settings_wrapper .ff_sidebar_toggle { display: flex } which unhid that legacy toggle on Global Settings, so the toggle was visible but clicking it did nothing observable.

Mirror the working form-level implementation on Global Settings so the sidebar collapses to a 56px icon-only rail with proper aria state, keyboard support, and localStorage persistence.

**Related issue:** N/A

## Scope

- [x] Free plugin
- [ ] Pro plugin
- [ ] Both

## Changes

- [x] PHP (backend logic, models, services, hooks)
- [ ] Vue/React (admin UI, block editor)
- [ ] CSS/SCSS (styling)
- [ ] Database (migrations, schema changes)
- [ ] REST API (new or changed endpoints)
- [ ] Build/config (Vite, composer, CI)

Files touched:
- app/Views/admin/globalSettings/menu.php
- app/Views/admin/global_menu.php

Details:
- Replace the legacy span toggle with a button carrying aria-controls, aria-expanded, collapse/expand labels, and a ff_sidebar_toggle_text span.
- Add id=ff_global_settings_sidebar to the wrap and add icon + label spans to every top-level link so the collapsed 56px rail shows icons only.
- Replace the inline JS in global_menu.php with the desktop/mobile aware handler used in form_wrapper.php, scoped to #ff_global_settings_sidebar so it cannot bind to the Tools page sidebar or any other admin page that renders global_menu.php.
- Persist collapsed state under fluentform_global_settings_sidebar_collapsed in localStorage.

## How to test

1. Visit wp-admin > Fluent Forms Pro > Settings (page=fluent_forms_settings).
2. Click the toggle in the sidebar header. Sidebar collapses to 56px and shows only icons. aria-expanded flips to false.
3. Click again. Sidebar expands back to 280px and aria-expanded flips to true.
4. Reload the page. Last collapsed/expanded state persists.
5. Visit Tools (page=fluent_forms_transfer) and Form Settings (a single form). Verify their sidebar toggles work exactly as before this change.

## Anything the reviewer should know?

The new handler is scoped to #ff_global_settings_sidebar so it cannot bleed onto the Tools page, which still uses the legacy span toggle and no-op .active flip. A follow-up PR can apply the same treatment there.